### PR TITLE
fix(deps)!: upgrade FastMCP 3.x and resolve Dependabot vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Ruff check
+        run: uv run ruff check src/
+
+      - name: Mypy
+        run: uv run mypy src/law_scrapper_mcp/
+
+      - name: Unit tests
+        run: uv run pytest tests/unit/ -v
+
+      - name: Integration tests
+        run: uv run pytest tests/integration/ -v -m integration

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ htmlcov/
 
 # Docker
 docker-compose.override.yml
+
+# MCP inspector
+.inspector-log.txt
+.inspector-log.txt.err
+
+# QA
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-07-08
+
+### Security
+
+- **FastMCP 2.12.4 → 3.2.0+** — Resolves transitive vulnerabilities in starlette, mcp, authlib, python-multipart, and python-dotenv
+- **uv override-dependencies** — Force minimum versions for cryptography (≥48.0.1), urllib3 (≥2.7.0), idna (≥3.15), werkzeug (≥3.1.6), requests (≥2.33.0)
+- **pdfplumber 0.11.10+** — Pulls Pillow ≥12.2.0 to address image processing CVEs
+- **pytest 9.0.3+** — Dev dependency security update
+
+### Changed
+
+- **FastMCP 3.x migration** — Tools access lifespan resources via `ctx.lifespan_context` (was `ctx.request_context.lifespan_context`)
+- **HTTP server startup** — Replaced manual Starlette/uvicorn wiring with `app.run(transport=..., path="/mcp")` and `@app.custom_route("/health")`
+- **Integration tests** — FastMCP in-memory `Client` fixture enables end-to-end tool tests without network
+- **CI pipeline** — GitHub Actions workflow for ruff, mypy, pytest; Dependabot for pip and github-actions
+
+### Added
+
+- **`tests/unit/test_server.py`** — Verifies 13 tools registered and lifespan service keys
+- **`tests/integration/test_http_transport.py`** — ASGI smoke test for `/health` endpoint
+- **`.github/workflows/ci.yml`** and **`.github/dependabot.yml`**
+
 ## [2.3.1] - 2026-02-20
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Law Scrapper MCP v2.3.1 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with FastMCP, it supports STDIO (default) and streamable-http transport on port 7683.
+Law Scrapper MCP v2.4.0 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with FastMCP 3.x, it supports STDIO (default) and streamable-http transport on port 7683.
 
 ## Development commands
 
@@ -36,6 +36,10 @@ uv run ruff check src/
 uv run mypy src/law_scrapper_mcp/
 ```
 
+## Testing strategy
+
+The project uses pytest with FastMCP in-memory Client for integration tests (41 tests covering all 13 tools). See README.md "MCP integration testing" section for architecture details.
+
 ## Architecture
 
 The project follows a layered architecture with src/ layout:
@@ -59,6 +63,7 @@ src/law_scrapper_mcp/
 - **TTL cache**: Async API response cache with configurable TTL (metadata=24h, search=10min)
 - **Error handling**: `@handle_tool_errors` decorator with error classification and traceback logging
 - **Async throughout**: httpx.AsyncClient with retry (tenacity), semaphore rate limiting, asyncio.Lock
+- **FastMCP 3.x**: Tools access lifespan resources via `ctx.lifespan_context`; HTTP via `app.run(transport=...)`
 
 **Tool categories** (13 tools total):
 - `metadata` — `get_system_metadata` (consolidates 6 old metadata tools)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Model Context Protocol (MCP) server for accessing and analyzing 
 
 ![Python version](https://img.shields.io/badge/python-3.13+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Version](https://img.shields.io/badge/version-2.3.1-orange.svg)
+![Version](https://img.shields.io/badge/version-2.4.0-orange.svg)
 
 <a href="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp/badge" alt="Law Scrapper MCP server" />
@@ -514,6 +514,10 @@ law-scrapper-mcp/
 
 ## Docker
 
+### Security and deployment
+
+When exposing the HTTP transport (`streamable-http`) to a network, place the server behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination. The `/health` endpoint is unauthenticated and intended for container healthchecks only — do not expose it publicly without access controls. Dependency versions are pinned in `uv.lock` with security overrides in `pyproject.toml` (`cryptography`, `urllib3`, `idna`, `werkzeug`, `requests`).
+
 ### Dockerfile
 
 The included `Dockerfile` builds a containerized Law Scrapper MCP server:
@@ -585,6 +589,13 @@ If upgrading from v1.0.2, note these breaking changes:
 | SSE transport | STDIO (default) | STDIO is default, HTTP via streamable-http |
 | Port 7683 | Port 7683 | Same default HTTP port |
 
+## What's new in v2.4.0
+
+- **Security hardening** — FastMCP 3.x upgrade and dependency overrides close 51 Dependabot alerts (cryptography, urllib3, pillow, starlette, and others)
+- **FastMCP 3.x** — `ctx.lifespan_context` API, `app.run()` for HTTP transport, `@custom_route` for `/health`
+- **Integration tests** — In-memory FastMCP `Client` tests for core tools (metadata, search, dates, act details)
+- **CI and Dependabot** — Automated quality gates and weekly dependency updates
+
 ## What's new in v2.3.1
 
 - **uvx / FastMCP fix** — Fixed `NameError: name 'Annotated' is not defined` when running via `uvx --from "git+https://github.com/numikel/law-scrapper-mcp" law-scrapper`. Removed `from __future__ import annotations` from `compare.py` so parameter type hints resolve correctly during tool registration.
@@ -627,6 +638,48 @@ uv run pytest --cov=law_scrapper_mcp --cov-report=term-missing
 # Run with timeout for slow tests
 uv run pytest --timeout=10 -v
 ```
+
+### MCP integration testing
+
+Law Scrapper MCP uses automated integration tests to verify all 13 tools and their MCP protocol interaction. **The tests do NOT use Playwright or MCP Inspector** — they use a fast, lightweight in-memory testing approach:
+
+**What it is:**
+- FastMCP in-memory `Client(app)` calling tools via the MCP protocol without an external server
+- Mock HTTP responses via `respx` (intercepting calls to `api.sejm.gov.pl`)
+- 41 integration tests covering all 13 tools, EnrichedResponse validation, and error handling
+- Tests verify: tool registration, parameter validation, response structure, stateful workflows (search → filter → read), and graceful error degradation
+
+**What it is NOT:**
+- NOT browser automation (no Playwright, Selenium, or headless browsers)
+- NOT MCP Inspector or any GUI-based testing
+- NOT requiring a running server process
+- NOT real API calls (all Sejm API endpoints are mocked with `respx`)
+
+**How to run:**
+```bash
+# Run integration tests
+uv run pytest tests/integration/ -v -m integration
+
+# Run specific test class
+uv run pytest tests/integration/test_tools_e2e.py::TestSearchTools -v
+
+# Run with coverage
+uv run pytest tests/integration/ -m integration --cov=law_scrapper_mcp
+```
+
+**Architecture:**
+- **Test framework**: pytest with async support (pytest-asyncio)
+- **HTTP mocking**: respx intercepts httpx calls before they reach the network
+- **MCP protocol**: FastMCP `Client(app)` simulates in-process STDIO transport
+- **Fixtures** (`tests/conftest.py`): Load JSON/HTML samples, mock API responses, provide `mcp_client` fixture
+- **Test file**: `tests/integration/test_tools_e2e.py` (41 tests)
+
+**Key test patterns:**
+1. **Tool listing** — Verify all 13 tools are registered and have descriptions
+2. **Smoke tests** — Each tool returns valid JSON with `{data, hints}` envelope
+3. **Data validation** — Results contain expected fields matching fixture values
+4. **Stateful workflows** — Chain tools: search → filter → load act → read sections → search in content
+5. **Error handling** — Invalid inputs return graceful errors in the response, not exceptions
 
 ### Code quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,23 @@
 [project]
 name = "law-scrapper-mcp"
-version = "2.3.1"
+version = "2.4.0"
 description = "LawScrapper MCP is an MCP server to monitoring and fetching Polish law acts published by the Polish Sejm, filters them by topic. Then with AI you can summarizes their content using an LLM."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "httpx>=0.28",
     "tenacity>=9.0",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",
     "python-dateutil>=2.9",
     "markdownify>=0.14",
-    "pdfplumber>=0.11",
+    "pdfplumber>=0.11.10",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",
     "respx>=0.22",
@@ -35,6 +35,13 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 dev-dependencies = []
+override-dependencies = [
+    "cryptography>=48.0.1",
+    "urllib3>=2.7.0",
+    "idna>=3.15",
+    "werkzeug>=3.1.6",
+    "requests>=2.33.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/law_scrapper_mcp"]

--- a/src/law_scrapper_mcp/client/cache.py
+++ b/src/law_scrapper_mcp/client/cache.py
@@ -44,9 +44,7 @@ class TTLCache:
         """Set value in cache with TTL."""
         async with self._lock:
             now = time.time()
-            self._cache[key] = CacheEntry(
-                value=value, expires_at=now + ttl, created_at=now
-            )
+            self._cache[key] = CacheEntry(value=value, expires_at=now + ttl, created_at=now)
 
             # Evict if over capacity
             if len(self._cache) > self._max_entries:

--- a/src/law_scrapper_mcp/client/circuit_breaker.py
+++ b/src/law_scrapper_mcp/client/circuit_breaker.py
@@ -45,9 +45,9 @@ class CircuitBreaker:
     def state(self) -> CircuitState:
         """Current circuit breaker state."""
         if self._state == CircuitState.OPEN and time.monotonic() - self._last_failure_time >= self._recovery_timeout:
-                self._state = CircuitState.HALF_OPEN
-                self._half_open_successes = 0
-                logger.info("Circuit breaker transitioning to HALF_OPEN")
+            self._state = CircuitState.HALF_OPEN
+            self._half_open_successes = 0
+            logger.info("Circuit breaker transitioning to HALF_OPEN")
         return self._state
 
     @property

--- a/src/law_scrapper_mcp/client/exceptions.py
+++ b/src/law_scrapper_mcp/client/exceptions.py
@@ -12,9 +12,7 @@ class LawScrapperError(Exception):
 class SejmApiError(LawScrapperError):
     """Error from Sejm API."""
 
-    def __init__(
-        self, message: str, status_code: int | None = None, url: str | None = None
-    ):
+    def __init__(self, message: str, status_code: int | None = None, url: str | None = None):
         super().__init__(message)
         self.status_code = status_code
         self.url = url
@@ -38,9 +36,7 @@ class ContentNotAvailableError(LawScrapperError):
     """Content not available for the specified format."""
 
     def __init__(self, eli: str, format: str):
-        super().__init__(
-            f"Treść niedostępna dla {eli} w formacie {format}"
-        )
+        super().__init__(f"Treść niedostępna dla {eli} w formacie {format}")
         self.eli = eli
         self.format = format
 
@@ -49,10 +45,7 @@ class DocumentNotLoadedError(LawScrapperError):
     """Document must be loaded before accessing content."""
 
     def __init__(self, eli: str):
-        super().__init__(
-            f"Dokument {eli} nie jest załadowany. "
-            f"Użyj get_act_details(eli='{eli}', load_content=true)"
-        )
+        super().__init__(f"Dokument {eli} nie jest załadowany. Użyj get_act_details(eli='{eli}', load_content=true)")
         self.eli = eli
 
 
@@ -60,8 +53,5 @@ class InvalidEliError(LawScrapperError):
     """Invalid ELI identifier format."""
 
     def __init__(self, eli: str):
-        super().__init__(
-            f"Nieprawidłowy format ELI: {eli}. "
-            f"Oczekiwany: wydawca/rok/pozycja (np. DU/2024/1716)"
-        )
+        super().__init__(f"Nieprawidłowy format ELI: {eli}. Oczekiwany: wydawca/rok/pozycja (np. DU/2024/1716)")
         self.eli = eli

--- a/src/law_scrapper_mcp/client/sejm_client.py
+++ b/src/law_scrapper_mcp/client/sejm_client.py
@@ -44,9 +44,7 @@ class SejmApiClient:
         """Initialize the HTTP client."""
         if self._client is None:
             self._client = httpx.AsyncClient(
-                timeout=httpx.Timeout(
-                    connect=5.0, read=self._timeout, write=10.0, pool=10.0
-                ),
+                timeout=httpx.Timeout(connect=5.0, read=self._timeout, write=10.0, pool=10.0),
                 headers={
                     "User-Agent": "law-scrapper-mcp/2.0",
                     "Accept": "application/json",
@@ -65,9 +63,7 @@ class SejmApiClient:
         wait=wait_exponential(min=1, max=10),
         retry=retry_if_exception_type((httpx.TimeoutException, httpx.HTTPStatusError)),
     )
-    async def _request(
-        self, method: str, path: str, **kwargs: Any
-    ) -> httpx.Response:
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         """Make HTTP request with retry logic and circuit breaker.
 
         Args:
@@ -122,9 +118,7 @@ class SejmApiClient:
                         url=url,
                     ) from e
 
-    async def get_json(
-        self, path: str, params: dict[str, Any] | None = None, cache_ttl: int | None = None
-    ) -> Any:
+    async def get_json(self, path: str, params: dict[str, Any] | None = None, cache_ttl: int | None = None) -> Any:
         """Get JSON response from API with optional caching.
 
         Args:
@@ -160,9 +154,7 @@ class SejmApiClient:
         Returns:
             Response text
         """
-        response = await self._request(
-            "GET", path, headers={"Accept": "text/html, text/plain, */*"}
-        )
+        response = await self._request("GET", path, headers={"Accept": "text/html, text/plain, */*"})
         return response.text
 
     async def get_bytes(self, path: str) -> bytes:
@@ -204,9 +196,7 @@ class SejmApiClient:
         """
         return await self.get_json("acts/search", params=params)
 
-    async def get_act_structure(
-        self, publisher: str, year: int, pos: int
-    ) -> list[dict[str, Any]]:
+    async def get_act_structure(self, publisher: str, year: int, pos: int) -> list[dict[str, Any]]:
         """Get act table of contents structure.
 
         Args:
@@ -220,9 +210,7 @@ class SejmApiClient:
         path = f"acts/{publisher}/{year}/{pos}/struct"
         return await self.get_json(path)
 
-    async def get_act_references(
-        self, publisher: str, year: int, pos: int
-    ) -> dict[str, Any]:
+    async def get_act_references(self, publisher: str, year: int, pos: int) -> dict[str, Any]:
         """Get act references/relationships.
 
         Args:

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
 
     # Server info
     server_name: str = "law-scrapper-mcp"
-    server_version: str = "2.3.0"
+    server_version: str = "2.4.0"
 
 
 settings = Settings()

--- a/src/law_scrapper_mcp/logging_config.py
+++ b/src/law_scrapper_mcp/logging_config.py
@@ -7,9 +7,7 @@ import sys
 from typing import Literal
 
 
-def setup_logging(
-    level: str = "INFO", format: Literal["text", "json"] = "text"
-) -> None:
+def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text") -> None:
     """Setup structured logging for the application.
 
     Args:
@@ -39,9 +37,7 @@ def setup_logging(
         formatter: logging.Formatter = JsonFormatter()
     else:
         # Text format for development
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
     # Configure root logger
     root_logger = logging.getLogger()

--- a/src/law_scrapper_mcp/models/tool_inputs.py
+++ b/src/law_scrapper_mcp/models/tool_inputs.py
@@ -15,36 +15,22 @@ from law_scrapper_mcp.models.enums import (
 class SearchRequest(BaseModel):
     """Parameters for searching legal acts."""
 
-    publisher: Publisher = Field(
-        default=Publisher.DU, description="Publisher code (DU or MP)"
-    )
+    publisher: Publisher = Field(default=Publisher.DU, description="Publisher code (DU or MP)")
     year: int | None = Field(default=None, description="Year of publication")
     keywords: list[str] | None = Field(
         default=None,
         description="Keywords to search for (AND logic - all must be present)",
     )
-    date_from: str | None = Field(
-        default=None, description="Start date for date range filter (YYYY-MM-DD)"
-    )
-    date_to: str | None = Field(
-        default=None, description="End date for date range filter (YYYY-MM-DD)"
-    )
+    date_from: str | None = Field(default=None, description="Start date for date range filter (YYYY-MM-DD)")
+    date_to: str | None = Field(default=None, description="End date for date range filter (YYYY-MM-DD)")
     title: str | None = Field(default=None, description="Title search phrase")
     act_type: str | None = Field(default=None, description="Type of legal act")
-    pub_date_from: str | None = Field(
-        default=None, description="Publication date from (YYYY-MM-DD)"
-    )
-    pub_date_to: str | None = Field(
-        default=None, description="Publication date to (YYYY-MM-DD)"
-    )
-    in_force: bool | None = Field(
-        default=None, description="Filter by acts currently in force"
-    )
+    pub_date_from: str | None = Field(default=None, description="Publication date from (YYYY-MM-DD)")
+    pub_date_to: str | None = Field(default=None, description="Publication date to (YYYY-MM-DD)")
+    in_force: bool | None = Field(default=None, description="Filter by acts currently in force")
     limit: int | None = Field(default=None, description="Maximum number of results")
     offset: int | None = Field(default=None, description="Number of results to skip")
-    detail_level: DetailLevel = Field(
-        default=DetailLevel.STANDARD, description="Level of detail in results"
-    )
+    detail_level: DetailLevel = Field(default=DetailLevel.STANDARD, description="Level of detail in results")
 
 
 class BrowseRequest(BaseModel):
@@ -52,17 +38,13 @@ class BrowseRequest(BaseModel):
 
     publisher: Publisher = Field(description="Publisher code (DU or MP)")
     year: int = Field(description="Year to browse")
-    detail_level: DetailLevel = Field(
-        default=DetailLevel.STANDARD, description="Level of detail in results"
-    )
+    detail_level: DetailLevel = Field(default=DetailLevel.STANDARD, description="Level of detail in results")
 
 
 class ActDetailsRequest(BaseModel):
     """Parameters for retrieving act details."""
 
-    eli: str = Field(
-        description="ELI identifier of the act (e.g., 'DU/2024/1' or full URL)"
-    )
+    eli: str = Field(description="ELI identifier of the act (e.g., 'DU/2024/1' or full URL)")
     load_content: bool = Field(
         default=False,
         description="Whether to load full content (HTML/PDF) into document store",
@@ -84,17 +66,13 @@ class SearchInActRequest(BaseModel):
 
     eli: str = Field(description="ELI identifier of the act")
     query: str = Field(description="Search query text")
-    context_chars: int = Field(
-        default=500, description="Number of characters of context around matches"
-    )
+    context_chars: int = Field(default=500, description="Number of characters of context around matches")
 
 
 class MetadataRequest(BaseModel):
     """Parameters for retrieving metadata."""
 
-    category: MetadataCategory = Field(
-        default=MetadataCategory.ALL, description="Category of metadata to retrieve"
-    )
+    category: MetadataCategory = Field(default=MetadataCategory.ALL, description="Category of metadata to retrieve")
 
 
 class RelationshipsRequest(BaseModel):
@@ -109,16 +87,10 @@ class RelationshipsRequest(BaseModel):
 class TrackChangesRequest(BaseModel):
     """Parameters for tracking changes to legal acts."""
 
-    publisher: Publisher = Field(
-        default=Publisher.DU, description="Publisher code (DU or MP)"
-    )
+    publisher: Publisher = Field(default=Publisher.DU, description="Publisher code (DU or MP)")
     date_from: str = Field(description="Start date for tracking (YYYY-MM-DD)")
-    date_to: str | None = Field(
-        default=None, description="End date for tracking (YYYY-MM-DD, default: today)"
-    )
-    keywords: list[str] | None = Field(
-        default=None, description="Filter by keywords"
-    )
+    date_to: str | None = Field(default=None, description="End date for tracking (YYYY-MM-DD, default: today)")
+    keywords: list[str] | None = Field(default=None, description="Filter by keywords")
 
 
 class DateCalculationRequest(BaseModel):
@@ -127,9 +99,7 @@ class DateCalculationRequest(BaseModel):
     days: int = Field(default=0, description="Number of days to add (positive=future, negative=past)")
     months: int = Field(default=0, description="Number of months to add (positive=future, negative=past)")
     years: int = Field(default=0, description="Number of years to add (positive=future, negative=past)")
-    base_date: str | None = Field(
-        default=None, description="Base date for calculation (YYYY-MM-DD, default: today)"
-    )
+    base_date: str | None = Field(default=None, description="Base date for calculation (YYYY-MM-DD, default: today)")
 
 
 def parse_eli(eli: str) -> tuple[str, int, int]:
@@ -155,9 +125,7 @@ def parse_eli(eli: str) -> tuple[str, int, int]:
     parts = eli.split("/")
 
     if len(parts) != 3:
-        raise ValueError(
-            f"Invalid ELI format: {eli}. Expected format: PUBLISHER/YEAR/POS"
-        )
+        raise ValueError(f"Invalid ELI format: {eli}. Expected format: PUBLISHER/YEAR/POS")
 
     publisher, year_str, pos_str = parts
 

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -14,9 +14,7 @@ class Hint(BaseModel):
 
     message: str = Field(description="Hint message")
     tool: str | None = Field(default=None, description="Related tool name")
-    parameters: dict[str, Any] | None = Field(
-        default=None, description="Suggested parameters"
-    )
+    parameters: dict[str, Any] | None = Field(default=None, description="Suggested parameters")
 
 
 class EnrichedResponse(BaseModel, Generic[T]):
@@ -25,9 +23,7 @@ class EnrichedResponse(BaseModel, Generic[T]):
     data: T = Field(description="The actual response data")
     hints: list[Hint] = Field(default_factory=list, description="Suggested next steps")
     error: str | None = Field(default=None, description="Error message if any")
-    metadata: dict[str, Any] = Field(
-        default_factory=dict, description="Additional metadata"
-    )
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
 
 class ActSummaryOutput(BaseModel):

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -2,8 +2,11 @@
 
 import logging
 from contextlib import asynccontextmanager
+from typing import Literal, cast
 
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
@@ -142,33 +145,34 @@ UWAGI:
 register_all_tools(app)
 
 
+@app.custom_route("/health", methods=["GET"])
+async def health(_request: Request) -> JSONResponse:
+    """Health check endpoint for Docker and monitoring."""
+    return JSONResponse(
+        {
+            "status": "ok",
+            "version": settings.server_version,
+            "server": settings.server_name,
+        }
+    )
+
+
 def main():
     """Entry point for the server."""
     setup_logging(settings.log_level, settings.log_format)
-
-    if settings.transport == "streamable-http":
-        import uvicorn
-        from starlette.applications import Starlette
-        from starlette.requests import Request
-        from starlette.responses import JSONResponse
-        from starlette.routing import Mount, Route
-
-        async def health(_request: Request) -> JSONResponse:
-            return JSONResponse({
-                "status": "ok",
-                "version": settings.server_version,
-                "server": settings.server_name,
-            })
-
-        starlette_app = Starlette(
-            routes=[
-                Route("/health", health),
-                Mount("/", app=app.http_app(path="/mcp")),
-            ],
+    transport = cast(
+        Literal["stdio", "http", "sse", "streamable-http"],
+        settings.transport,
+    )
+    if transport == "streamable-http":
+        app.run(
+            transport=transport,
+            host=settings.host,
+            port=settings.port,
+            path="/mcp",
         )
-        uvicorn.run(starlette_app, host=settings.host, port=settings.port)
     else:
-        app.run(transport="stdio")
+        app.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -31,9 +31,7 @@ class ActService:
         publisher, year, pos = parse_eli(eli)
 
         # Get act details
-        data = await self._client.get_json(
-            f"acts/{publisher}/{year}/{pos}", cache_ttl=settings.cache_details_ttl
-        )
+        data = await self._client.get_json(f"acts/{publisher}/{year}/{pos}", cache_ttl=settings.cache_details_ttl)
 
         # Get structure/TOC
         toc_data = []
@@ -76,9 +74,7 @@ class ActService:
             is_loaded=is_loaded,
         )
 
-    async def _load_content(
-        self, eli: str, publisher: str, year: int, pos: int, has_html: bool
-    ) -> None:
+    async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool) -> None:
         """Load act content into document store."""
         try:
             if has_html:
@@ -87,9 +83,7 @@ class ActService:
             else:
                 # Try PDF
                 try:
-                    pdf_bytes = await self._client.get_bytes(
-                        f"acts/{publisher}/{year}/{pos}/text.pdf"
-                    )
+                    pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf")
                     markdown = self._content_processor.pdf_to_text(pdf_bytes)
                     if not markdown:
                         markdown = f"*Content extraction failed. PDF available at: {self._client.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf*"

--- a/src/law_scrapper_mcp/services/changes_service.py
+++ b/src/law_scrapper_mcp/services/changes_service.py
@@ -35,9 +35,7 @@ class ChangesService:
         if keywords:
             params["keyword"] = ",".join(keywords)
 
-        data = await self._client.get_json(
-            "acts/search", params=params, cache_ttl=settings.cache_changes_ttl
-        )
+        data = await self._client.get_json("acts/search", params=params, cache_ttl=settings.cache_changes_ttl)
 
         items = data.get("items", [])
         results = []

--- a/src/law_scrapper_mcp/services/document_store.py
+++ b/src/law_scrapper_mcp/services/document_store.py
@@ -58,9 +58,7 @@ class DocumentStore:
         async with self._lock:
             doc_size = len(markdown.encode("utf-8"))
             if doc_size > self._max_size_bytes:
-                logger.warning(
-                    f"Document {eli} exceeds max size ({doc_size} > {self._max_size_bytes}), truncating"
-                )
+                logger.warning(f"Document {eli} exceeds max size ({doc_size} > {self._max_size_bytes}), truncating")
                 # Truncate to max size
                 markdown = markdown[: self._max_size_bytes]
                 # Re-index sections for truncated content
@@ -83,10 +81,7 @@ class DocumentStore:
             # Find section by ID (case-insensitive, flexible matching)
             section_id_lower = section_id.lower().replace(" ", "_")
             for section in doc.sections:
-                if (
-                    section.id.lower() == section_id_lower
-                    or section.title.lower().startswith(section_id.lower())
-                ):
+                if section.id.lower() == section_id_lower or section.title.lower().startswith(section_id.lower()):
                     return section.content
 
             # Try matching by "Art. X" pattern
@@ -94,9 +89,7 @@ class DocumentStore:
             if art_match:
                 art_num = art_match.group(1)
                 for section in doc.sections:
-                    if re.match(
-                        rf"Art\.?\s*{re.escape(art_num)}", section.title, re.IGNORECASE
-                    ):
+                    if re.match(rf"Art\.?\s*{re.escape(art_num)}", section.title, re.IGNORECASE):
                         return section.content
 
             return None
@@ -122,9 +115,7 @@ class DocumentStore:
                 section_id = "unknown"
                 section_title = "Unknown section"
                 for section in doc.sections:
-                    if section.start_pos <= match.start() < (
-                        section.end_pos or len(doc.markdown)
-                    ):
+                    if section.start_pos <= match.start() < (section.end_pos or len(doc.markdown)):
                         section_id = section.id
                         section_title = section.title
                         break
@@ -168,12 +159,8 @@ class DocumentStore:
                     "eli": doc.eli,
                     "size_bytes": doc.size_bytes,
                     "section_count": len(doc.sections),
-                    "loaded_at": time.strftime(
-                        "%Y-%m-%d %H:%M:%S", time.localtime(doc.loaded_at)
-                    ),
-                    "last_accessed": time.strftime(
-                        "%Y-%m-%d %H:%M:%S", time.localtime(doc.last_accessed)
-                    ),
+                    "loaded_at": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(doc.loaded_at)),
+                    "last_accessed": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(doc.last_accessed)),
                 }
                 for doc in self._store.values()
             ]

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -67,10 +67,7 @@ class ResultStore:
                 query_summary=query_summary,
                 total_count=total_count,
             )
-            logger.info(
-                f"Stored result set {result_set_id}: {len(results)} results "
-                f"(query: {query_summary})"
-            )
+            logger.info(f"Stored result set {result_set_id}: {len(results)} results (query: {query_summary})")
             return result_set_id
 
     async def get(self, result_set_id: str) -> StoredResultSet | None:
@@ -95,9 +92,7 @@ class ResultStore:
                     "query_summary": rs.query_summary,
                     "result_count": len(rs.results),
                     "total_count": rs.total_count,
-                    "created_at": time.strftime(
-                        "%Y-%m-%d %H:%M:%S", time.localtime(rs.created_at)
-                    ),
+                    "created_at": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(rs.created_at)),
                 }
                 for rs in self._store.values()
             ]
@@ -143,11 +138,7 @@ class ResultStore:
             except re.error as e:
                 raise ValueError(f"Invalid regex pattern: {e}") from e
 
-            filtered = [
-                r
-                for r in filtered
-                if _match_field(r, field, compiled)
-            ]
+            filtered = [r for r in filtered if _match_field(r, field, compiled)]
 
         # Date range filter
         if date_field and (date_from or date_to):
@@ -166,9 +157,7 @@ class ResultStore:
     def _evict_expired(self) -> None:
         """Remove expired result sets (called under lock)."""
         now = time.time()
-        expired = [
-            k for k, v in self._store.items() if now - v.last_accessed > self._ttl
-        ]
+        expired = [k for k, v in self._store.items() if now - v.last_accessed > self._ttl]
         for key in expired:
             del self._store[key]
 

--- a/src/law_scrapper_mcp/services/search_service.py
+++ b/src/law_scrapper_mcp/services/search_service.py
@@ -68,9 +68,7 @@ class SearchService:
         if offset:
             params["offset"] = offset
 
-        data = await self._client.get_json(
-            "acts/search", params=params, cache_ttl=settings.cache_search_ttl
-        )
+        data = await self._client.get_json("acts/search", params=params, cache_ttl=settings.cache_search_ttl)
 
         items = data.get("items", [])
         total_count = data.get("count", len(items))

--- a/src/law_scrapper_mcp/tools/act_content.py
+++ b/src/law_scrapper_mcp/tools/act_content.py
@@ -32,9 +32,9 @@ def register(mcp: FastMCP) -> None:
     async def read_act_content(
         eli: Annotated[
             str,
-            "Identyfikator ELI aktu. Format: \"{wydawca}/{rok}/{pozycja}\". "
+            'Identyfikator ELI aktu. Format: "{wydawca}/{rok}/{pozycja}". '
             "Wydawcy: DU (Dziennik Ustaw), MP (Monitor Polski). "
-            "Przykłady: \"DU/2024/1716\", \"MP/2023/500\", \"DU/2024/1\". "
+            'Przykłady: "DU/2024/1716", "MP/2023/500", "DU/2024/1". '
             "Akt MUSI być wcześniej załadowany przez get_act_details(eli=..., load_content=True).",
         ],
         section: Annotated[
@@ -66,14 +66,12 @@ def register(mcp: FastMCP) -> None:
         - read_act_content(eli="MP/2024/100") - Spis treści aktu z MP
         """
         assert ctx is not None
-        document_store = ctx.request_context.lifespan_context["document_store"]
+        document_store = ctx.lifespan_context["document_store"]
 
         if section is None:
             # Return table of contents
             sections = await document_store.get_toc(eli)
-            toc = [
-                {"id": s.id, "title": s.title, "level": s.level} for s in sections
-            ]
+            toc = [{"id": s.id, "title": s.title, "level": s.level} for s in sections]
             response = EnrichedResponse(
                 data=ContentOutput(
                     eli=eli,
@@ -132,7 +130,7 @@ def register(mcp: FastMCP) -> None:
         - list_loaded_documents() - Wyświetl wszystkie załadowane dokumenty
         """
         assert ctx is not None
-        document_store = ctx.request_context.lifespan_context["document_store"]
+        document_store = ctx.lifespan_context["document_store"]
 
         raw_docs = await document_store.list_documents()
         documents = [LoadedDocumentInfo(**d) for d in raw_docs]

--- a/src/law_scrapper_mcp/tools/act_details.py
+++ b/src/law_scrapper_mcp/tools/act_details.py
@@ -33,9 +33,9 @@ def register(mcp: FastMCP) -> None:
     async def get_act_details(
         eli: Annotated[
             str,
-            "Identyfikator ELI aktu. Format: \"{wydawca}/{rok}/{pozycja}\". "
+            'Identyfikator ELI aktu. Format: "{wydawca}/{rok}/{pozycja}". '
             "Wydawcy: DU (Dziennik Ustaw), MP (Monitor Polski). "
-            "Przykłady: \"DU/2024/1716\", \"MP/2023/500\", \"DU/2024/1\".",
+            'Przykłady: "DU/2024/1716", "MP/2023/500", "DU/2024/1".',
         ],
         load_content: Annotated[
             str | bool,
@@ -66,7 +66,7 @@ def register(mcp: FastMCP) -> None:
         - get_act_details(eli="DU/2021/1500") - Sprawdź status i daty obowiązywania
         """
         assert ctx is not None
-        act_service = ctx.request_context.lifespan_context["act_service"]
+        act_service = ctx.lifespan_context["act_service"]
 
         # Normalize bool (MCP clients may send string)
         if isinstance(load_content, str):

--- a/src/law_scrapper_mcp/tools/act_search.py
+++ b/src/law_scrapper_mcp/tools/act_search.py
@@ -27,9 +27,9 @@ def register(mcp: FastMCP) -> None:
     async def search_in_act(
         eli: Annotated[
             str,
-            "Identyfikator ELI aktu. Format: \"{wydawca}/{rok}/{pozycja}\". "
+            'Identyfikator ELI aktu. Format: "{wydawca}/{rok}/{pozycja}". '
             "Wydawcy: DU (Dziennik Ustaw), MP (Monitor Polski). "
-            "Przykłady: \"DU/2024/1716\", \"MP/2023/500\", \"DU/2024/1\". "
+            'Przykłady: "DU/2024/1716", "MP/2023/500", "DU/2024/1". '
             "Akt MUSI być wcześniej załadowany przez get_act_details(eli=..., load_content=True).",
         ],
         query: Annotated[
@@ -59,7 +59,7 @@ def register(mcp: FastMCP) -> None:
         - search_in_act(eli="DU/2024/1692", query="termin") - Wszystkie wzmianki o terminach
         """
         assert ctx is not None
-        document_store = ctx.request_context.lifespan_context["document_store"]
+        document_store = ctx.lifespan_context["document_store"]
 
         # Normalize int (MCP clients may send string)
         context_chars_int = 500

--- a/src/law_scrapper_mcp/tools/browse.py
+++ b/src/law_scrapper_mcp/tools/browse.py
@@ -62,8 +62,8 @@ def register(mcp: FastMCP) -> None:
         - browse_acts(publisher="DU", year=2000) - Akty z roku 2000
         """
         assert ctx is not None
-        search_service = ctx.request_context.lifespan_context["search_service"]
-        result_store = ctx.request_context.lifespan_context["result_store"]
+        search_service = ctx.lifespan_context["search_service"]
+        result_store = ctx.lifespan_context["result_store"]
 
         # Normalize year (MCP clients may send string)
         year_int = 0

--- a/src/law_scrapper_mcp/tools/changes.py
+++ b/src/law_scrapper_mcp/tools/changes.py
@@ -39,8 +39,7 @@ def register(mcp: FastMCP) -> None:
         ] = None,
         keywords: Annotated[
             list[str] | None,
-            "Słowa kluczowe do filtrowania zmian (logika AND). "
-            "Np. ['podatek'], ['zdrowotny', 'ubezpieczenie'].",
+            "Słowa kluczowe do filtrowania zmian (logika AND). Np. ['podatek'], ['zdrowotny', 'ubezpieczenie'].",
         ] = None,
         ctx: Context = None,
     ) -> str:
@@ -59,8 +58,8 @@ def register(mcp: FastMCP) -> None:
         - track_legal_changes(date_from="2024-01-01", keywords=["zdrowotny"]) - Zmiany zdrowotne
         """
         assert ctx is not None
-        changes_service = ctx.request_context.lifespan_context["changes_service"]
-        result_store = ctx.request_context.lifespan_context["result_store"]
+        changes_service = ctx.lifespan_context["changes_service"]
+        result_store = ctx.lifespan_context["result_store"]
 
         results, date_range = await changes_service.track_changes(
             publisher=publisher,

--- a/src/law_scrapper_mcp/tools/compare.py
+++ b/src/law_scrapper_mcp/tools/compare.py
@@ -28,14 +28,14 @@ def register(mcp: FastMCP) -> None:
     async def compare_acts(
         eli_a: Annotated[
             str,
-            "Identyfikator ELI pierwszego aktu. Format: \"{wydawca}/{rok}/{pozycja}\". "
-            "Przykłady: \"DU/2024/1716\", \"MP/2023/500\".",
+            'Identyfikator ELI pierwszego aktu. Format: "{wydawca}/{rok}/{pozycja}". '
+            'Przykłady: "DU/2024/1716", "MP/2023/500".',
         ],
         eli_b: Annotated[
             str,
             "Identyfikator ELI drugiego aktu do porównania. "
-            "Format: \"{wydawca}/{rok}/{pozycja}\". "
-            "Przykłady: \"DU/2024/1692\", \"DU/2020/1444\".",
+            'Format: "{wydawca}/{rok}/{pozycja}". '
+            'Przykłady: "DU/2024/1692", "DU/2020/1444".',
         ],
         ctx: Context = None,
     ) -> str:
@@ -57,7 +57,7 @@ def register(mcp: FastMCP) -> None:
         - compare_acts(eli_a="DU/2021/1500", eli_b="DU/2021/1600") - Porównaj podobne akty
         """
         assert ctx is not None
-        act_service = ctx.request_context.lifespan_context["act_service"]
+        act_service = ctx.lifespan_context["act_service"]
 
         # Fetch details for both acts (no content loading needed)
         details_a = await act_service.get_details(eli=eli_a, load_content=False)
@@ -93,14 +93,10 @@ def register(mcp: FastMCP) -> None:
             differences.append("Tytuły różnią się")
 
         if (details_a.type or "N/A") != (details_b.type or "N/A"):
-            differences.append(
-                f"Typy różnią się: '{details_a.type or 'N/A'}' vs '{details_b.type or 'N/A'}'"
-            )
+            differences.append(f"Typy różnią się: '{details_a.type or 'N/A'}' vs '{details_b.type or 'N/A'}'")
 
         if details_a.status != details_b.status:
-            differences.append(
-                f"Statusy różnią się: '{details_a.status}' vs '{details_b.status}'"
-            )
+            differences.append(f"Statusy różnią się: '{details_a.status}' vs '{details_b.status}'")
 
         if details_a.promulgation_date != details_b.promulgation_date:
             differences.append(
@@ -120,13 +116,9 @@ def register(mcp: FastMCP) -> None:
             only_a = set_a - set_b
             only_b = set_b - set_a
             if only_a:
-                differences.append(
-                    f"Słowa kluczowe tylko w A: {', '.join(sorted(only_a))}"
-                )
+                differences.append(f"Słowa kluczowe tylko w A: {', '.join(sorted(only_a))}")
             if only_b:
-                differences.append(
-                    f"Słowa kluczowe tylko w B: {', '.join(sorted(only_b))}"
-                )
+                differences.append(f"Słowa kluczowe tylko w B: {', '.join(sorted(only_b))}")
 
         if not differences:
             differences.append("Brak istotnych różnic w metadanych")

--- a/src/law_scrapper_mcp/tools/dates.py
+++ b/src/law_scrapper_mcp/tools/dates.py
@@ -56,8 +56,7 @@ def register(mcp: FastMCP) -> None:
     async def calculate_legal_date(
         days: Annotated[
             str | int,
-            "Liczba dni do dodania (+) lub odjęcia (-). "
-            "Np. days=14 = za 14 dni, days=-14 = 14 dni temu. Domyślnie 0.",
+            "Liczba dni do dodania (+) lub odjęcia (-). Np. days=14 = za 14 dni, days=-14 = 14 dni temu. Domyślnie 0.",
         ] = 0,
         months: Annotated[
             str | int,
@@ -66,8 +65,7 @@ def register(mcp: FastMCP) -> None:
         ] = 0,
         years: Annotated[
             str | int,
-            "Liczba lat do dodania (+) lub odjęcia (-). "
-            "Np. years=1 = za rok, years=-5 = 5 lat temu. Domyślnie 0.",
+            "Liczba lat do dodania (+) lub odjęcia (-). Np. years=1 = za rok, years=-5 = 5 lat temu. Domyślnie 0.",
         ] = 0,
         base_date: Annotated[
             str | None,

--- a/src/law_scrapper_mcp/tools/filter_results.py
+++ b/src/law_scrapper_mcp/tools/filter_results.py
@@ -106,7 +106,7 @@ def register(mcp: FastMCP) -> None:
         - filter_results(result_set_id="rs_1", sort_by="promulgation_date", sort_desc=True, limit=10) - 10 najnowszych
         """
         assert ctx is not None
-        result_store = ctx.request_context.lifespan_context["result_store"]
+        result_store = ctx.lifespan_context["result_store"]
 
         # Normalize params (MCP clients may send int/bool as strings)
         year_int: int | None = None
@@ -119,11 +119,7 @@ def register(mcp: FastMCP) -> None:
             with contextlib.suppress(ValueError, TypeError):
                 limit_int = int(limit)
 
-        sort_desc_bool = (
-            sort_desc.lower() in ("true", "1", "yes")
-            if isinstance(sort_desc, str)
-            else bool(sort_desc)
-        )
+        sort_desc_bool = sort_desc.lower() in ("true", "1", "yes") if isinstance(sort_desc, str) else bool(sort_desc)
 
         filtered, original_count = await result_store.filter_results(
             result_set_id,
@@ -215,7 +211,6 @@ def register(mcp: FastMCP) -> None:
 
         return response.model_dump_json()
 
-
     @mcp.tool(tags={"utility", "filter"})
     @handle_tool_errors(
         default_factory=lambda e, kw: ResultSetListOutput(sets=[], count=0),
@@ -237,7 +232,7 @@ def register(mcp: FastMCP) -> None:
         - list_result_sets() - Wyświetl wszystkie aktywne zestawy wyników
         """
         assert ctx is not None
-        result_store = ctx.request_context.lifespan_context["result_store"]
+        result_store = ctx.lifespan_context["result_store"]
 
         raw_sets = await result_store.list_sets()
         sets = [ResultSetInfo(**s) for s in raw_sets]

--- a/src/law_scrapper_mcp/tools/metadata.py
+++ b/src/law_scrapper_mcp/tools/metadata.py
@@ -49,7 +49,7 @@ def register(mcp: FastMCP) -> None:
         - get_system_metadata(category="all") - Wszystkie kategorie metadanych
         """
         assert ctx is not None
-        metadata_service = ctx.request_context.lifespan_context["metadata_service"]
+        metadata_service = ctx.lifespan_context["metadata_service"]
 
         # Convert string to enum
         try:
@@ -63,9 +63,7 @@ def register(mcp: FastMCP) -> None:
             data=MetadataOutput(
                 category=category,
                 metadata=metadata,
-                count=sum(
-                    len(v) if isinstance(v, list) else 1 for v in metadata.values()
-                ),
+                count=sum(len(v) if isinstance(v, list) else 1 for v in metadata.values()),
             ),
             hints=metadata_hints(category),
         )

--- a/src/law_scrapper_mcp/tools/relationships.py
+++ b/src/law_scrapper_mcp/tools/relationships.py
@@ -27,9 +27,9 @@ def register(mcp: FastMCP) -> None:
     async def analyze_act_relationships(
         eli: Annotated[
             str,
-            "Identyfikator ELI aktu. Format: \"{wydawca}/{rok}/{pozycja}\". "
+            'Identyfikator ELI aktu. Format: "{wydawca}/{rok}/{pozycja}". '
             "Wydawcy: DU (Dziennik Ustaw), MP (Monitor Polski). "
-            "Przykłady: \"DU/2024/1716\", \"MP/2023/500\", \"DU/2024/1\".",
+            'Przykłady: "DU/2024/1716", "MP/2023/500", "DU/2024/1".',
         ],
         relationship_type: Annotated[
             str | None,
@@ -55,7 +55,7 @@ def register(mcp: FastMCP) -> None:
         - analyze_act_relationships(eli="DU/2024/1", relationship_type="Akty uznane za uchylone") - Uchylone akty
         """
         assert ctx is not None
-        client = ctx.request_context.lifespan_context["client"]
+        client = ctx.lifespan_context["client"]
 
         # Parse ELI
         parts = eli.split("/")
@@ -64,9 +64,7 @@ def register(mcp: FastMCP) -> None:
         publisher, year, pos = parts
 
         # Get references
-        references_data = await client.get_json(
-            f"acts/{publisher}/{year}/{pos}/references"
-        )
+        references_data = await client.get_json(f"acts/{publisher}/{year}/{pos}/references")
 
         # Process relationships
         relationships = {}
@@ -77,9 +75,7 @@ def register(mcp: FastMCP) -> None:
         elif isinstance(references_data, list):
             relationships["references"] = references_data
 
-        total_count = sum(
-            len(v) if isinstance(v, list) else 1 for v in relationships.values()
-        )
+        total_count = sum(len(v) if isinstance(v, list) else 1 for v in relationships.values())
 
         response = EnrichedResponse(
             data=RelationshipsOutput(

--- a/src/law_scrapper_mcp/tools/search.py
+++ b/src/law_scrapper_mcp/tools/search.py
@@ -21,9 +21,7 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(tags={"search"})
     @handle_tool_errors(
-        default_factory=lambda e, kw: SearchOutput(
-            results=[], total_count=0, query_summary="", returned_count=0
-        ),
+        default_factory=lambda e, kw: SearchOutput(results=[], total_count=0, query_summary="", returned_count=0),
     )
     async def search_legal_acts(
         publisher: Annotated[
@@ -106,8 +104,8 @@ def register(mcp: FastMCP) -> None:
         - search_legal_acts(title="budżet", year=2024) - Akty budżetowe z 2024
         """
         assert ctx is not None
-        search_service = ctx.request_context.lifespan_context["search_service"]
-        result_store = ctx.request_context.lifespan_context["result_store"]
+        search_service = ctx.lifespan_context["search_service"]
+        result_store = ctx.lifespan_context["result_store"]
 
         # Normalize params (MCP clients may send int/bool as strings)
         year_int: int | None = None
@@ -127,11 +125,7 @@ def register(mcp: FastMCP) -> None:
 
         in_force_bool: bool | None = None
         if in_force is not None:
-            in_force_bool = (
-                in_force.lower() in ("true", "1", "yes")
-                if isinstance(in_force, str)
-                else bool(in_force)
-            )
+            in_force_bool = in_force.lower() in ("true", "1", "yes") if isinstance(in_force, str) else bool(in_force)
 
         # Convert detail_level string to enum
         try:

--- a/test_server_load.py
+++ b/test_server_load.py
@@ -1,7 +1,8 @@
 """Quick test to verify server loads correctly."""
 
-import sys
 import importlib.util
+import sys
+
 
 def test_import(module_name):
     """Test if a module can be imported."""
@@ -11,13 +12,19 @@ def test_import(module_name):
             print(f"❌ Module {module_name} not found")
             return False
 
+        loader = spec.loader
+        if loader is None:
+            print(f"Module {module_name} has no loader")
+            return False
+
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        loader.exec_module(module)
         print(f"✓ Module {module_name} loaded successfully")
         return True
     except Exception as e:
         print(f"❌ Failed to load {module_name}: {e}")
         return False
+
 
 if __name__ == "__main__":
     print("Testing Law Scrapper MCP v2.0 imports...\n")
@@ -48,7 +55,7 @@ if __name__ == "__main__":
         if test_import(module):
             success_count += 1
 
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print(f"Results: {success_count}/{len(modules_to_test)} modules loaded successfully")
 
     if success_count == len(modules_to_test):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
+import respx
+from httpx import Response
 
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
@@ -62,7 +65,7 @@ def cache() -> TTLCache:
 
 
 @pytest.fixture
-async def mock_client(cache: TTLCache) -> SejmApiClient:
+async def mock_client(cache: TTLCache) -> AsyncGenerator[SejmApiClient]:
     """Create a SejmApiClient with mocked httpx.
 
     Note: Tests using this fixture should use respx to mock HTTP responses.
@@ -83,3 +86,75 @@ def document_store() -> DocumentStore:
 def content_processor() -> ContentProcessor:
     """Create a ContentProcessor instance."""
     return ContentProcessor()
+
+
+@pytest.fixture
+def mock_api_responses(
+    publishers_data: list,
+    search_results: dict,
+    act_detail: dict,
+    act_references: dict,
+):
+    """Setup common API response mocks for integration tests."""
+    act_detail_2 = {
+        "ELI": "DU/2024/2",
+        "publisher": "DU",
+        "year": 2024,
+        "pos": 2,
+        "title": "Rozporządzenie testowe 2",
+        "status": "akt obowiązujący",
+        "type": "Rozporządzenie",
+        "announcementDate": "2024-01-10",
+        "promulgation": "2024-01-10",
+        "entryIntoForce": "2024-03-01",
+        "validFrom": "2024-03-01",
+        "repealDate": None,
+        "changeDate": None,
+        "keywords": ["transport"],
+        "references": None,
+        "volume": 1,
+        "textPDF": "/eli/acts/DU/2024/2/text.pdf",
+        "textHTML": None,
+        "inForce": "YES",
+    }
+    with respx.mock:
+        respx.get("https://api.sejm.gov.pl/eli/acts").mock(return_value=Response(200, json=publishers_data))
+        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
+            return_value=Response(200, json=["prawo", "ustawa", "kodeks"])
+        )
+        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(
+            return_value=Response(200, json=["akt obowiązujący", "uchylony"])
+        )
+        respx.get("https://api.sejm.gov.pl/eli/types").mock(
+            return_value=Response(200, json=["Ustawa", "Rozporządzenie"])
+        )
+        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(
+            return_value=Response(200, json=["Sejm RP", "Senat RP"])
+        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024").mock(return_value=Response(200, json=search_results))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.html").mock(
+            return_value=Response(
+                200,
+                text="<html><body><h1>Test Act</h1><p>Art. 1. Content here.</p></body></html>",
+            )
+        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/references").mock(
+            return_value=Response(200, json=act_references)
+        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/2").mock(return_value=Response(200, json=act_detail_2))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/2/struct").mock(return_value=Response(404))
+        yield
+
+
+@pytest.fixture
+async def mcp_client(mock_api_responses):
+    """FastMCP in-memory client with mocked Sejm API responses."""
+    from fastmcp import Client
+
+    from law_scrapper_mcp.server import app
+
+    async with Client(app) as client:
+        yield client

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1,0 +1,24 @@
+"""Integration tests for HTTP transport."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from law_scrapper_mcp.config import settings
+from law_scrapper_mcp.server import app
+
+pytestmark = pytest.mark.integration
+
+
+def test_health_endpoint() -> None:
+    """GET /health returns status, version, and server name."""
+    asgi_app = app.http_app(path="/mcp")
+    with TestClient(asgi_app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["version"] == settings.server_version
+    assert data["server"] == settings.server_name

--- a/tests/integration/test_tools_e2e.py
+++ b/tests/integration/test_tools_e2e.py
@@ -1,155 +1,607 @@
 """End-to-end integration tests for MCP tools.
 
-These tests verify that tools work correctly through the FastMCP interface.
-They use mocked HTTP responses but test the full tool execution path.
+Test strategy:
+  - All 13 tools are exercised through the FastMCP in-memory Client (no real network).
+  - HTTP calls to api.sejm.gov.pl are intercepted by respx (see conftest.mock_api_responses).
+  - Each smoke test verifies:
+      1. The tool returns a valid JSON payload without raising.
+      2. The EnrichedResponse envelope contains both `data` and `hints` keys.
+      3. At least one business-logic field in `data` carries the expected value.
+  - Stateful workflow tests chain tools in the order a real client would use them
+    (search → filter, get_act_details(load_content=True) → read/search in content).
+  - Error-handling tests confirm graceful degradation: the decorator catches
+    exceptions and returns an EnrichedResponse with a non-null `error` field
+    instead of propagating the exception to the MCP client.
+
+Coverage map (13 tools):
+  metadata   : get_system_metadata
+  search     : search_legal_acts, browse_acts
+  filter     : filter_results, list_result_sets
+  analysis   : get_act_details, read_act_content, search_in_act,
+               analyze_act_relationships, compare_acts
+  tracking   : track_legal_changes
+  dates      : calculate_legal_date
+  utility    : list_loaded_documents
 """
 
 from __future__ import annotations
 
-import pytest
-import respx
-from httpx import Response
+import json
+from typing import Any
 
-# Mark all tests in this module as integration tests
+import pytest
+
 pytestmark = pytest.mark.integration
 
+EXPECTED_TOOLS = sorted(
+    [
+        "analyze_act_relationships",
+        "browse_acts",
+        "calculate_legal_date",
+        "compare_acts",
+        "filter_results",
+        "get_act_details",
+        "get_system_metadata",
+        "list_loaded_documents",
+        "list_result_sets",
+        "read_act_content",
+        "search_in_act",
+        "search_legal_acts",
+        "track_legal_changes",
+    ]
+)
 
-@pytest.fixture
-def mock_api_responses(publishers_data: list, search_results: dict, act_detail: dict):
-    """Setup common API response mocks."""
-    with respx.mock:
-        # Publishers/metadata endpoints
-        respx.get("https://api.sejm.gov.pl/eli/acts").mock(
-            return_value=Response(200, json=publishers_data)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
-            return_value=Response(200, json=["prawo", "ustawa", "kodeks"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(
-            return_value=Response(200, json=["akt obowiązujący", "uchylony"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/types").mock(
-            return_value=Response(200, json=["Ustawa", "Rozporządzenie"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(
-            return_value=Response(200, json=["Sejm RP", "Senat RP"])
-        )
 
-        # Search endpoints
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024").mock(
-            return_value=Response(200, json=search_results)
-        )
+def _parse_tool_result(result: Any) -> dict[str, Any]:
+    """Extract JSON payload from a FastMCP call_tool result."""
+    if hasattr(result, "data") and result.data is not None:
+        if isinstance(result.data, dict):
+            return result.data
+        if isinstance(result.data, str):
+            return json.loads(result.data)
 
-        # Act details endpoints
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.html").mock(
-            return_value=Response(
-                200,
-                text="<html><body><h1>Test Act</h1><p>Art. 1. Content</p></body></html>",
-            )
-        )
+    if result.content:
+        return json.loads(result.content[0].text)
 
-        yield
+    raise ValueError(f"Unexpected tool result format: {result!r}")
+
+
+def _assert_enriched(payload: dict[str, Any]) -> None:
+    """Assert that the EnrichedResponse envelope is well-formed."""
+    assert "data" in payload, "EnrichedResponse must contain 'data'"
+    assert "hints" in payload, "EnrichedResponse must contain 'hints'"
+    assert isinstance(payload["hints"], list), "'hints' must be a list"
+
+
+# ---------------------------------------------------------------------------
+# list_tools
+# ---------------------------------------------------------------------------
+
+
+class TestListToolsMCP:
+    """Verify all 13 tools are registered and accessible via the MCP protocol."""
+
+    async def test_list_tools_returns_all_13(self, mcp_client) -> None:
+        """list_tools() returns exactly the 13 expected tool names."""
+        tools = await mcp_client.list_tools()
+        tool_names = sorted(tool.name for tool in tools)
+
+        assert len(tool_names) == 13
+        assert tool_names == EXPECTED_TOOLS
+
+    async def test_all_tools_have_descriptions(self, mcp_client) -> None:
+        """Every tool exposes a non-empty description string."""
+        tools = await mcp_client.list_tools()
+        for tool in tools:
+            assert tool.description, f"Tool '{tool.name}' is missing a description"
+
+
+# ---------------------------------------------------------------------------
+# get_system_metadata
+# ---------------------------------------------------------------------------
 
 
 class TestMetadataTools:
     """Tests for metadata retrieval tools."""
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_get_metadata_all(self, mock_api_responses):
-        """Test getting all metadata categories."""
-        # TODO: Use FastMCP test client when available
-        # from fastmcp import Client
-        # client = Client.from_app(app)
-        # result = await client.call_tool("get_metadata", {"category": "all"})
-        # assert "keywords" in result.data
-        pass
+    async def test_get_metadata_publishers(self, mcp_client) -> None:
+        """Publishers category returns a list of publisher objects."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "publishers"})
+        payload = _parse_tool_result(result)
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_get_metadata_publishers(self, mock_api_responses):
-        """Test getting publishers metadata."""
-        pass
+        _assert_enriched(payload)
+        assert payload["data"]["category"] == "publishers"
+        assert "publishers" in payload["data"]["metadata"]
+        assert len(payload["data"]["metadata"]["publishers"]) == 2
+
+    async def test_get_metadata_keywords(self, mcp_client) -> None:
+        """Keywords category returns a non-empty list of keyword strings."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "keywords"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["category"] == "keywords"
+        assert "keywords" in payload["data"]["metadata"]
+        assert len(payload["data"]["metadata"]["keywords"]) >= 1
+
+    async def test_get_metadata_types(self, mcp_client) -> None:
+        """Types category returns document type values."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "types"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["category"] == "types"
+        assert "types" in payload["data"]["metadata"]
+
+    async def test_get_metadata_statuses(self, mcp_client) -> None:
+        """Statuses category returns at least one status value."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "statuses"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["category"] == "statuses"
+        assert "statuses" in payload["data"]["metadata"]
+
+    async def test_get_metadata_all(self, mcp_client) -> None:
+        """'all' category returns a combined metadata dict with multiple keys."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "all"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["count"] > 0
+        # At least publishers and keywords should be present
+        assert len(payload["data"]["metadata"]) >= 2
+
+
+# ---------------------------------------------------------------------------
+# search_legal_acts, browse_acts, track_legal_changes
+# ---------------------------------------------------------------------------
 
 
 class TestSearchTools:
     """Tests for search and browse tools."""
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_search_legal_acts(self, mock_api_responses):
-        """Test searching legal acts."""
-        # TODO: Implement when FastMCP test client is available
-        pass
+    async def test_search_legal_acts(self, mcp_client) -> None:
+        """search_legal_acts returns a paginated result set with acts."""
+        result = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        payload = _parse_tool_result(result)
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_browse_acts_by_year(self, mock_api_responses):
-        """Test browsing acts by publisher and year."""
-        pass
+        _assert_enriched(payload)
+        assert payload["data"]["total_count"] == 3
+        assert payload["data"]["returned_count"] == 3
+        assert payload["data"]["result_set_id"] is not None
+
+    async def test_search_legal_acts_returns_enriched_results(self, mcp_client) -> None:
+        """Each result in search output carries required fields."""
+        result = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        payload = _parse_tool_result(result)
+
+        first = payload["data"]["results"][0]
+        assert "eli" in first
+        assert "title" in first
+        assert "status" in first
+
+    async def test_list_result_sets_after_search(self, mcp_client) -> None:
+        """list_result_sets reports the set created by the preceding search."""
+        await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+
+        result = await mcp_client.call_tool("list_result_sets", {})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["count"] >= 1
+        assert len(payload["data"]["sets"]) >= 1
+
+    async def test_browse_acts(self, mcp_client) -> None:
+        """browse_acts(publisher, year) returns acts for the given year."""
+        result = await mcp_client.call_tool("browse_acts", {"publisher": "DU", "year": 2024})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["returned_count"] == 3
+        assert payload["data"]["result_set_id"] is not None
+
+    async def test_track_legal_changes(self, mcp_client) -> None:
+        """track_legal_changes returns acts published in the given date range."""
+        result = await mcp_client.call_tool(
+            "track_legal_changes",
+            {"date_from": "2024-01-01", "date_to": "2024-12-31"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert "date_range" in payload["data"]
+        assert payload["data"]["publisher"] == "DU"
+        # The mock search returns 3 acts regardless of date params
+        assert payload["data"]["total_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# filter_results, list_result_sets
+# ---------------------------------------------------------------------------
+
+
+class TestFilterTools:
+    """Tests for result filtering tools."""
+
+    async def test_filter_results_by_type(self, mcp_client) -> None:
+        """filter_results narrows a result set to matching document types."""
+        search = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        search_payload = _parse_tool_result(search)
+        result_set_id = search_payload["data"]["result_set_id"]
+
+        result = await mcp_client.call_tool(
+            "filter_results",
+            {"result_set_id": result_set_id, "type_equals": "Ustawa"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["source_result_set_id"] == result_set_id
+        assert payload["data"]["filtered_count"] >= 1
+        for act in payload["data"]["results"]:
+            assert act["type"] == "Ustawa"
+
+    async def test_filter_results_by_regex_pattern(self, mcp_client) -> None:
+        """filter_results applies regex to act titles."""
+        browse = await mcp_client.call_tool("browse_acts", {"publisher": "DU", "year": 2024})
+        browse_payload = _parse_tool_result(browse)
+        rs_id = browse_payload["data"]["result_set_id"]
+
+        result = await mcp_client.call_tool(
+            "filter_results",
+            {"result_set_id": rs_id, "pattern": "ustawa"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["filtered_count"] >= 1
+
+    async def test_filter_results_creates_new_result_set(self, mcp_client) -> None:
+        """filter_results stores filtered output as a new result_set_id."""
+        search = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        rs_id = _parse_tool_result(search)["data"]["result_set_id"]
+
+        filter_result = await mcp_client.call_tool(
+            "filter_results",
+            {"result_set_id": rs_id, "type_equals": "Ustawa"},
+        )
+        filter_payload = _parse_tool_result(filter_result)
+
+        # A new result_set_id is created for chained filtering
+        if filter_payload["data"]["filtered_count"] > 0:
+            assert filter_payload["data"]["result_set_id"] is not None
+            assert filter_payload["data"]["result_set_id"] != rs_id
+
+
+# ---------------------------------------------------------------------------
+# get_act_details, list_loaded_documents
+# ---------------------------------------------------------------------------
 
 
 class TestActDetailsTools:
-    """Tests for act details and content tools."""
+    """Tests for act details and content loading tools."""
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_get_act_details(self, mock_api_responses):
-        """Test getting act details."""
-        pass
+    async def test_get_act_details(self, mcp_client, act_detail: dict) -> None:
+        """get_act_details returns metadata matching the fixture."""
+        result = await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1"})
+        payload = _parse_tool_result(result)
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_get_act_details_with_content(self, mock_api_responses):
-        """Test getting act details with content loading."""
-        pass
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        assert payload["data"]["title"] == act_detail["title"]
+        assert payload["data"]["is_loaded"] is False
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_read_act_content(self, mock_api_responses):
-        """Test reading act content by section."""
-        pass
+    async def test_list_loaded_documents_empty(self, mcp_client) -> None:
+        """list_loaded_documents returns empty list when no acts are loaded."""
+        result = await mcp_client.call_tool("list_loaded_documents", {})
+        payload = _parse_tool_result(result)
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_search_in_act(self, mock_api_responses):
-        """Test searching within an act."""
-        pass
+        _assert_enriched(payload)
+        assert payload["data"]["count"] == 0
+        assert payload["data"]["documents"] == []
+
+    async def test_get_act_details_with_load_content(self, mcp_client) -> None:
+        """get_act_details with load_content=True marks act as loaded."""
+        result = await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        assert payload["data"]["is_loaded"] is True
+
+    async def test_list_loaded_documents_after_load(self, mcp_client) -> None:
+        """list_loaded_documents reports the act after load_content=True."""
+        await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
+
+        result = await mcp_client.call_tool("list_loaded_documents", {})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["count"] == 1
+        assert payload["data"]["documents"][0]["eli"] == "DU/2024/1"
 
 
-class TestChangesTools:
-    """Tests for changes tracking tools."""
+# ---------------------------------------------------------------------------
+# read_act_content, search_in_act
+# ---------------------------------------------------------------------------
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_track_changes(self, mock_api_responses):
-        """Test tracking legal changes."""
-        pass
+
+class TestActContentTools:
+    """Tests for tools that read content from loaded acts."""
+
+    async def _load_act(self, mcp_client) -> None:
+        """Helper: load DU/2024/1 content into the document store."""
+        await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
+
+    async def test_read_act_content_returns_toc(self, mcp_client) -> None:
+        """read_act_content without section returns the table of contents."""
+        await self._load_act(mcp_client)
+
+        result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        assert "toc" in payload["data"]
+        assert isinstance(payload["data"]["toc"], list)
+        # The mock HTML produces at least one section (h1 heading)
+        assert len(payload["data"]["toc"]) >= 1
+
+    async def test_read_act_content_specific_section(self, mcp_client) -> None:
+        """read_act_content with a valid section_id returns non-empty content."""
+        await self._load_act(mcp_client)
+
+        # First get toc to find a valid section id
+        toc_result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1"})
+        toc_payload = _parse_tool_result(toc_result)
+        sections = toc_payload["data"]["toc"]
+        assert sections, "TOC must not be empty to test section reading"
+
+        first_section_id = sections[0]["id"]
+        result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1", "section": first_section_id})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        assert payload["data"]["content"]  # non-empty string
+
+    async def test_read_act_content_unknown_section(self, mcp_client) -> None:
+        """read_act_content with a non-existent section returns graceful error."""
+        await self._load_act(mcp_client)
+
+        result = await mcp_client.call_tool(
+            "read_act_content",
+            {"eli": "DU/2024/1", "section": "Rozdział_NONEXISTENT_999"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        # Error field is set; data is present but content is empty
+        assert payload.get("error") is not None
+
+    async def test_search_in_act(self, mcp_client) -> None:
+        """search_in_act finds occurrences of a query term in loaded content."""
+        await self._load_act(mcp_client)
+
+        result = await mcp_client.call_tool("search_in_act", {"eli": "DU/2024/1", "query": "Content"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        assert payload["data"]["query"] == "Content"
+        assert payload["data"]["total_matches"] >= 1
+
+    async def test_search_in_act_no_matches(self, mcp_client) -> None:
+        """search_in_act returns zero matches for a term not in the content."""
+        await self._load_act(mcp_client)
+
+        result = await mcp_client.call_tool("search_in_act", {"eli": "DU/2024/1", "query": "XYZNONEXISTENT_TERM"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["total_matches"] == 0
+        assert payload["data"]["matches"] == []
+
+
+# ---------------------------------------------------------------------------
+# analyze_act_relationships, compare_acts
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipTools:
+    """Tests for relationship and comparison analysis tools."""
+
+    async def test_analyze_act_relationships(self, mcp_client, act_references: dict) -> None:
+        """analyze_act_relationships returns the mocked reference data."""
+        result = await mcp_client.call_tool("analyze_act_relationships", {"eli": "DU/2024/1"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli"] == "DU/2024/1"
+        # The fixture has "Akty zmienione" and "Podstawa prawna"
+        assert payload["data"]["total_count"] == 2
+        assert "Akty zmienione" in payload["data"]["relationships"]
+        assert "Podstawa prawna" in payload["data"]["relationships"]
+
+    async def test_analyze_act_relationships_filtered(self, mcp_client) -> None:
+        """relationship_type filter returns only the requested category."""
+        result = await mcp_client.call_tool(
+            "analyze_act_relationships",
+            {"eli": "DU/2024/1", "relationship_type": "Akty zmienione"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["relationship_type"] == "Akty zmienione"
+        assert "Akty zmienione" in payload["data"]["relationships"]
+        assert "Podstawa prawna" not in payload["data"]["relationships"]
+
+    async def test_compare_acts(self, mcp_client) -> None:
+        """compare_acts returns a comparison with differences and fields for both acts."""
+        result = await mcp_client.call_tool("compare_acts", {"eli_a": "DU/2024/1", "eli_b": "DU/2024/2"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["eli_a"] == "DU/2024/1"
+        assert payload["data"]["eli_b"] == "DU/2024/2"
+        assert "comparison" in payload["data"]
+        assert "differences" in payload["data"]
+        assert isinstance(payload["data"]["differences"], list)
+        assert len(payload["data"]["differences"]) >= 1
+
+    async def test_compare_acts_same_act(self, mcp_client) -> None:
+        """compare_acts on the same ELI reports no differences."""
+        result = await mcp_client.call_tool("compare_acts", {"eli_a": "DU/2024/1", "eli_b": "DU/2024/1"})
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        differences = payload["data"]["differences"]
+        assert any("Brak" in d for d in differences), "Same-act comparison should report no differences"
+
+
+# ---------------------------------------------------------------------------
+# calculate_legal_date
+# ---------------------------------------------------------------------------
 
 
 class TestDateTools:
     """Tests for date utility tools."""
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_get_current_date(self):
-        """Test getting current date."""
-        pass
+    async def test_calculate_date_offset(self, mcp_client) -> None:
+        """calculate_legal_date adds the given number of days to base_date."""
+        result = await mcp_client.call_tool(
+            "calculate_legal_date",
+            {"days": 14, "base_date": "2025-02-01"},
+        )
+        payload = _parse_tool_result(result)
 
-    @pytest.mark.skip(reason="Requires FastMCP test client integration")
-    async def test_calculate_date_offset(self):
-        """Test calculating date with offset."""
-        pass
+        _assert_enriched(payload)
+        assert payload["data"]["base_date"] == "2025-02-01"
+        assert payload["data"]["calculated_date"] == "2025-02-15"
+        assert payload["data"]["days_offset"] == 14
+
+    async def test_calculate_date_negative_offset(self, mcp_client) -> None:
+        """calculate_legal_date supports negative days (dates in the past)."""
+        result = await mcp_client.call_tool(
+            "calculate_legal_date",
+            {"days": -7, "base_date": "2025-02-08"},
+        )
+        payload = _parse_tool_result(result)
+
+        _assert_enriched(payload)
+        assert payload["data"]["calculated_date"] == "2025-02-01"
 
 
-# Placeholder tests to ensure test discovery works
-def test_integration_tests_marked():
+# ---------------------------------------------------------------------------
+# EnrichedResponse structure validation (cross-cutting)
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichedResponseStructure:
+    """Verify that every tool response follows the EnrichedResponse envelope."""
+
+    async def test_search_response_structure(self, mcp_client) -> None:
+        """search_legal_acts wraps payload in {data, hints}."""
+        result = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        raw = result.content[0].text if result.content else None
+        assert raw is not None
+        payload = json.loads(raw)
+
+        assert set(payload.keys()) >= {"data", "hints"}
+        assert isinstance(payload["hints"], list)
+
+    async def test_metadata_response_structure(self, mcp_client) -> None:
+        """get_system_metadata wraps payload in {data, hints}."""
+        result = await mcp_client.call_tool("get_system_metadata", {"category": "publishers"})
+        raw = result.content[0].text if result.content else None
+        assert raw is not None
+        payload = json.loads(raw)
+
+        assert "data" in payload
+        assert "hints" in payload
+
+    async def test_act_details_response_structure(self, mcp_client) -> None:
+        """get_act_details wraps payload in {data, hints}."""
+        result = await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1"})
+        raw = result.content[0].text if result.content else None
+        assert raw is not None
+        payload = json.loads(raw)
+
+        assert "data" in payload
+        assert "hints" in payload
+
+    async def test_hints_are_valid_objects(self, mcp_client) -> None:
+        """Hints returned by search_legal_acts are valid hint objects."""
+        result = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        payload = json.loads(result.content[0].text)
+
+        for hint in payload["hints"]:
+            assert "message" in hint, "Each hint must have a 'message' field"
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Verify graceful error handling in tool execution."""
+
+    async def test_get_act_details_invalid_eli_format(self, mcp_client) -> None:
+        """get_act_details with malformed ELI returns error in payload, not exception."""
+        result = await mcp_client.call_tool("get_act_details", {"eli": "INVALID"})
+        payload = _parse_tool_result(result)
+
+        # Tool must NOT raise; it returns EnrichedResponse with error
+        assert "error" in payload
+        assert payload["error"] is not None
+        assert "data" in payload  # default_factory output is present
+
+    async def test_filter_results_unknown_set_id(self, mcp_client) -> None:
+        """filter_results with an unknown result_set_id returns graceful error."""
+        result = await mcp_client.call_tool(
+            "filter_results",
+            {"result_set_id": "rs_nonexistent_999"},
+        )
+        payload = _parse_tool_result(result)
+
+        assert "error" in payload
+        assert payload["error"] is not None
+
+    async def test_read_act_content_not_loaded(self, mcp_client) -> None:
+        """read_act_content on a non-loaded act returns graceful error payload."""
+        result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1"})
+        payload = _parse_tool_result(result)
+
+        # DocumentNotLoadedError caught by decorator
+        assert "error" in payload
+        assert payload["error"] is not None
+
+    async def test_analyze_relationships_invalid_eli(self, mcp_client) -> None:
+        """analyze_act_relationships with invalid ELI returns graceful error."""
+        result = await mcp_client.call_tool("analyze_act_relationships", {"eli": "ONLY_TWO/PARTS"})
+        payload = _parse_tool_result(result)
+
+        assert "error" in payload
+        assert payload["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures smoke-check (non-MCP)
+# ---------------------------------------------------------------------------
+
+
+def test_integration_tests_marked() -> None:
     """Verify integration tests are properly marked."""
     assert True
 
 
 def test_fixtures_available(
-    publishers_data: list, search_results: dict, act_detail: dict
-):
+    publishers_data: list,
+    search_results: dict,
+    act_detail: dict,
+) -> None:
     """Verify that fixtures are available for integration tests."""
     assert len(publishers_data) == 2
     assert search_results["count"] == 3

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,7 +59,7 @@ class TestSettingsDefaults:
         """Test default server info."""
         settings = Settings()
         assert settings.server_name == "law-scrapper-mcp"
-        assert settings.server_version == "2.3.0"
+        assert settings.server_version == "2.4.0"
 
 
 class TestSettingsFromEnvironment:

--- a/tests/unit/test_content_processor.py
+++ b/tests/unit/test_content_processor.py
@@ -17,9 +17,7 @@ class TestHtmlToMarkdown:
         assert "# Title" in md
         assert "Paragraph text." in md
 
-    def test_html_to_markdown_with_sample(
-        self, content_processor: ContentProcessor, sample_act_html: str
-    ):
+    def test_html_to_markdown_with_sample(self, content_processor: ContentProcessor, sample_act_html: str):
         """Test HTML to Markdown with sample act HTML."""
         md = content_processor.html_to_markdown(sample_act_html)
         assert "USTAWA z dnia 1 stycznia 2024 r." in md
@@ -37,9 +35,7 @@ class TestHtmlToMarkdown:
         assert "Text" in md
         assert "<script>" not in md
 
-    def test_html_to_markdown_normalizes_whitespace(
-        self, content_processor: ContentProcessor
-    ):
+    def test_html_to_markdown_normalizes_whitespace(self, content_processor: ContentProcessor):
         """Test that excessive blank lines are removed."""
         html = "<h1>Title</h1>\n\n\n\n<p>Text</p>"
         md = content_processor.html_to_markdown(html)
@@ -89,9 +85,7 @@ class TestPdfToText:
         assert "\n\n" in text  # Pages should be separated
 
     @patch("pdfplumber.open")
-    def test_pdf_to_text_extraction_failure(
-        self, mock_pdfplumber, content_processor: ContentProcessor
-    ):
+    def test_pdf_to_text_extraction_failure(self, mock_pdfplumber, content_processor: ContentProcessor):
         """Test that PDF extraction failures are handled gracefully."""
         mock_pdfplumber.side_effect = Exception("PDF parsing error")
 
@@ -101,9 +95,7 @@ class TestPdfToText:
         assert text == ""
 
     @patch("pdfplumber.open")
-    def test_pdf_to_text_no_text_on_page(
-        self, mock_pdfplumber, content_processor: ContentProcessor
-    ):
+    def test_pdf_to_text_no_text_on_page(self, mock_pdfplumber, content_processor: ContentProcessor):
         """Test PDF with pages that have no text."""
         mock_page = MagicMock()
         mock_page.extract_text.return_value = None
@@ -120,9 +112,7 @@ class TestPdfToText:
 class TestIndexSections:
     """Tests for section indexing."""
 
-    def test_index_sections_with_markdown_headings(
-        self, content_processor: ContentProcessor
-    ):
+    def test_index_sections_with_markdown_headings(self, content_processor: ContentProcessor):
         """Test indexing sections with standard Markdown headings."""
         markdown = """# Chapter 1
 Content of chapter 1
@@ -153,9 +143,7 @@ Art. 3. Third article content."""
         art_sections = [s for s in sections if s.title.startswith("Art.")]
         assert len(art_sections) >= 3
 
-    def test_index_sections_with_rozdzial_pattern(
-        self, content_processor: ContentProcessor
-    ):
+    def test_index_sections_with_rozdzial_pattern(self, content_processor: ContentProcessor):
         """Test indexing sections with Rozdział pattern."""
         markdown = """Rozdział 1 General provisions
 
@@ -170,9 +158,7 @@ More content here."""
         rozdzial_sections = [s for s in sections if "Rozdział" in s.title]
         assert len(rozdzial_sections) >= 2
 
-    def test_index_sections_with_sample_act(
-        self, content_processor: ContentProcessor, sample_act_html: str
-    ):
+    def test_index_sections_with_sample_act(self, content_processor: ContentProcessor, sample_act_html: str):
         """Test indexing sections with sample act HTML."""
         markdown = content_processor.html_to_markdown(sample_act_html)
         sections = content_processor.index_sections(markdown)

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -295,7 +295,7 @@ class TestLRUEviction:
 
         # Load 3 documents to fill the store
         for i in range(3):
-            await store.load(f"DU/2024/{i+1}", f"Content {i+1}", sections)
+            await store.load(f"DU/2024/{i + 1}", f"Content {i + 1}", sections)
 
         assert await store.is_loaded("DU/2024/1")
 
@@ -314,7 +314,7 @@ class TestLRUEviction:
 
         # Load 3 documents
         for i in range(3):
-            await store.load(f"DU/2024/{i+1}", f"Content {i+1}", sections)
+            await store.load(f"DU/2024/{i + 1}", f"Content {i + 1}", sections)
             time.sleep(0.1)
 
         # Access document 1 and 2, but not 3

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -253,7 +253,7 @@ class TestApiResponseModels:
             ActSummaryOutput(
                 eli="DU/2024/1",
                 publisher="DU",
-                year="invalid",  # Should be int
+                year="invalid",  # type: ignore[arg-type]  # Should be int
                 pos=1,
                 title="Test",
                 status="test",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,65 @@
+"""Tests for MCP server registration and lifespan."""
+
+from __future__ import annotations
+
+from fastmcp import Client
+
+from law_scrapper_mcp.server import app, lifespan
+
+EXPECTED_TOOLS = sorted(
+    [
+        "analyze_act_relationships",
+        "browse_acts",
+        "calculate_legal_date",
+        "compare_acts",
+        "filter_results",
+        "get_act_details",
+        "get_system_metadata",
+        "list_loaded_documents",
+        "list_result_sets",
+        "read_act_content",
+        "search_in_act",
+        "search_legal_acts",
+        "track_legal_changes",
+    ]
+)
+
+LIFESPAN_KEYS = {
+    "client",
+    "cache",
+    "document_store",
+    "content_processor",
+    "result_store",
+    "metadata_service",
+    "search_service",
+    "act_service",
+    "changes_service",
+}
+
+
+async def test_all_tools_registered() -> None:
+    """list_tools() returns exactly 13 tools."""
+    async with Client(app) as client:
+        tools = await client.list_tools()
+        tool_names = sorted(tool.name for tool in tools)
+
+    assert len(tool_names) == 13
+    assert tool_names == EXPECTED_TOOLS
+
+
+async def test_tool_names_match_expected() -> None:
+    """Tool names match the MCP contract."""
+    async with Client(app) as client:
+        tools = await client.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+    assert tool_names == set(EXPECTED_TOOLS)
+
+
+async def test_lifespan_yields_services() -> None:
+    """Lifespan initializes all required service keys."""
+    async with lifespan(app) as ctx:
+        assert set(ctx.keys()) == LIFESPAN_KEYS
+        assert ctx["metadata_service"] is not None
+        assert ctx["search_service"] is not None
+        assert ctx["act_service"] is not None

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -30,13 +30,9 @@ class TestActService:
         )
 
     @respx.mock
-    async def test_get_details_basic(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_basic(self, service: ActService, act_detail: dict):
         """Test getting basic act details."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
             return_value=Response(404)  # No structure available
         )
@@ -54,13 +50,9 @@ class TestActService:
         assert result.is_loaded is False
 
     @respx.mock
-    async def test_get_details_with_structure(
-        self, service: ActService, act_detail: dict, act_structure: list
-    ):
+    async def test_get_details_with_structure(self, service: ActService, act_detail: dict, act_structure: list):
         """Test getting details with structure/TOC."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
             return_value=Response(200, json=act_structure)
         )
@@ -72,16 +64,10 @@ class TestActService:
         assert result.toc[0]["title"] == "Przepisy ogólne"
 
     @respx.mock
-    async def test_get_details_with_keywords(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_with_keywords(self, service: ActService, act_detail: dict):
         """Test that keywords are properly extracted."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
         result = await service.get_details("DU/2024/1")
 
@@ -98,12 +84,8 @@ class TestActService:
         document_store: DocumentStore,
     ):
         """Test loading HTML content into document store."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.html").mock(
             return_value=Response(200, text=sample_act_html)
         )
@@ -130,12 +112,8 @@ class TestActService:
             [Section(id="art_1", title="Art. 1.", level=2, start_pos=0)],
         )
 
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
         result = await service.get_details("DU/2024/1", load_content=True)
 
@@ -143,9 +121,7 @@ class TestActService:
         # Should not make additional HTTP requests for content
 
     @respx.mock
-    async def test_get_details_load_content_pdf_fallback(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_load_content_pdf_fallback(self, service: ActService, act_detail: dict):
         """Test loading PDF content when HTML is not available."""
         # Modify act_detail to not have HTML
         act_detail_no_html = act_detail.copy()
@@ -154,9 +130,7 @@ class TestActService:
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
             return_value=Response(200, json=act_detail_no_html)
         )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf").mock(
             return_value=Response(200, content=b"%PDF-1.4 fake pdf")
         )
@@ -167,9 +141,7 @@ class TestActService:
         assert result.has_pdf is True
 
     @respx.mock
-    async def test_get_details_handles_missing_content(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_handles_missing_content(self, service: ActService, act_detail: dict):
         """Test handling of missing content gracefully."""
         act_detail_no_content = act_detail.copy()
         act_detail_no_content["textHTML"] = None
@@ -178,9 +150,7 @@ class TestActService:
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
             return_value=Response(200, json=act_detail_no_content)
         )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
         result = await service.get_details("DU/2024/1", load_content=True)
 
@@ -188,34 +158,20 @@ class TestActService:
         assert result.has_pdf is False
 
     @respx.mock
-    async def test_get_details_from_url_eli(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_from_url_eli(self, service: ActService, act_detail: dict):
         """Test getting details using full URL ELI."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
-        result = await service.get_details(
-            "https://api.sejm.gov.pl/eli/DU/2024/1", load_content=False
-        )
+        result = await service.get_details("https://api.sejm.gov.pl/eli/DU/2024/1", load_content=False)
 
         assert result.eli == "DU/2024/1"
 
     @respx.mock
-    async def test_get_details_all_date_fields(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_all_date_fields(self, service: ActService, act_detail: dict):
         """Test that all date fields are properly extracted."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
         result = await service.get_details("DU/2024/1")
 
@@ -227,29 +183,19 @@ class TestActService:
         assert result.change_date is None
 
     @respx.mock
-    async def test_get_details_with_volume(
-        self, service: ActService, act_detail: dict
-    ):
+    async def test_get_details_with_volume(self, service: ActService, act_detail: dict):
         """Test that volume is properly extracted."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
 
         result = await service.get_details("DU/2024/1")
 
         assert result.volume == 1
 
     @respx.mock
-    async def test_format_toc_recursive(
-        self, service: ActService, act_detail: dict, act_structure: list
-    ):
+    async def test_format_toc_recursive(self, service: ActService, act_detail: dict, act_structure: list):
         """Test that TOC formatting handles nested children."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(
-            return_value=Response(200, json=act_detail)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
         respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(
             return_value=Response(200, json=act_structure)
         )
@@ -264,9 +210,7 @@ class TestActService:
     @respx.mock
     async def test_get_details_api_error(self, service: ActService):
         """Test handling of API errors."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/999").mock(
-            return_value=Response(404)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/999").mock(return_value=Response(404))
 
         with pytest.raises(Exception):  # noqa: B017
             await service.get_details("DU/2024/999")

--- a/tests/unit/test_services/test_changes_service.py
+++ b/tests/unit/test_services/test_changes_service.py
@@ -19,13 +19,9 @@ class TestChangesService:
         return ChangesService(client=mock_client)
 
     @respx.mock
-    async def test_track_changes_basic(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_basic(self, service: ChangesService, search_results: dict):
         """Test basic changes tracking."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -37,13 +33,9 @@ class TestChangesService:
         assert date_range == "2024-01-01 to 2024-12-31"
 
     @respx.mock
-    async def test_track_changes_defaults_date_to_today(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_defaults_date_to_today(self, service: ChangesService, search_results: dict):
         """Test that date_to defaults to today when not provided."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -55,13 +47,9 @@ class TestChangesService:
         assert len(results) == 3
 
     @respx.mock
-    async def test_track_changes_with_keywords(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_with_keywords(self, service: ChangesService, search_results: dict):
         """Test changes tracking with keyword filter."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -73,13 +61,9 @@ class TestChangesService:
         assert len(results) > 0
 
     @respx.mock
-    async def test_track_changes_mp_publisher(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_mp_publisher(self, service: ChangesService, search_results: dict):
         """Test changes tracking for Monitor Polski."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="MP",
@@ -93,9 +77,7 @@ class TestChangesService:
     async def test_track_changes_empty_results(self, service: ChangesService):
         """Test changes tracking with no results."""
         empty_results = {"count": 0, "items": []}
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=empty_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=empty_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -107,13 +89,9 @@ class TestChangesService:
         assert "1900-01-01 to 1900-12-31" in date_range
 
     @respx.mock
-    async def test_track_changes_result_formatting(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_result_formatting(self, service: ChangesService, search_results: dict):
         """Test that results are properly formatted."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -134,13 +112,9 @@ class TestChangesService:
         assert results[0].in_force == "YES"
 
     @respx.mock
-    async def test_track_changes_multiple_keywords(
-        self, service: ChangesService, search_results: dict
-    ):
+    async def test_track_changes_multiple_keywords(self, service: ChangesService, search_results: dict):
         """Test changes tracking with multiple keywords."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",
@@ -154,9 +128,7 @@ class TestChangesService:
     @respx.mock
     async def test_track_changes_api_error(self, service: ChangesService):
         """Test handling of API errors."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(500)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(500))
 
         with pytest.raises(Exception):  # noqa: B017
             await service.track_changes(
@@ -165,9 +137,7 @@ class TestChangesService:
             )
 
     @respx.mock
-    async def test_track_changes_handles_missing_fields(
-        self, service: ChangesService
-    ):
+    async def test_track_changes_handles_missing_fields(self, service: ChangesService):
         """Test that missing fields in results are handled gracefully."""
         partial_results = {
             "count": 1,
@@ -183,9 +153,7 @@ class TestChangesService:
                 }
             ],
         }
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=partial_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=partial_results))
 
         results, date_range = await service.track_changes(
             publisher="DU",

--- a/tests/unit/test_services/test_metadata_service.py
+++ b/tests/unit/test_services/test_metadata_service.py
@@ -23,9 +23,7 @@ class TestMetadataService:
     async def test_get_metadata_keywords(self, service: MetadataService):
         """Test fetching keywords metadata."""
         mock_keywords = ["prawo", "ustawa", "kodeks"]
-        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
-            return_value=Response(200, json=mock_keywords)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(return_value=Response(200, json=mock_keywords))
 
         result = await service.get_metadata(MetadataCategory.KEYWORDS)
 
@@ -33,13 +31,9 @@ class TestMetadataService:
         assert result["keywords"] == mock_keywords
 
     @respx.mock
-    async def test_get_metadata_publishers(
-        self, service: MetadataService, publishers_data: list
-    ):
+    async def test_get_metadata_publishers(self, service: MetadataService, publishers_data: list):
         """Test fetching publishers metadata."""
-        respx.get("https://api.sejm.gov.pl/eli/acts").mock(
-            return_value=Response(200, json=publishers_data)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts").mock(return_value=Response(200, json=publishers_data))
 
         result = await service.get_metadata(MetadataCategory.PUBLISHERS)
 
@@ -51,9 +45,7 @@ class TestMetadataService:
     async def test_get_metadata_statuses(self, service: MetadataService):
         """Test fetching statuses metadata."""
         mock_statuses = ["akt obowiązujący", "uchylony", "nieobowiązujący"]
-        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(
-            return_value=Response(200, json=mock_statuses)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(return_value=Response(200, json=mock_statuses))
 
         result = await service.get_metadata(MetadataCategory.STATUSES)
 
@@ -64,9 +56,7 @@ class TestMetadataService:
     async def test_get_metadata_types(self, service: MetadataService):
         """Test fetching types metadata."""
         mock_types = ["Ustawa", "Rozporządzenie", "Obwieszczenie"]
-        respx.get("https://api.sejm.gov.pl/eli/types").mock(
-            return_value=Response(200, json=mock_types)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/types").mock(return_value=Response(200, json=mock_types))
 
         result = await service.get_metadata(MetadataCategory.TYPES)
 
@@ -77,9 +67,7 @@ class TestMetadataService:
     async def test_get_metadata_institutions(self, service: MetadataService):
         """Test fetching institutions metadata."""
         mock_institutions = ["Sejm RP", "Senat RP", "Prezydent RP"]
-        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(
-            return_value=Response(200, json=mock_institutions)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(return_value=Response(200, json=mock_institutions))
 
         result = await service.get_metadata(MetadataCategory.INSTITUTIONS)
 
@@ -89,21 +77,11 @@ class TestMetadataService:
     @respx.mock
     async def test_get_metadata_all(self, service: MetadataService):
         """Test fetching all metadata categories."""
-        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
-            return_value=Response(200, json=["prawo"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/acts").mock(
-            return_value=Response(200, json=[])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(
-            return_value=Response(200, json=["akt obowiązujący"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/types").mock(
-            return_value=Response(200, json=["Ustawa"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(
-            return_value=Response(200, json=["Sejm RP"])
-        )
+        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(return_value=Response(200, json=["prawo"]))
+        respx.get("https://api.sejm.gov.pl/eli/acts").mock(return_value=Response(200, json=[]))
+        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(return_value=Response(200, json=["akt obowiązujący"]))
+        respx.get("https://api.sejm.gov.pl/eli/types").mock(return_value=Response(200, json=["Ustawa"]))
+        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(return_value=Response(200, json=["Sejm RP"]))
 
         result = await service.get_metadata(MetadataCategory.ALL)
 
@@ -116,21 +94,13 @@ class TestMetadataService:
     @respx.mock
     async def test_get_metadata_all_handles_errors(self, service: MetadataService):
         """Test that ALL category handles errors gracefully."""
-        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
-            return_value=Response(200, json=["prawo"])
-        )
+        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(return_value=Response(200, json=["prawo"]))
         respx.get("https://api.sejm.gov.pl/eli/acts").mock(
             return_value=Response(500)  # Simulate error
         )
-        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(
-            return_value=Response(200, json=["akt obowiązujący"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/types").mock(
-            return_value=Response(200, json=["Ustawa"])
-        )
-        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(
-            return_value=Response(200, json=["Sejm RP"])
-        )
+        respx.get("https://api.sejm.gov.pl/eli/statuses").mock(return_value=Response(200, json=["akt obowiązujący"]))
+        respx.get("https://api.sejm.gov.pl/eli/types").mock(return_value=Response(200, json=["Ustawa"]))
+        respx.get("https://api.sejm.gov.pl/eli/institutions").mock(return_value=Response(200, json=["Sejm RP"]))
 
         result = await service.get_metadata(MetadataCategory.ALL)
 
@@ -142,9 +112,7 @@ class TestMetadataService:
     @respx.mock
     async def test_get_metadata_api_error(self, service: MetadataService):
         """Test handling of API errors."""
-        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(
-            return_value=Response(500)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/keywords").mock(return_value=Response(500))
 
         with pytest.raises(Exception):  # noqa: B017
             await service.get_metadata(MetadataCategory.KEYWORDS)

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -42,15 +42,30 @@ def store() -> ResultStore:
 def sample_results() -> list[ActSummaryOutput]:
     return [
         _make_act("DU/2024/1", "Ustawa o podatku dochodowym", act_type="Ustawa", promulgation_date="2024-01-10"),
-        _make_act("DU/2024/2", "Rozporządzenie Ministra Zdrowia", act_type="Rozporządzenie", promulgation_date="2024-03-15"),
+        _make_act(
+            "DU/2024/2", "Rozporządzenie Ministra Zdrowia", act_type="Rozporządzenie", promulgation_date="2024-03-15"
+        ),
         _make_act("DU/2024/3", "Ustawa o ochronie danych osobowych", act_type="Ustawa", promulgation_date="2024-06-01"),
-        _make_act("DU/2024/4", "Rozporządzenie w sprawie transportu", act_type="Rozporządzenie", promulgation_date="2024-07-20"),
-        _make_act("DU/2024/5", "Obwieszczenie Ministra Zdrowia", act_type="Obwieszczenie", promulgation_date="2024-09-01", status="akt jednorazowy"),
+        _make_act(
+            "DU/2024/4",
+            "Rozporządzenie w sprawie transportu",
+            act_type="Rozporządzenie",
+            promulgation_date="2024-07-20",
+        ),
+        _make_act(
+            "DU/2024/5",
+            "Obwieszczenie Ministra Zdrowia",
+            act_type="Obwieszczenie",
+            promulgation_date="2024-09-01",
+            status="akt jednorazowy",
+        ),
     ]
 
 
 class TestResultStore:
-    async def test_store_returns_incremental_ids(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+    async def test_store_returns_incremental_ids(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
         id1 = await store.store(sample_results[:2], "query1", 2)
         id2 = await store.store(sample_results[2:], "query2", 3)
         assert id1 == "rs_1"
@@ -112,7 +127,9 @@ class TestResultStoreFiltering:
         filtered, _ = await store.filter_results(rs_id, year_equals=2024)
         assert len(filtered) == 2
 
-    async def test_filter_by_regex_pattern_title(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+    async def test_filter_by_regex_pattern_title(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
         rs_id = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, pattern="zdrow|Zdrowia")
         assert len(filtered) == 2  # Minister Zdrowia appears in 2 titles
@@ -151,7 +168,7 @@ class TestResultStoreFiltering:
         rs_id = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, sort_by="promulgation_date", sort_desc=True)
         dates = [r.promulgation_date for r in filtered]
-        assert dates == sorted(dates, reverse=True)
+        assert dates == sorted(dates, key=lambda d: d or "", reverse=True)
 
     async def test_filter_limit(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
         rs_id = await store.store(sample_results, "test", 5)
@@ -162,12 +179,16 @@ class TestResultStoreFiltering:
         with pytest.raises(ResultSetNotFoundError, match="Zestaw wyników 'rs_999' nie istnieje lub wygasł"):
             await store.filter_results("rs_999")
 
-    async def test_filter_invalid_regex_raises(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+    async def test_filter_invalid_regex_raises(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
         rs_id = await store.store(sample_results, "test", 5)
         with pytest.raises(ValueError, match="Invalid regex"):
             await store.filter_results(rs_id, pattern="[invalid")
 
-    async def test_filter_invalid_field_defaults_to_title(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+    async def test_filter_invalid_field_defaults_to_title(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
         rs_id = await store.store(sample_results, "test", 5)
         # Invalid field should default to title
         filtered, _ = await store.filter_results(rs_id, pattern="podatk", field="nonexistent")
@@ -178,7 +199,9 @@ class TestResultStoreFiltering:
         filtered, _ = await store.filter_results(rs_id, pattern="xyznonexistent")
         assert len(filtered) == 0
 
-    async def test_filter_no_filters_returns_all(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+    async def test_filter_no_filters_returns_all(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
         rs_id = await store.store(sample_results, "test", 5)
         filtered, original = await store.filter_results(rs_id)
         assert len(filtered) == 5

--- a/tests/unit/test_services/test_search_service.py
+++ b/tests/unit/test_services/test_search_service.py
@@ -20,17 +20,11 @@ class TestSearchService:
         return SearchService(client=mock_client)
 
     @respx.mock
-    async def test_search_basic(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_basic(self, service: SearchService, search_results: dict):
         """Test basic search."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", year=2024
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", year=2024)
 
         assert len(results) == 3
         assert total_count == 3
@@ -38,29 +32,19 @@ class TestSearchService:
         assert "year=2024" in query_summary
 
     @respx.mock
-    async def test_search_with_keywords(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_with_keywords(self, service: SearchService, search_results: dict):
         """Test search with keywords."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", keywords=["test", "prawo"]
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", keywords=["test", "prawo"])
 
         assert len(results) > 0
         assert "keywords=test,prawo" in query_summary
 
     @respx.mock
-    async def test_search_with_date_range(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_with_date_range(self, service: SearchService, search_results: dict):
         """Test search with date range."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, total_count, query_summary = await service.search(
             publisher="DU",
@@ -73,47 +57,29 @@ class TestSearchService:
         assert "effective_to=2024-12-31" in query_summary
 
     @respx.mock
-    async def test_search_with_title(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_with_title(self, service: SearchService, search_results: dict):
         """Test search with title filter."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", title="Ustawa testowa"
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", title="Ustawa testowa")
 
         assert "title=Ustawa testowa" in query_summary
 
     @respx.mock
-    async def test_search_with_in_force_filter(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_with_in_force_filter(self, service: SearchService, search_results: dict):
         """Test search with in_force filter."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", in_force=True
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", in_force=True)
 
         assert "in_force=True" in query_summary
 
     @respx.mock
-    async def test_search_with_pagination(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_with_pagination(self, service: SearchService, search_results: dict):
         """Test search with limit and offset."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", limit=50, offset=10
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", limit=50, offset=10)
 
         assert len(results) > 0
 
@@ -121,29 +87,19 @@ class TestSearchService:
     async def test_search_empty_results(self, service: SearchService):
         """Test search with empty results."""
         empty_results = {"count": 0, "items": []}
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=empty_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=empty_results))
 
-        results, total_count, query_summary = await service.search(
-            publisher="DU", keywords=["nonexistent"]
-        )
+        results, total_count, query_summary = await service.search(publisher="DU", keywords=["nonexistent"])
 
         assert len(results) == 0
         assert total_count == 0
 
     @respx.mock
-    async def test_search_detail_level_minimal(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_detail_level_minimal(self, service: SearchService, search_results: dict):
         """Test search with minimal detail level."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, _, _ = await service.search(
-            publisher="DU", detail_level=DetailLevel.MINIMAL
-        )
+        results, _, _ = await service.search(publisher="DU", detail_level=DetailLevel.MINIMAL)
 
         # Minimal level should not include optional fields
         assert results[0].eli is not None
@@ -152,47 +108,31 @@ class TestSearchService:
         assert results[0].type is None
 
     @respx.mock
-    async def test_search_detail_level_standard(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_detail_level_standard(self, service: SearchService, search_results: dict):
         """Test search with standard detail level."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, _, _ = await service.search(
-            publisher="DU", detail_level=DetailLevel.STANDARD
-        )
+        results, _, _ = await service.search(publisher="DU", detail_level=DetailLevel.STANDARD)
 
         # Standard level should include type, dates, etc.
         assert results[0].type is not None
         assert results[0].promulgation_date is not None
 
     @respx.mock
-    async def test_search_detail_level_full(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_detail_level_full(self, service: SearchService, search_results: dict):
         """Test search with full detail level."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
-        results, _, _ = await service.search(
-            publisher="DU", detail_level=DetailLevel.FULL
-        )
+        results, _, _ = await service.search(publisher="DU", detail_level=DetailLevel.FULL)
 
         # Full level should include all available fields
         assert results[0].type is not None
         assert results[0].in_force is not None
 
     @respx.mock
-    async def test_browse_by_publisher_year(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_browse_by_publisher_year(self, service: SearchService, search_results: dict):
         """Test browsing acts by publisher and year."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024").mock(return_value=Response(200, json=search_results))
 
         results, total_count = await service.browse("DU", 2024)
 
@@ -200,17 +140,11 @@ class TestSearchService:
         assert total_count == 3
 
     @respx.mock
-    async def test_browse_with_detail_level(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_browse_with_detail_level(self, service: SearchService, search_results: dict):
         """Test browse with detail level."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/MP/2023").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/MP/2023").mock(return_value=Response(200, json=search_results))
 
-        results, total_count = await service.browse(
-            "MP", 2023, detail_level=DetailLevel.FULL
-        )
+        results, total_count = await service.browse("MP", 2023, detail_level=DetailLevel.FULL)
 
         assert len(results) > 0
         assert results[0].type is not None
@@ -219,9 +153,7 @@ class TestSearchService:
     async def test_browse_empty_results(self, service: SearchService):
         """Test browse with no results."""
         empty_results = {"totalCount": 0, "items": []}
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/1900").mock(
-            return_value=Response(200, json=empty_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/1900").mock(return_value=Response(200, json=empty_results))
 
         results, total_count = await service.browse("DU", 1900)
 
@@ -229,13 +161,9 @@ class TestSearchService:
         assert total_count == 0
 
     @respx.mock
-    async def test_search_formats_query_summary_correctly(
-        self, service: SearchService, search_results: dict
-    ):
+    async def test_search_formats_query_summary_correctly(self, service: SearchService, search_results: dict):
         """Test that query summary is properly formatted."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(
-            return_value=Response(200, json=search_results)
-        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
 
         results, total_count, query_summary = await service.search(
             publisher="DU",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,33 @@
 version = 1
 revision = 2
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[manifest]
+overrides = [
+    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "idna", specifier = ">=3.15" },
+    { name = "requests", specifier = ">=2.33.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+    { name = "werkzeug", specifier = ">=3.1.6" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload_time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload_time = "2026-05-16T08:18:32.051Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -35,14 +62,24 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.5"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553, upload_time = "2025-10-02T13:36:09.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload_time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608, upload_time = "2025-10-02T13:36:07.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload_time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload_time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload_time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -56,6 +93,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload_time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload_time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload_time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload_time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload_time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload_time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload_time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload_time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload_time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload_time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload_time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload_time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload_time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload_time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -245,73 +308,67 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.3"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload_time = "2025-10-15T23:18:31.74Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload_time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/42/9c391dd801d6cf0d561b5890549d4b27bafcc53b39c31a817e69d87c625b/cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a", size = 7225004, upload_time = "2025-10-15T23:16:52.239Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/67/38769ca6b65f07461eb200e85fc1639b438bdc667be02cf7f2cd6a64601c/cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc", size = 4296667, upload_time = "2025-10-15T23:16:54.369Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload_time = "2025-10-15T23:16:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload_time = "2025-10-15T23:16:58.442Z" },
-    { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload_time = "2025-10-15T23:17:00.378Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload_time = "2025-10-15T23:17:01.98Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload_time = "2025-10-15T23:17:04.078Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload_time = "2025-10-15T23:17:05.483Z" },
-    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload_time = "2025-10-15T23:17:07.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload_time = "2025-10-15T23:17:09.343Z" },
-    { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload_time = "2025-10-15T23:17:11.22Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload_time = "2025-10-15T23:17:12.829Z" },
-    { url = "https://files.pythonhosted.org/packages/96/92/8a6a9525893325fc057a01f654d7efc2c64b9de90413adcf605a85744ff4/cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018", size = 3055988, upload_time = "2025-10-15T23:17:14.65Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/bf/80fbf45253ea585a1e492a6a17efcb93467701fa79e71550a430c5e60df0/cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb", size = 3514451, upload_time = "2025-10-15T23:17:16.142Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/af/9b302da4c87b0beb9db4e756386a7c6c5b8003cd0e742277888d352ae91d/cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c", size = 2928007, upload_time = "2025-10-15T23:17:18.04Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e2/a510aa736755bffa9d2f75029c229111a1d02f8ecd5de03078f4c18d91a3/cryptography-46.0.3-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217", size = 7158012, upload_time = "2025-10-15T23:17:19.982Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dc/9aa866fbdbb95b02e7f9d086f1fccfeebf8953509b87e3f28fff927ff8a0/cryptography-46.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5", size = 4288728, upload_time = "2025-10-15T23:17:21.527Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/fd/bc1daf8230eaa075184cbbf5f8cd00ba9db4fd32d63fb83da4671b72ed8a/cryptography-46.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715", size = 4435078, upload_time = "2025-10-15T23:17:23.042Z" },
-    { url = "https://files.pythonhosted.org/packages/82/98/d3bd5407ce4c60017f8ff9e63ffee4200ab3e23fe05b765cab805a7db008/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54", size = 4293460, upload_time = "2025-10-15T23:17:24.885Z" },
-    { url = "https://files.pythonhosted.org/packages/26/e9/e23e7900983c2b8af7a08098db406cf989d7f09caea7897e347598d4cd5b/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459", size = 3995237, upload_time = "2025-10-15T23:17:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/af68c509d4a138cfe299d0d7ddb14afba15233223ebd933b4bbdbc7155d3/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422", size = 4967344, upload_time = "2025-10-15T23:17:28.06Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e3/8643d077c53868b681af077edf6b3cb58288b5423610f21c62aadcbe99f4/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7", size = 4466564, upload_time = "2025-10-15T23:17:29.665Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/43/c1e8726fa59c236ff477ff2b5dc071e54b21e5a1e51aa2cee1676f1c986f/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044", size = 4292415, upload_time = "2025-10-15T23:17:31.686Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f9/2f8fefdb1aee8a8e3256a0568cffc4e6d517b256a2fe97a029b3f1b9fe7e/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665", size = 4931457, upload_time = "2025-10-15T23:17:33.478Z" },
-    { url = "https://files.pythonhosted.org/packages/79/30/9b54127a9a778ccd6d27c3da7563e9f2d341826075ceab89ae3b41bf5be2/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3", size = 4466074, upload_time = "2025-10-15T23:17:35.158Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/68/b4f4a10928e26c941b1b6a179143af9f4d27d88fe84a6a3c53592d2e76bf/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20", size = 4420569, upload_time = "2025-10-15T23:17:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/49/3746dab4c0d1979888f125226357d3262a6dd40e114ac29e3d2abdf1ec55/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de", size = 4681941, upload_time = "2025-10-15T23:17:39.236Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/30/27654c1dbaf7e4a3531fa1fc77986d04aefa4d6d78259a62c9dc13d7ad36/cryptography-46.0.3-cp314-cp314t-win32.whl", hash = "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914", size = 3022339, upload_time = "2025-10-15T23:17:40.888Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/30/640f34ccd4d2a1bc88367b54b926b781b5a018d65f404d409aba76a84b1c/cryptography-46.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db", size = 3494315, upload_time = "2025-10-15T23:17:42.769Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8b/88cc7e3bd0a8e7b861f26981f7b820e1f46aa9d26cc482d0feba0ecb4919/cryptography-46.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21", size = 2919331, upload_time = "2025-10-15T23:17:44.468Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/45fe7f376a7df8daf6da3556603b36f53475a99ce4faacb6ba2cf3d82021/cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936", size = 7218248, upload_time = "2025-10-15T23:17:46.294Z" },
-    { url = "https://files.pythonhosted.org/packages/27/32/b68d27471372737054cbd34c84981f9edbc24fe67ca225d389799614e27f/cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683", size = 4294089, upload_time = "2025-10-15T23:17:48.269Z" },
-    { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload_time = "2025-10-15T23:17:49.837Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload_time = "2025-10-15T23:17:51.357Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload_time = "2025-10-15T23:17:52.964Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload_time = "2025-10-15T23:17:54.965Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload_time = "2025-10-15T23:17:56.754Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload_time = "2025-10-15T23:17:58.588Z" },
-    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload_time = "2025-10-15T23:18:00.897Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload_time = "2025-10-15T23:18:02.749Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload_time = "2025-10-15T23:18:04.85Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload_time = "2025-10-15T23:18:06.908Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload_time = "2025-10-15T23:18:08.672Z" },
-    { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload_time = "2025-10-15T23:18:10.632Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload_time = "2025-10-15T23:18:12.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload_time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload_time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload_time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload_time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload_time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload_time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload_time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload_time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload_time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload_time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload_time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload_time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload_time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload_time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload_time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload_time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload_time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload_time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload_time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload_time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload_time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload_time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload_time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload_time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload_time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload_time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload_time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload_time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload_time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload_time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload_time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload_time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload_time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload_time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload_time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload_time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload_time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload_time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload_time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
 name = "cyclopts"
-version = "3.24.0"
+version = "4.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ca/7782da3b03242d5f0a16c20371dff99d4bd1fedafe26bc48ff82e42be8c9/cyclopts-3.24.0.tar.gz", hash = "sha256:de6964a041dfb3c57bf043b41e68c43548227a17de1bad246e3a0bfc5c4b7417", size = 76131, upload_time = "2025-09-08T15:40:57.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/f4c775c651d91f9cd8149f70baec94c902a34e5f17a7a67881881bcfb244/cyclopts-4.20.0.tar.gz", hash = "sha256:1d819de2b12dc6b1c9f17ce0f4937d82922c0b83ac846eb4b3289c9c9f321c9f", size = 190236, upload_time = "2026-06-29T15:04:42.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/8b/2c95f0645c6f40211896375e6fa51f504b8ccb29c21f6ae661fe87ab044e/cyclopts-3.24.0-py3-none-any.whl", hash = "sha256:809d04cde9108617106091140c3964ee6fceb33cecdd537f7ffa360bde13ed71", size = 86154, upload_time = "2025-09-08T15:40:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/7243bc65d33c5ff5150569c42c8c1154aadae20b25638afe35f7f568489c/cyclopts-4.20.0-py3-none-any.whl", hash = "sha256:0b4337e9c11303d86b33d3f37c629dc01638f84591681e0e5611286bdd507646", size = 229383, upload_time = "2026-06-29T15:04:40.621Z" },
 ]
 
 [[package]]
@@ -365,24 +422,74 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.12.4"
+version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/92/cf0e921675af66534eb6dfffffa1871b5062f01650bcea63b62005a12f50/fastmcp-3.4.3.tar.gz", hash = "sha256:31e212ae9ff223876c6d7af2082e73f90bc692460e7a054568dfa88719f075ff", size = 28789252, upload_time = "2026-07-05T23:27:55.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/79/64000c2792743877baae152499a951c06a9c14b793309ac4ac06135f1ae7/fastmcp-3.4.3-py3-none-any.whl", hash = "sha256:bdf15277800586a033a6e1e95d20301cd508aaa872df3d508c956a2195de6c72", size = 8019, upload_time = "2026-07-05T23:27:53.241Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/fa/500f6362016c34fba01c6412bbfd53435dc75900abd1266d88e111e2e9c2/fastmcp_slim-3.4.3.tar.gz", hash = "sha256:e3e12ac1e87c5195fa59a1c3cd2d31b487a463c269089fb4020b7571cbb57b29", size = 588086, upload_time = "2026-07-05T23:27:33.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/4f/66765dfe4fe65b45e134e54ca46118d93189fb10cd8ecb635cf504b68552/fastmcp_slim-3.4.3-py3-none-any.whl", hash = "sha256:21ad50465494edb141eed76b177dc788e00e705a5df09b53a31efebeb4432a95", size = 761455, upload_time = "2026-07-05T23:27:32.547Z" },
+]
+
+[package.optional-dependencies]
+client = [
     { name = "authlib" },
-    { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "httpx" },
     { name = "mcp" },
-    { name = "openapi-core" },
-    { name = "openapi-pydantic" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "rich" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b2/57845353a9bc63002995a982e66f3d0be4ec761e7bcb89e7d0638518d42a/fastmcp-2.12.4.tar.gz", hash = "sha256:b55fe89537038f19d0f4476544f9ca5ac171033f61811cc8f12bdeadcbea5016", size = 7167745, upload_time = "2025-09-26T16:43:27.71Z" }
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "joserfc" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload_time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/c7/562ff39f25de27caec01e4c1e88cbb5fcae5160802ba3d90be33165df24f/fastmcp-2.12.4-py3-none-any.whl", hash = "sha256:56188fbbc1a9df58c537063f25958c57b5c4d715f73e395c41b51550b247d140", size = 329090, upload_time = "2025-09-26T16:43:25.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload_time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -433,11 +540,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload_time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload_time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload_time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload_time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -450,12 +557,66 @@ wheels = [
 ]
 
 [[package]]
-name = "isodate"
-version = "0.7.2"
+name = "jaraco-classes"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload_time = "2024-10-08T23:04:11.5Z" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload_time = "2024-03-31T07:27:36.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload_time = "2024-10-08T23:04:09.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload_time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload_time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload_time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload_time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload_time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload_time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload_time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload_time = "2026-07-08T12:41:42.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload_time = "2026-07-08T12:41:41.521Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload_time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload_time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -501,8 +662,25 @@ wheels = [
 ]
 
 [[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload_time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload_time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
 name = "law-scrapper-mcp"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -528,14 +706,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.12.4" },
+    { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "markdownify", specifier = ">=0.14" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
-    { name = "pdfplumber", specifier = ">=0.11" },
+    { name = "pdfplumber", specifier = ">=0.11.10" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
@@ -548,32 +726,6 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = []
-
-[[package]]
-name = "lazy-object-proxy"
-version = "1.12.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload_time = "2025-08-22T13:50:06.783Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload_time = "2025-08-22T13:42:44.982Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload_time = "2025-08-22T13:42:46.141Z" },
-    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload_time = "2025-08-22T13:42:47.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload_time = "2025-08-22T13:42:48.49Z" },
-    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload_time = "2025-08-22T13:42:49.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload_time = "2025-08-22T13:42:57.719Z" },
-    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload_time = "2025-08-22T13:42:50.62Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload_time = "2025-08-22T13:42:51.731Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload_time = "2025-08-22T13:42:53.225Z" },
-    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload_time = "2025-08-22T13:42:54.391Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload_time = "2025-08-22T13:42:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload_time = "2025-08-22T13:42:56.793Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload_time = "2025-08-22T13:49:49.366Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload_time = "2025-08-22T13:49:50.488Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload_time = "2025-08-22T13:49:54.224Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload_time = "2025-08-22T13:49:55.29Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload_time = "2025-08-22T13:49:56.35Z" },
-    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload_time = "2025-08-22T13:49:57.302Z" },
-]
 
 [[package]]
 name = "librt"
@@ -648,60 +800,8 @@ wheels = [
 ]
 
 [[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload_time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload_time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload_time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload_time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload_time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload_time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload_time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload_time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload_time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload_time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload_time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload_time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload_time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload_time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload_time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload_time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload_time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload_time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload_time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload_time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload_time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload_time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload_time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload_time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload_time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload_time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload_time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload_time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload_time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload_time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload_time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload_time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload_time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload_time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload_time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload_time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload_time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload_time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload_time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload_time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload_time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload_time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload_time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload_time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload_time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
 name = "mcp"
-version = "1.18.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -710,15 +810,18 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/e0/fe34ce16ea2bacce489ab859abd1b47ae28b438c3ef60b9c5eee6c02592f/mcp-1.18.0.tar.gz", hash = "sha256:aa278c44b1efc0a297f53b68df865b988e52dd08182d702019edcf33a8e109f6", size = 482926, upload_time = "2025-10-16T19:19:55.125Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload_time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/44/f5970e3e899803823826283a70b6003afd46f28e082544407e24575eccd3/mcp-1.18.0-py3-none-any.whl", hash = "sha256:42f10c270de18e7892fdf9da259029120b1ea23964ff688248c69db9d72b1d0a", size = 168762, upload_time = "2025-10-16T19:19:53.2Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload_time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -776,26 +879,6 @@ wheels = [
 ]
 
 [[package]]
-name = "openapi-core"
-version = "0.19.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "isodate" },
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "more-itertools" },
-    { name = "openapi-schema-validator" },
-    { name = "openapi-spec-validator" },
-    { name = "parse" },
-    { name = "typing-extensions" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/35/1acaa5f2fcc6e54eded34a2ec74b479439c4e469fc4e8d0e803fda0234db/openapi_core-0.19.5.tar.gz", hash = "sha256:421e753da56c391704454e66afe4803a290108590ac8fa6f4a4487f4ec11f2d3", size = 103264, upload_time = "2025-03-20T20:17:28.193Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/6f/83ead0e2e30a90445ee4fc0135f43741aebc30cca5b43f20968b603e30b6/openapi_core-0.19.5-py3-none-any.whl", hash = "sha256:ef7210e83a59394f46ce282639d8d26ad6fc8094aa904c9c16eb1bac8908911f", size = 106595, upload_time = "2025-03-20T20:17:26.77Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -808,32 +891,15 @@ wheels = [
 ]
 
 [[package]]
-name = "openapi-schema-validator"
-version = "0.6.3"
+name = "opentelemetry-api"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-specifications" },
-    { name = "rfc3339-validator" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload_time = "2025-01-10T18:08:22.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload_time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload_time = "2025-01-10T18:08:19.758Z" },
-]
-
-[[package]]
-name = "openapi-spec-validator"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "lazy-object-proxy" },
-    { name = "openapi-schema-validator" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload_time = "2025-06-07T14:48:56.299Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload_time = "2025-06-07T14:48:54.077Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload_time = "2026-06-24T15:19:35.434Z" },
 ]
 
 [[package]]
@@ -843,15 +909,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload_time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload_time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "parse"
-version = "1.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload_time = "2024-06-11T04:41:57.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload_time = "2024-06-11T04:41:55.057Z" },
 ]
 
 [[package]]
@@ -874,87 +931,100 @@ wheels = [
 
 [[package]]
 name = "pdfminer-six"
-version = "20251230"
+version = "20260107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload_time = "2025-12-30T15:49:13.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/a4/5cec1112009f0439a5ca6afa8ace321f0ab2f48da3255b7a1c8953014670/pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602", size = 8512094, upload_time = "2026-01-07T13:29:12.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", size = 6591909, upload_time = "2025-12-30T15:49:10.76Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8b/28c4eaec9d6b036a52cb44720408f26b1a143ca9bce76cc19e8f5de00ab4/pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9", size = 6592252, upload_time = "2026-01-07T13:29:10.742Z" },
 ]
 
 [[package]]
 name = "pdfplumber"
-version = "0.11.9"
+version = "0.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pdfminer-six" },
     { name = "pillow" },
     { name = "pypdfium2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload_time = "2026-01-05T08:10:29.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/56/6f450312ba05a27d7713b73857c1a25100dbda04fbc1331b13fb227a607d/pdfplumber-0.11.10.tar.gz", hash = "sha256:b95b2d28c66efb0a794a83b88c6c6aea5987532a445d20a1cbcfa657022e6e57", size = 102892, upload_time = "2026-06-15T03:31:31.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload_time = "2026-01-05T08:10:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9a/07d658e1e7fad860f1c541ab941348125dbdab773be3a0afaf32361866c7/pdfplumber-0.11.10-py3-none-any.whl", hash = "sha256:7741ea81bf165b474b153e6789d10d18e06b6ddcf3ec84289c3ef2fed6802580", size = 60047, upload_time = "2026-06-15T03:31:29.702Z" },
 ]
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload_time = "2026-02-11T04:23:07.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload_time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload_time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload_time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload_time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload_time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload_time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload_time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload_time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload_time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload_time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload_time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload_time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload_time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload_time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload_time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload_time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload_time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload_time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload_time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload_time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload_time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload_time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload_time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload_time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload_time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload_time = "2026-02-11T04:21:51.633Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload_time = "2026-02-11T04:21:53.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload_time = "2026-02-11T04:22:03.088Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload_time = "2026-02-11T04:22:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload_time = "2026-02-11T04:22:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload_time = "2026-02-11T04:22:09.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload_time = "2026-02-11T04:22:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload_time = "2026-02-11T04:22:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload_time = "2026-02-11T04:22:15.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload_time = "2026-02-11T04:22:17.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload_time = "2026-02-11T04:22:19.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload_time = "2026-02-11T04:22:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload_time = "2026-02-11T04:22:22.833Z" },
-    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload_time = "2026-02-11T04:22:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload_time = "2026-02-11T04:22:26.685Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload_time = "2026-02-11T04:22:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload_time = "2026-02-11T04:22:31.799Z" },
-    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload_time = "2026-02-11T04:22:33.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload_time = "2026-02-11T04:22:35.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload_time = "2026-02-11T04:22:37.698Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload_time = "2026-02-11T04:22:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload_time = "2026-02-11T04:22:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload_time = "2026-02-11T04:22:44.543Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload_time = "2026-02-11T04:22:46.347Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload_time = "2026-02-11T04:22:48.114Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload_time = "2026-02-11T04:22:50.342Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload_time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload_time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload_time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload_time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload_time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload_time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload_time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload_time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload_time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload_time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload_time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload_time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload_time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload_time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload_time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload_time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload_time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload_time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload_time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload_time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload_time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload_time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload_time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload_time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload_time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload_time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload_time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload_time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload_time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload_time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload_time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload_time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload_time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload_time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload_time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload_time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload_time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload_time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload_time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload_time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload_time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload_time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload_time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload_time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload_time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload_time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload_time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload_time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload_time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload_time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload_time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload_time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload_time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload_time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload_time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload_time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -964,6 +1034,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload_time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload_time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload_time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload_time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -1068,32 +1163,46 @@ wheels = [
 ]
 
 [[package]]
-name = "pypdfium2"
-version = "5.4.0"
+name = "pyjwt"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/23/b3979a1d4f536fabce02e3d9f332e8aeeed064d9df9391f2a77160f4ab36/pypdfium2-5.4.0.tar.gz", hash = "sha256:7219e55048fb3999fc8adcaea467088507207df4676ff9e521a3ae15a67d99c4", size = 269136, upload_time = "2026-02-08T16:54:08.383Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload_time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/c0/3d707bff5e973272b5412556d19e8c6889ce859a235465f0049cc8d35bc3/pypdfium2-5.4.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:8bc51a12a8c8eabbdbd7499d3e5ec47bcf56ba18e07b52bdd07d321cc1252c90", size = 2759769, upload_time = "2026-02-08T16:53:32.985Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6b/306cafcb0b18d5fab41687d9ed76eabea86a9ff78bc568bee1bfa34e526d/pypdfium2-5.4.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:a414ef5b685824cc6c7acbe19b7dbc735de2023cf473321a8ebfe8d7f5d8a41f", size = 2301913, upload_time = "2026-02-08T16:53:35.026Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/37/3d737c7eb84fb22939ab0a643aa0183dbc0745c309e962b4d61eeff8211b/pypdfium2-5.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0e83657db8da5971434ff5683bf3faa007ee1f3a56b61f245b8aa5b60442c23a", size = 2814181, upload_time = "2026-02-08T16:53:36.481Z" },
-    { url = "https://files.pythonhosted.org/packages/96/d7/0895737ec3d95ad607ade42e98fa8868b91e35b1170ec39b8c1b5fdb124c/pypdfium2-5.4.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e42b1d14db642e96bb3a57167f620b4247e9c843d22b9fb569b16a7c35a18f47", size = 2943476, upload_time = "2026-02-08T16:53:37.992Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/53/f8ab449997d3efa52737b8e6c494f1c3f09dc0642161fadc934f16a57cf0/pypdfium2-5.4.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0698c9a002f839127e74ec0185147e08b64e47a1e6caeaee95df434c05b26e8c", size = 2976675, upload_time = "2026-02-08T16:53:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/28/b8a4d4c1557019101bb722c88ba532ec9c14640117ab1c272c80774d83d7/pypdfium2-5.4.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22e9d4c73fc48b18b022977ea6fe78df43adf95440e1135020ed35fea9595017", size = 2762396, upload_time = "2026-02-08T16:53:41.958Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/4a/6c765f6e0b69d792e2d4c7ef2359301896c82df265d60f9a56e87618ec50/pypdfium2-5.4.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f0619f8a8ae3eb71b2cdc1fbd2a8f5d43f0fc6bee66d1b3aac2c9c23e44a3bf", size = 3068559, upload_time = "2026-02-08T16:53:43.974Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/17/4464e4ab6dd98ac3783c10eb799d8da49cb551a769c987eb9c6ba72a5ccf/pypdfium2-5.4.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50124415d815c41de8ce7e21cee5450f74f6f1240a140573bb71ccac804d5e5f", size = 3419384, upload_time = "2026-02-08T16:53:46.041Z" },
-    { url = "https://files.pythonhosted.org/packages/92/08/fa315a2ab353b41501b7088be72dc6cf8ad2bd4f1ebdfdb90c41b7f29155/pypdfium2-5.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce482d76e5447e745d761307401eaa366616ca44032b86cf7fbe6be918ade64e", size = 2998123, upload_time = "2026-02-08T16:53:47.705Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/a171d313d54a028d9437dea2c5d07fc9e1592f4daf5c39cbf514fca75242/pypdfium2-5.4.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16b9c6b07f3dbe7eda209bf7aaf131ca9614e1dae527e9764180dd58bcbaf411", size = 3673594, upload_time = "2026-02-08T16:53:49.139Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c0/60416f011f7e5a4ca29f40ae94907f34975239f3c6dd7fcb51f99e110f3b/pypdfium2-5.4.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3b08d48b7cca3b51aefaad7855bc0e9e251432a6eef1356d532ff438be84855e", size = 2965025, upload_time = "2026-02-08T16:53:50.553Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e2/8e36144b5e933c707b6aeab7dc6638eee8208697925b48b5b78ef68fb52a/pypdfium2-5.4.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0a1526e2a2bde7f2f13bec0f471d9fd475f7bbac2c0c860d48c35af8394d5931", size = 4130551, upload_time = "2026-02-08T16:53:52.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/64/8cda96259a8fdecd457f5d14a9d650315d7bdf496f96055d1d55900b3881/pypdfium2-5.4.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:40cea0bceb1e60a71b3855e2b04d175d2199b7da06212bb80f0c78067d065810", size = 3746587, upload_time = "2026-02-08T16:53:54.219Z" },
-    { url = "https://files.pythonhosted.org/packages/33/6b/7764491269f188a922bd6b254359d718899fc3092c90f0f68c2f6e451921/pypdfium2-5.4.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7a116f8fbeae7aa3a18ff2d1fa331ac647831cc16b589d4fbbbb66d64ecc8793", size = 4336703, upload_time = "2026-02-08T16:53:56.18Z" },
-    { url = "https://files.pythonhosted.org/packages/87/b0/2484bd3c20ead51ecea2082deaf94a3e91bad709fa14f049ca7fb598dc9a/pypdfium2-5.4.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:55c7fc894718db5fa2981d46dee45fe3a4fcd60d26f5095ad8f7779600fa8b6f", size = 4375051, upload_time = "2026-02-08T16:53:57.804Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ac/5f0536be885c3cadc09422de0324a193a21c165488a574029d9d2db92ecb/pypdfium2-5.4.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:dfc1c0c7e6e7ba258ebb338aaf664eb933bff1854cda76e4ee530886ea39b31a", size = 3928935, upload_time = "2026-02-08T16:53:59.265Z" },
-    { url = "https://files.pythonhosted.org/packages/13/b9/693b665df0939555491bece0777cafda1270e208734e925006de313abb5b/pypdfium2-5.4.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:4c0a48ede7180f804c029c509c2b6ea0c66813a3fde9eb9afc390183f947164d", size = 4997642, upload_time = "2026-02-08T16:54:00.809Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/ea/ba585acdfbefe309ee2fe5ebfeb097e36abe1d33c2a5108828c493c070bb/pypdfium2-5.4.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dea22d15c44a275702fd95ad664ba6eaa3c493d53d58b4d69272a04bdfb0df70", size = 4179914, upload_time = "2026-02-08T16:54:02.264Z" },
-    { url = "https://files.pythonhosted.org/packages/97/47/238383e89081a0ed1ca2bf4ef44f7e512fa0c72ffc51adc7df83bfcfd9b9/pypdfium2-5.4.0-py3-none-win32.whl", hash = "sha256:35c643827ed0f4dae9cedf3caf836f94cba5b31bd2c115b80a7c85f004636de9", size = 2995844, upload_time = "2026-02-08T16:54:03.692Z" },
-    { url = "https://files.pythonhosted.org/packages/08/37/f1338a0600c6c6e31759f8f80d7ab20aa0bc43b11594da67091300e051d4/pypdfium2-5.4.0-py3-none-win_amd64.whl", hash = "sha256:f9d9ce3c6901294d6984004d4a797dea110f8248b1bde33a823d25b45d3c2685", size = 3104198, upload_time = "2026-02-08T16:54:05.304Z" },
-    { url = "https://files.pythonhosted.org/packages/65/17/18ad82f070da18ab970928f730fbd44d9b05aafcb52a2ebb6470eaae53f9/pypdfium2-5.4.0-py3-none-win_arm64.whl", hash = "sha256:2b78ea216fb92e7709b61c46241ebf2cc0c60cf18ad2fb4633af665d7b4e21e6", size = 2938727, upload_time = "2026-02-08T16:54:06.814Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload_time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdfium2"
+version = "5.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b9/a887db9950379fe619f6921ade84730346e6adf008b197951ddcc42dfd1a/pypdfium2-5.11.0.tar.gz", hash = "sha256:0733749ac253c615953a5e75d4322b9f1de8c0d90137ec8dbcef403f3e57b5d9", size = 276614, upload_time = "2026-06-29T11:11:40.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/09/0aec4588adaa7eb4e42da127a57a5dd3a3997ff32be62af93f8afeb4668b/pypdfium2-5.11.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:115bc68ab2e85c9ee46f97a4c1794f1d7205c8b763fc5c16d9893eaa54608627", size = 3388299, upload_time = "2026-06-29T11:11:00.183Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/53/9e349a311cb0e7cef5dd0824a6f96c9b161da5e5e67a3db030d38e624fe9/pypdfium2-5.11.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:4396d0848b79134fcdf141a4e3dfe6719efe1162309a02876b440025cfd80720", size = 2843597, upload_time = "2026-06-29T11:11:02.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/13/13571dc7f1d11a4e4bde6ab8961318b04ff70bdc2aea5e7f88be5ef53167/pypdfium2-5.11.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:73fe55dd258f02332bc0a34128ddc2994fd610e664d1f2f7d78dd9e2570f15ee", size = 3586638, upload_time = "2026-06-29T11:11:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a2/9865e2822e97f6e4bed3b0e4838bd88444c62df6ebe0ccae352027133120/pypdfium2-5.11.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:badb4f4df98e25fb1b58301911c98fa18da60de98b0223a6ffa91717be068b96", size = 3649576, upload_time = "2026-06-29T11:11:06.011Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bb/dcd0ba152626c30a67bff43974b728c6bdd9a0d34af54cfa875489e46ce2/pypdfium2-5.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fbff7c3e3141f24f3a25cedddbb6c6d17baa95f83c7b7ea40d6866956df3a43", size = 3648292, upload_time = "2026-06-29T11:11:07.767Z" },
+    { url = "https://files.pythonhosted.org/packages/65/62/39b40afda909bd65b212e9dbf32e7c6a2da4205ff64576965a49ba689c47/pypdfium2-5.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:faeda49c171be254b5028b7d17e54306c585374210d3e7ea4962a36774d5b76a", size = 3380060, upload_time = "2026-06-29T11:11:09.571Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cf/999b793ca17d153765dc3656e7f4cc90c4bf411b9262f15b8e7e31af164f/pypdfium2-5.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b63f6f1e67d05d2bc36f55c35ede5cd18ded8886a2fcf68f320d188ee7934348", size = 3778180, upload_time = "2026-06-29T11:11:11.234Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6c/54fd2b487eed6a420ee7fff5c7754739379c4459fa185deab3cb2b72e4e2/pypdfium2-5.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:44f96d8459b4ba9d1330ab44a8dde836b361cb00027830eaab710080888cf44a", size = 4190704, upload_time = "2026-06-29T11:11:13.076Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/690b9a1b8de405ff7693c1d10472f0c5395294c6d53654ae1ef97ccf70fa/pypdfium2-5.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba8a78329c10f01c80b1f6e9aa33cac13665c198d056a007827b703958bd986d", size = 3705232, upload_time = "2026-06-29T11:11:14.864Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fc/18298367dc073041320bbb5d51fb3b42b0d9164fd13bd4d13dcb0d66bc64/pypdfium2-5.11.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e7a60197c5d18b0ec77a695e4a1082f89f323c13063cecf4446f1297ed632a36", size = 4031064, upload_time = "2026-06-29T11:11:17.201Z" },
+    { url = "https://files.pythonhosted.org/packages/45/1f/53d5b6ab0869963474b7ea13097c5abd8f2cf13548f0076e9bafc7e9d6b0/pypdfium2-5.11.0-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d167456433d565398a5c9f1efad23dfa6dfadc1a201ec687594fec645d843e", size = 3995092, upload_time = "2026-06-29T11:11:18.905Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7a/942a390e41fb59a797d9303eae6e6a8c3d1b84deade03206ac163076033f/pypdfium2-5.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:953f5bcb6a65067381f0a38c50ffaed864fac6f20b0fa2c14ffb15a52bda8943", size = 4995668, upload_time = "2026-06-29T11:11:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e9/fd1f8d3157c92665166f7d9bfcdd26901290b4271fcd2f90c7419ca0ee4c/pypdfium2-5.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:479b081423b2c16de44ddb6e25826d665298e1ee7cf09d802b656716dd930201", size = 4539453, upload_time = "2026-06-29T11:11:22.474Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/56/4280069868245d2346e6ec7b42e155c16a19be731f2f57fb726c35661aac/pypdfium2-5.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:81356f0503356d6f21629fcd47bbfffcfe26487f47a7989a56c02bd4e39b4c55", size = 5237429, upload_time = "2026-06-29T11:11:24.17Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/99d962bea28c3305835d07a1732a771104ce958f46e68a1892e740a7c904/pypdfium2-5.11.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:25be9d70f5776c68fa28b92ec42a7be91de5d6c4085ed5c6c89e1bfa373ae918", size = 5143685, upload_time = "2026-06-29T11:11:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4a/c935d1fdd73092fd036627282948c794c8f14a7ddde39cf732898b258866/pypdfium2-5.11.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:8edec20239f77d4dea2eeee5d29ebd83e77e1e2900691b77387fead76f81bc4a", size = 4647708, upload_time = "2026-06-29T11:11:28.006Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/f4f1895efa581f8b85748bf8d620ad37550583ca5226feeb9a33dcb3031e/pypdfium2-5.11.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:2560db37ce77a6caf651dc129bc44ee610a5fbb0050ec70f5a643f76bf241173", size = 5089405, upload_time = "2026-06-29T11:11:30.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/40/ca5b1071aee0a96937a30007504a0ca484340709e22a459e99650165fd57/pypdfium2-5.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34086bc1fcb964bb8104889d941ba9c8a35a75866250bb81d2f2bb2791bb42af", size = 5051368, upload_time = "2026-06-29T11:11:31.868Z" },
+    { url = "https://files.pythonhosted.org/packages/28/01/e445a77e784a5b0047a2c30b263630dfaa57318ff3196e6ad3093dca6929/pypdfium2-5.11.0-py3-none-win32.whl", hash = "sha256:324054f36acf6bea42a9d2534eb407da2e312dba746d955c9fd7e324bc160898", size = 3645281, upload_time = "2026-06-29T11:11:33.691Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b8af6eedbc5c8af49817d8f37c2e55be8a2c7f75fca9bee78efbfeb40f6/pypdfium2-5.11.0-py3-none-win_amd64.whl", hash = "sha256:d3b698e7b51bdf2d633cc834395677319e1d66757896b30c632dfac7d7236c81", size = 3778234, upload_time = "2026-06-29T11:11:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/657503553694c70fba0aa5d213144d80401611c82e0205f43f1ff39f40af/pypdfium2-5.11.0-py3-none-win_arm64.whl", hash = "sha256:897788d71b740752e29875856c369fdb52283f609aecf2355f0473db05dfc1b6", size = 3567726, upload_time = "2026-06-29T11:11:38.689Z" },
 ]
 
 [[package]]
@@ -1107,7 +1216,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1116,9 +1225,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload_time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload_time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload_time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload_time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1182,11 +1291,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload_time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload_time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload_time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload_time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -1200,6 +1309,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload_time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload_time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload_time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload_time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload_time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1253,7 +1371,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1261,9 +1379,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload_time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload_time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload_time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload_time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1276,18 +1394,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload_time = "2024-12-19T22:33:59.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload_time = "2024-12-19T22:33:57.837Z" },
-]
-
-[[package]]
-name = "rfc3339-validator"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload_time = "2021-05-12T16:37:54.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload_time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -1408,6 +1514,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload_time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload_time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1448,14 +1567,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload_time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload_time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload_time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload_time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -1489,12 +1608,21 @@ wheels = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "2.5.0"
+name = "uncalled-for"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload_time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload_time = "2026-05-06T13:38:25.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload_time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload_time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload_time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload_time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1511,13 +1639,109 @@ wheels = [
 ]
 
 [[package]]
-name = "werkzeug"
-version = "3.1.1"
+name = "watchfiles"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453, upload_time = "2024-11-01T16:40:45.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload_time = "2026-05-18T04:32:04.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371, upload_time = "2024-11-01T16:40:43.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload_time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload_time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload_time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload_time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload_time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload_time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload_time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload_time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload_time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload_time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload_time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload_time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload_time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload_time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload_time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload_time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload_time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload_time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload_time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload_time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload_time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload_time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload_time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload_time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload_time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload_time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload_time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload_time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload_time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload_time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload_time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload_time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload_time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload_time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload_time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload_time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload_time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload_time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload_time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload_time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload_time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload_time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload_time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload_time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload_time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload_time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload_time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload_time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload_time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload_time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload_time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload_time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload_time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload_time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload_time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload_time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload_time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload_time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload_time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload_time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload_time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload_time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload_time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload_time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload_time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload_time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload_time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload_time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload_time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload_time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload_time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload_time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload_time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload_time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload_time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload_time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload_time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload_time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload_time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload_time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload_time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload_time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload_time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload_time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload_time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload_time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload_time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload_time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload_time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload_time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
## Summary

- Upgrade to FastMCP 3.4.x and migrate tools to `lifespan_context` API
- Resolve Dependabot security issues via `uv` dependency bumps and overrides (including werkzeug >= 3.1.6, cryptography, urllib3, pillow, and related transitives)
- Refactor `server.py` (stdio transport fix, HTTP health endpoint)
- Add GitHub Actions CI (ruff, mypy, unit + integration tests) and Dependabot config
- Expand MCP integration coverage to 41 tests (FastMCP in-memory Client + HTTP transport test)
- Document MCP integration test architecture in README (prior commit on branch)

Supersedes and replaces Dependabot PRs #3 (werkzeug) and #4 (uv group bumps).

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run mypy .`
- [x] `uv run pytest tests/unit/ -q` (190 passed)
- [x] `uv run pytest tests/integration/ -m integration -q` (41 passed)