### PR TITLE
fix(security): eliminate ReDoS vulnerability in filter_results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ docker-compose.override.yml
 .ruff_cache/
 .mypy_cache/
 .pytest_cache/
+
+# Other
+docs/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`filter_results` breaking change: result set size cap** — Previously unlimited, calls on result sets larger than 100 records (`LAW_MCP_FILTER_MAX_RECORDS`) are now refused, even without a `pattern`; the response reports `error_category: precondition` so it's clear the request needs adjusting. Narrow the search or raise `LAW_MCP_FILTER_MAX_RECORDS` to work around it.
-- **`filter_results`: pattern compilation has bounded resource budgets** — Some simple-looking patterns, e.g. `\p{L}{0,112}`, are now rejected because their compiled size exceeds the limit. Patterns with more than four variable range quantifiers (such as `{1,900}`) are also rejected before compilation to avoid blocking the event loop.
+- **`filter_results`: pattern compilation has bounded resource budgets** — Some simple-looking patterns, e.g. `\p{L}{0,112}`, are now rejected because their compiled size exceeds the limit. Patterns with more than four variable range quantifiers (such as `{1,900}`) are also rejected before compilation to avoid blocking the event loop. The preflight recognizes only exact RE2 POSIX tokens (`[[:name:]]` / `[[:^name:]]`); incomplete `[.` / `[=` forms cannot hide ranges from the guard.
 - **`filter_results` parameter description names the supported pattern syntax** — The `pattern` parameter description now documents the supported regex subset, matching the validation error message.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`filter_results` breaking change: result set size cap** — Previously unlimited, calls on result sets larger than 100 records (`LAW_MCP_FILTER_MAX_RECORDS`) are now refused, even without a `pattern`; the response reports `error_category: precondition` so it's clear the request needs adjusting. Narrow the search or raise `LAW_MCP_FILTER_MAX_RECORDS` to work around it.
-- **`filter_results`: pattern compilation has a bounded compiled-size budget** — Some simple-looking patterns, e.g. `\p{L}{0,112}`, are now rejected because their compiled size exceeds the limit. Matching is linear-time and compiled program size is capped; compilation *time* is not separately bounded.
+- **`filter_results`: pattern compilation has bounded resource budgets** — Some simple-looking patterns, e.g. `\p{L}{0,112}`, are now rejected because their compiled size exceeds the limit. Patterns with more than four variable range quantifiers (such as `{1,900}`) are also rejected before compilation to avoid blocking the event loop.
 - **`filter_results` parameter description names the supported pattern syntax** — The `pattern` parameter description now documents the supported regex subset, matching the validation error message.
 
 ### Added
 
 - **New dependency: `google-re2`** — Ships as prebuilt binary wheels for CPython 3.13 on Windows and manylinux; no compiler needed to install.
 - **`LAW_MCP_MAX_PATTERN_LENGTH`** (default 512, range 64-4096) — Out-of-range values are clamped with a startup warning instead of blocking the server.
+- **`LAW_MCP_FILTER_MAX_RECORDS`** (default 100, floor 1) — Limits records processed by a single `filter_results` call; operators may raise it, but very high values lengthen the synchronous scan.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`filter_results`: fixed ReDoS vulnerability** — Client-supplied patterns now compile through a linear-time matching engine instead of Python's backtracking `re`; lookaround and backreferences are rejected with a validation error instead of executed. Previously, `pattern="(.+)+!"` could freeze the server indefinitely.
+
+### Fixed
+
+- **HTTP client resource leak on shutdown** — If the server exited through an exception or interruption while running, the HTTP client was never closed; shutdown now always releases it.
+
+### Changed
+
+- **`filter_results` breaking change: result set size cap** — Previously unlimited, calls on result sets larger than 100 records (`LAW_MCP_FILTER_MAX_RECORDS`) are now refused, even without a `pattern`; the response reports `error_category: precondition` so it's clear the request needs adjusting. Narrow the search or raise `LAW_MCP_FILTER_MAX_RECORDS` to work around it.
+- **`filter_results`: pattern compilation has a bounded compiled-size budget** — Some simple-looking patterns, e.g. `\p{L}{0,112}`, are now rejected because their compiled size exceeds the limit. Matching is linear-time and compiled program size is capped; compilation *time* is not separately bounded.
+- **`filter_results` parameter description names the supported pattern syntax** — The `pattern` parameter description now documents the supported regex subset, matching the validation error message.
+
+### Added
+
+- **New dependency: `google-re2`** — Ships as prebuilt binary wheels for CPython 3.13 on Windows and manylinux; no compiler needed to install.
+- **`LAW_MCP_MAX_PATTERN_LENGTH`** (default 512, range 64-4096) — Out-of-range values are clamped with a startup warning instead of blocking the server.
+
+### Removed
+
+- **Dead exception handler in document search** — Removed an unreachable `try/except` around escaped-query compilation.
+
 ## [2.4.0] - 2026-07-08
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` | `60.0` | Seconds before trying recovery |
 | `LAW_MCP_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS` | `3` | Test calls in half-open state |
 | `LAW_MCP_MAX_PATTERN_LENGTH` | `512` | Max `filter_results` pattern length, clamped to 64-4096 |
-| `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call, floor 1 |
+| `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call; floor 1, no ceiling (very high values lengthen the synchronous but linear scan) |
 | `LAW_MCP_LOG_LEVEL` | `INFO` | Log level: DEBUG, INFO, WARNING, ERROR |
 | `LAW_MCP_LOG_FORMAT` | `text` | Log format: `text` or `json` |
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_CIRCUIT_BREAKER_THRESHOLD` | `5` | Failures before circuit breaker opens |
 | `LAW_MCP_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` | `60.0` | Seconds before trying recovery |
 | `LAW_MCP_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS` | `3` | Test calls in half-open state |
+| `LAW_MCP_MAX_PATTERN_LENGTH` | `512` | Max `filter_results` pattern length, clamped to 64-4096 |
+| `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call, floor 1 |
 | `LAW_MCP_LOG_LEVEL` | `INFO` | Log level: DEBUG, INFO, WARNING, ERROR |
 | `LAW_MCP_LOG_FORMAT` | `text` | Log format: `text` or `json` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.2.0",
+    "google-re2>=1.1.20251105",
     "httpx>=0.28",
     "tenacity>=9.0",
     "pydantic>=2.10",

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
 
     @property
     def effective_max_pattern_length(self) -> int:
-        """Return max pattern length clamped to the allowed range (D3.1)."""
+        """Return max pattern length clamped to the allowed range"""
         return min(
             max(self.max_pattern_length, MAX_PATTERN_LENGTH_FLOOR),
             MAX_PATTERN_LENGTH_CEILING,
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
 
 
 def log_pattern_limit_clamping(current: Settings, log: logging.Logger) -> None:
-    """Log a warning when the max pattern length setting was clamped (D3.1)."""
+    """Log a warning when the max pattern length setting was clamped"""
     if not current.max_pattern_length_was_clamped:
         return
     log.warning(

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -10,6 +11,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # do najbliższej granicy, a nie odrzucana — start serwera nie może się nie udać.
 MAX_PATTERN_LENGTH_FLOOR = 64
 MAX_PATTERN_LENGTH_CEILING = 4096
+
+# Dolna granica liczby rekordów, jakie filter_results może zwrócić. Wartość 0 (lub ujemna)
+# oznacza, że KAŻDE wywołanie na niepustym zestawie wyników skończy się odmową —
+# narzędzie stałoby się trwale niesprawne. Górnej granicy celowo nie ma: to pozostaje
+# w gestii operatora, podobnie jak reszta pól tego pliku (bez Field()).
+FILTER_MAX_RECORDS_FLOOR = 1
 
 
 class Settings(BaseSettings):
@@ -40,6 +47,35 @@ class Settings(BaseSettings):
     doc_store_max_size_bytes: int = 5 * 1024 * 1024
     doc_store_ttl: int = 7200
 
+    # Filtrowanie wyników (filter_results)
+    # Parametry operacyjne (D3): strojalne przez operatora. Nie są zabezpieczeniem
+    # przed ReDoS — tę rolę pełni silnik RE2 w services/pattern_matching.py.
+    max_pattern_length: int = 512
+    filter_max_records: int = 100
+
+    @property
+    def effective_max_pattern_length(self) -> int:
+        """Limit długości wzorca po przycięciu do widełek (D3.1)."""
+        return min(
+            max(self.max_pattern_length, MAX_PATTERN_LENGTH_FLOOR),
+            MAX_PATTERN_LENGTH_CEILING,
+        )
+
+    @property
+    def max_pattern_length_was_clamped(self) -> bool:
+        """Czy skonfigurowana wartość musiała zostać przycięta do widełek."""
+        return self.effective_max_pattern_length != self.max_pattern_length
+
+    @property
+    def effective_filter_max_records(self) -> int:
+        """Limit rekordów po przycięciu do dolnej granicy.
+
+        Asymetrycznie wobec `max_pattern_length` — bez osobnego ostrzeżenia w logu:
+        wartość efektywna jest i tak obserwowalna w komunikacie ResultSetTooLargeError
+        przy pierwszym wywołaniu filter_results, więc cichy floor nie ukrywa problemu.
+        """
+        return max(self.filter_max_records, FILTER_MAX_RECORDS_FLOOR)
+
     # Circuit breaker
     circuit_breaker_threshold: int = 5
     circuit_breaker_recovery_timeout: float = 60.0
@@ -52,6 +88,19 @@ class Settings(BaseSettings):
     # Server info
     server_name: str = "law-scrapper-mcp"
     server_version: str = "2.4.0"
+
+
+def log_pattern_limit_clamping(current: Settings, log: logging.Logger) -> None:
+    """Zgłoś w logu fakt przycięcia limitu długości wzorca (D3.1, punkt 1)."""
+    if not current.max_pattern_length_was_clamped:
+        return
+    log.warning(
+        "LAW_MCP_MAX_PATTERN_LENGTH=%d jest poza dozwolonym zakresem %d-%d; serwer używa wartości efektywnej %d.",
+        current.max_pattern_length,
+        MAX_PATTERN_LENGTH_FLOOR,
+        MAX_PATTERN_LENGTH_CEILING,
+        current.effective_max_pattern_length,
+    )
 
 
 settings = Settings()

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -7,15 +7,8 @@ from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Widełki limitu długości wzorca (D3.1). Wartość spoza zakresu jest przycinana
-# do najbliższej granicy, a nie odrzucana — start serwera nie może się nie udać.
 MAX_PATTERN_LENGTH_FLOOR = 64
 MAX_PATTERN_LENGTH_CEILING = 4096
-
-# Dolna granica liczby rekordów, jakie filter_results może zwrócić. Wartość 0 (lub ujemna)
-# oznacza, że KAŻDE wywołanie na niepustym zestawie wyników skończy się odmową —
-# narzędzie stałoby się trwale niesprawne. Górnej granicy celowo nie ma: to pozostaje
-# w gestii operatora, podobnie jak reszta pól tego pliku (bez Field()).
 FILTER_MAX_RECORDS_FLOOR = 1
 
 
@@ -47,15 +40,13 @@ class Settings(BaseSettings):
     doc_store_max_size_bytes: int = 5 * 1024 * 1024
     doc_store_ttl: int = 7200
 
-    # Filtrowanie wyników (filter_results)
-    # Parametry operacyjne (D3): strojalne przez operatora. Nie są zabezpieczeniem
-    # przed ReDoS — tę rolę pełni silnik RE2 w services/pattern_matching.py.
+    # Filtering
     max_pattern_length: int = 512
     filter_max_records: int = 100
 
     @property
     def effective_max_pattern_length(self) -> int:
-        """Limit długości wzorca po przycięciu do widełek (D3.1)."""
+        """Return max pattern length clamped to the allowed range (D3.1)."""
         return min(
             max(self.max_pattern_length, MAX_PATTERN_LENGTH_FLOOR),
             MAX_PATTERN_LENGTH_CEILING,
@@ -63,16 +54,16 @@ class Settings(BaseSettings):
 
     @property
     def max_pattern_length_was_clamped(self) -> bool:
-        """Czy skonfigurowana wartość musiała zostać przycięta do widełek."""
+        """Return whether the configured max pattern length was clamped."""
         return self.effective_max_pattern_length != self.max_pattern_length
 
     @property
     def effective_filter_max_records(self) -> int:
-        """Limit rekordów po przycięciu do dolnej granicy.
+        """Return filter max records raised to the minimum allowed value.
 
-        Asymetrycznie wobec `max_pattern_length` — bez osobnego ostrzeżenia w logu:
-        wartość efektywna jest i tak obserwowalna w komunikacie ResultSetTooLargeError
-        przy pierwszym wywołaniu filter_results, więc cichy floor nie ukrywa problemu.
+        Asymmetric vs `max_pattern_length` — no separate log warning: the
+        effective value is already visible in the ResultSetTooLargeError message
+        on the first filter_results call, so a silent floor does not hide the issue.
         """
         return max(self.filter_max_records, FILTER_MAX_RECORDS_FLOOR)
 
@@ -91,7 +82,7 @@ class Settings(BaseSettings):
 
 
 def log_pattern_limit_clamping(current: Settings, log: logging.Logger) -> None:
-    """Zgłoś w logu fakt przycięcia limitu długości wzorca (D3.1, punkt 1)."""
+    """Log a warning when the max pattern length setting was clamped (D3.1)."""
     if not current.max_pattern_length_was_clamped:
         return
     log.warning(

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -6,6 +6,11 @@ from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Widełki limitu długości wzorca (D3.1). Wartość spoza zakresu jest przycinana
+# do najbliższej granicy, a nie odrzucana — start serwera nie może się nie udać.
+MAX_PATTERN_LENGTH_FLOOR = 64
+MAX_PATTERN_LENGTH_CEILING = 4096
+
 
 class Settings(BaseSettings):
     """Application settings with environment variable support."""

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -11,7 +11,7 @@ from starlette.responses import JSONResponse
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
-from law_scrapper_mcp.config import settings
+from law_scrapper_mcp.config import log_pattern_limit_clamping, settings
 from law_scrapper_mcp.logging_config import setup_logging
 from law_scrapper_mcp.services.act_service import ActService
 from law_scrapper_mcp.services.changes_service import ChangesService
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 async def lifespan(server):
     """Initialize and cleanup server resources."""
     logger.info("Starting Law Scrapper MCP Server v%s", settings.server_version)
+    log_pattern_limit_clamping(settings, logger)
 
     circuit_breaker = CircuitBreaker(
         failure_threshold=settings.circuit_breaker_threshold,
@@ -51,27 +52,32 @@ async def lifespan(server):
     )
     content_processor = ContentProcessor()
 
-    result_store = ResultStore()
+    result_store = ResultStore(
+        max_pattern_length=settings.effective_max_pattern_length,
+        pattern_length_limit_clamped=settings.max_pattern_length_was_clamped,
+        max_records=settings.effective_filter_max_records,
+    )
     metadata_service = MetadataService(client)
     search_service = SearchService(client)
     act_service = ActService(client, document_store, content_processor)
     changes_service = ChangesService(client)
 
-    yield {
-        "client": client,
-        "cache": cache,
-        "document_store": document_store,
-        "content_processor": content_processor,
-        "result_store": result_store,
-        "metadata_service": metadata_service,
-        "search_service": search_service,
-        "act_service": act_service,
-        "changes_service": changes_service,
-    }
-
-    await client.close()
-    await cache.clear()
-    logger.info("Law Scrapper MCP Server stopped")
+    try:
+        yield {
+            "client": client,
+            "cache": cache,
+            "document_store": document_store,
+            "content_processor": content_processor,
+            "result_store": result_store,
+            "metadata_service": metadata_service,
+            "search_service": search_service,
+            "act_service": act_service,
+            "changes_service": changes_service,
+        }
+    finally:
+        await client.close()
+        await cache.clear()
+        logger.info("Law Scrapper MCP Server stopped")
 
 
 app = FastMCP(

--- a/src/law_scrapper_mcp/services/document_store.py
+++ b/src/law_scrapper_mcp/services/document_store.py
@@ -95,7 +95,13 @@ class DocumentStore:
             return None
 
     async def search(self, eli: str, query: str, context_chars: int = 500) -> list[SearchHit]:
-        """Search within a loaded document."""
+        """Search literal text within a loaded document.
+
+        The query is escaped before compilation, so Python's backtracking
+        engine never receives client-supplied regex syntax. Replacing
+        ``re.escape(query)`` with ``query`` would reintroduce the ReDoS risk
+        addressed by the pattern filtering path.
+        """
         async with self._lock:
             doc = self._get_doc(eli)
             doc.last_accessed = time.time()

--- a/src/law_scrapper_mcp/services/document_store.py
+++ b/src/law_scrapper_mcp/services/document_store.py
@@ -101,10 +101,16 @@ class DocumentStore:
             doc.last_accessed = time.time()
 
             hits = []
-            try:
-                pattern = re.compile(re.escape(query), re.IGNORECASE)
-            except re.error:
-                pattern = re.compile(re.escape(query), re.IGNORECASE)
+            # re.escape jest tu obowiązkowe: `query` pochodzi od klienta i musi być
+            # traktowane dosłownie. Usunięcie escapowania oznaczałoby przyjmowanie
+            # surowego wzorca od wywołującego, czyli odtworzenie w tym miejscu
+            # podatności ReDoS zamkniętej w klastrze 1 (ustalenie F01, patrz
+            # docs/mcp-audit-2026-08-06.md).
+            # Wzorce od klienta wolno kompilować wyłącznie przez
+            # services/pattern_matching.compile_pattern (silnik RE2).
+            # Escapowany wzorzec nigdy nie rzuca re.error, dlatego nie ma tu
+            # obsługi wyjątku (ustalenie F51).
+            pattern = re.compile(re.escape(query), re.IGNORECASE)
 
             for match in pattern.finditer(doc.markdown):
                 start = max(0, match.start() - context_chars)

--- a/src/law_scrapper_mcp/services/document_store.py
+++ b/src/law_scrapper_mcp/services/document_store.py
@@ -101,15 +101,6 @@ class DocumentStore:
             doc.last_accessed = time.time()
 
             hits = []
-            # re.escape jest tu obowiązkowe: `query` pochodzi od klienta i musi być
-            # traktowane dosłownie. Usunięcie escapowania oznaczałoby przyjmowanie
-            # surowego wzorca od wywołującego, czyli odtworzenie w tym miejscu
-            # podatności ReDoS zamkniętej w klastrze 1 (ustalenie F01, patrz
-            # docs/mcp-audit-2026-08-06.md).
-            # Wzorce od klienta wolno kompilować wyłącznie przez
-            # services/pattern_matching.compile_pattern (silnik RE2).
-            # Escapowany wzorzec nigdy nie rzuca re.error, dlatego nie ma tu
-            # obsługi wyjątku (ustalenie F51).
             pattern = re.compile(re.escape(query), re.IGNORECASE)
 
             for match in pattern.finditer(doc.markdown):

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -1,0 +1,161 @@
+"""Kompilacja wzorców regex dostarczonych przez klienta.
+
+Jedyne miejsce w projekcie, które kompiluje wzorzec pochodzący od wywołującego
+narzędzie MCP. Silnikiem jest RE2 (`google-re2`), który gwarantuje złożoność
+liniową względem długości wejścia — katastroficzny nawrót jest tu niemożliwy
+strukturalnie, a nie mitygowany limitami czy timeoutem.
+
+Kontekst: ustalenie F01 audytu `docs/mcp-audit-2026-08-06.md`, decyzje D1-D3 i D5
+specyfikacji `docs/superpowers/specs/2026-08-07-klaster-1.md`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import re2
+
+from law_scrapper_mcp.config import (
+    MAX_PATTERN_LENGTH_CEILING,
+    MAX_PATTERN_LENGTH_FLOOR,
+)
+
+# Parametr klasy "bezpieczeństwo" (D3): stała w kodzie, celowo NIE konfigurowalna
+# przez zmienną środowiskową. Domyślna wartość biblioteki RE2 to również 8 MiB
+# (`re2.Options().max_mem == 8388608`), więc ta stała musi być NIŻSZA od
+# domyślnej, żeby cokolwiek realnie ograniczać. Powód: skompilowane wzorce
+# trafiają do globalnego `functools.lru_cache(maxsize=128)` wewnątrz pakietu
+# `google-re2` — przy limicie 8 MiB sufit tego cache'u to ~1 GiB pamięci
+# utrzymywanej przez legalne, niezłośliwe wzorce klienta. Przy 2 MiB sufit
+# spada do ~256 MiB.
+#
+# 2 MiB (a nie 1 MiB) dobrane empirycznie: `\p{L}` to ogromna klasa Unicode,
+# więc powtórzenia tej klasy są dla RE2 najdroższe pamięciowo ze wszystkich
+# konstrukcji w obsługiwanym podzbiorze składni. Przy 1 MiB granica
+# `\p{L}{0,n}` leżała przy n≈55 — odrzucała niewinne wzorce w stylu
+# `\p{L}{0,200}(?:zdrow|apteka)\p{L}{0,200}`. Przy 2 MiB granica dla
+# `\p{L}{0,n}` to n≈111 (zmierzone: n=111 kompiluje się, n=112 już nie).
+# Wzorce klasy `.`, `\w`, `[a-ząćęłńóśźż]` uderzają najpierw we własny limit
+# powtórzeń RE2 (1000), więc dla nich obie wartości max_mem są równoważne.
+RE2_MAX_MEM_BYTES = 2 * 1024 * 1024
+
+# Skompilowany wzorzec RE2 (`re2._Regexp`). Pakiet `google-re2` nie dostarcza
+# stubów typów, więc alias jest jawnym `Any` zamiast fikcyjnej nazwy typu.
+CompiledPattern = Any
+
+SUPPORTED_SYNTAX_HINT = (
+    "Obsługiwany podzbiór składni: alternatywa (a|b), klasy znaków "
+    r"([a-z], \d, \p{L}, [[:alpha:]]), kwantyfikatory (*, +, ?, {n,m}), "
+    r"kotwice (^, $), grupy nieprzechwytujące. Lookaround ((?=...), (?<=...), "
+    r"(?!...)) oraz backreferencje (\1) nie są obsługiwane."
+)
+
+
+class PatternValidationError(ValueError):
+    """Wzorzec odrzucony przed uruchomieniem dopasowania.
+
+    Dziedziczy po ValueError, ponieważ warstwa narzędzi traktuje ValueError jako
+    błąd wejścia użytkownika, a nie awarię serwera.
+    """
+
+
+def _build_options() -> Any:
+    """Zbuduj opcje RE2 wspólne dla wszystkich wzorców od klienta."""
+    options = re2.Options()
+    # RE2 nie eksponuje stałej odpowiadającej re.IGNORECASE (D1).
+    options.case_sensitive = False
+    # Warstwa absl zapisuje błędy parsowania bezpośrednio na stderr, omijając
+    # logging_config.py i zanieczyszczając logi JSON (D5).
+    options.log_errors = False
+    options.max_mem = RE2_MAX_MEM_BYTES
+    return options
+
+
+def _is_pattern_too_large(e: re2.error) -> bool:
+    """Rozpoznaj przekroczenie budżetu pamięci kompilacji (`RE2_MAX_MEM_BYTES`).
+
+    RE2 sygnalizuje to tym samym typem wyjątku co błąd składni (`re2.error`),
+    więc trzeba rozróżnić po treści komunikatu, żeby nie sugerować klientowi
+    poprawy składni, gdy problemem jest wyłącznie złożoność wzorca (U4).
+    """
+    if not e.args:
+        return False
+    detail = e.args[0]
+    return isinstance(detail, bytes) and b"pattern too large" in detail
+
+
+def _re2_error_detail(e: re2.error) -> str:
+    """Wydobądź czytelny opis błędu składni z wyjątku `re2.error`.
+
+    Warstwa C++ RE2 zwraca komunikat jako `bytes` (`e.args[0]`), bo wzorzec
+    jest kodowany do UTF-8 zanim trafi poza Pythona — interpolowanie tego
+    surowo dawałoby polskim znakom repr w stylu `b'...\\xc5\\xbc...'` w
+    komunikacie błędu, co myli model językowy będący klientem tego narzędzia
+    (U3). Dekodujemy z `errors="replace"`, żeby formatowanie komunikatu błędu
+    nigdy samo nie rzuciło wyjątku.
+    """
+    if not e.args:
+        return str(e)
+    detail = e.args[0]
+    if isinstance(detail, bytes):
+        return detail.decode("utf-8", "replace")
+    return str(detail)
+
+
+def _too_complex_message() -> str:
+    return (
+        "Wzorzec jest zbyt złożony: przekracza budżet pamięci kompilacji silnika "
+        "wyszukiwania. Uprość wzorzec — zmniejsz liczbę alternatyw albo zawęź "
+        "kwantyfikatory takie jak {n,m}."
+    )
+
+
+def _too_long_message(actual_length: int, max_length: int, limit_was_clamped: bool) -> str:
+    base = f"Wzorzec jest za długi: {actual_length} znaków, limit wynosi {max_length}."
+    if limit_was_clamped:
+        return (
+            f"{base} Limit efektywny {max_length} wynika z przycięcia konfiguracji "
+            f"LAW_MCP_MAX_PATTERN_LENGTH do dozwolonego zakresu "
+            f"{MAX_PATTERN_LENGTH_FLOOR}-{MAX_PATTERN_LENGTH_CEILING}."
+        )
+    return f"{base} Skróć wzorzec lub zawęź listę alternatyw."
+
+
+def compile_pattern(
+    pattern: str,
+    *,
+    max_length: int,
+    limit_was_clamped: bool = False,
+) -> CompiledPattern:
+    """Zwaliduj i skompiluj wzorzec pochodzący od klienta.
+
+    Args:
+        pattern: Surowy wzorzec przekazany przez wywołującego narzędzie.
+        max_length: Efektywny limit długości wzorca (po przycięciu do widełek).
+        limit_was_clamped: Czy `max_length` powstał z przycięcia konfiguracji.
+            Wpływa wyłącznie na treść komunikatu błędu (D3.1).
+
+    Raises:
+        PatternValidationError: Wzorzec przekracza limit długości, używa składni
+            spoza podzbioru obsługiwanego przez RE2, przekracza budżet pamięci
+            kompilacji (`RE2_MAX_MEM_BYTES`), albo zawiera znaki, których nie
+            da się zakodować w UTF-8 — np. samotny surogat UTF-16 (U1).
+    """
+    if len(pattern) > max_length:
+        raise PatternValidationError(_too_long_message(len(pattern), max_length, limit_was_clamped))
+
+    try:
+        return re2.compile(pattern, _build_options())
+    except (re2.error, UnicodeError) as e:
+        # `str.encode("utf-8")` wewnątrz `re2/__init__.py` rzuca UnicodeError
+        # (np. dla samotnych surogatów) zanim cokolwiek dotknie warstwy C++,
+        # więc ten wyjątek nigdy nie jest instancją `re2.error` (U1).
+        if isinstance(e, re2.error):
+            if _is_pattern_too_large(e):
+                raise PatternValidationError(_too_complex_message()) from e
+            detail = _re2_error_detail(e)
+        else:
+            detail = str(e)
+        raise PatternValidationError(
+            f"Wzorzec nie jest obsługiwany przez silnik wyszukiwania: {detail}. {SUPPORTED_SYNTAX_HINT}"
+        ) from e

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -68,13 +68,47 @@ def _is_pattern_too_large(e: re2.error) -> bool:
     return isinstance(detail, bytes) and b"pattern too large" in detail
 
 
-def _has_too_many_variable_range_quantifiers(pattern: str) -> bool:
-    r"""Count unescaped `{min,max}` quantifiers outside character classes.
+def _quoted_literal_message() -> str:
+    return (
+        r"Cytowane literały \Q...\E nie są obsługiwane. Użyj sekwencji "
+        r"ucieczki dla każdego znaku specjalnego."
+    )
+
+
+def _variable_range_quantifier_end(pattern: str, opening_brace_index: int) -> tuple[int, bool] | None:
+    """Return the end and variability of a valid `{min,max}` quantifier.
+
+    The caller advances directly to the returned end, so each character is
+    inspected at most once. Other brace forms are left to RE2 syntax
+    validation without searching ahead for a closing brace.
+    """
+    cursor = opening_brace_index + 1
+    minimum_start = cursor
+    while cursor < len(pattern) and "0" <= pattern[cursor] <= "9":
+        cursor += 1
+    if cursor == minimum_start or cursor == len(pattern) or pattern[cursor] != ",":
+        return None
+
+    minimum = pattern[minimum_start:cursor]
+    cursor += 1
+    maximum_start = cursor
+    while cursor < len(pattern) and "0" <= pattern[cursor] <= "9":
+        cursor += 1
+    if cursor == maximum_start or cursor == len(pattern) or pattern[cursor] != "}":
+        return None
+
+    return cursor + 1, int(minimum) != int(pattern[maximum_start:cursor])
+
+
+def _validate_variable_range_quantifier_limit(pattern: str) -> None:
+    r"""Validate range quantifiers with a forward-only lexical scan.
 
     This deliberately performs only lexical recognition; RE2 remains the
-    authority for regex syntax validation. Skipping escapes and character
-    classes prevents literals such as `\{1,900}` and `[{1,900}]` from being
-    counted as quantifiers.
+    authority for regex syntax validation. The scanner models escaped
+    characters, POSIX character-class tokens, and bracket-expression state so
+    literals such as `\{1,900}` and `[[:alpha:]{1,900}]` are not counted as
+    quantifiers. Quoted literals (`\Q...\E`) are excluded from the documented
+    subset and rejected before they can hide range quantifiers.
     """
     quantifier_count = 0
     in_character_class = False
@@ -83,31 +117,39 @@ def _has_too_many_variable_range_quantifiers(pattern: str) -> bool:
     while index < len(pattern):
         character = pattern[index]
         if character == "\\":
+            if index + 1 < len(pattern) and pattern[index + 1] in {"Q", "E"}:
+                raise PatternValidationError(_quoted_literal_message())
             index += 2
             continue
-        if character == "[" and not in_character_class:
+
+        if in_character_class:
+            if character == "[" and index + 1 < len(pattern) and pattern[index + 1] in {":", ".", "="}:
+                closing_delimiter = pattern[index + 1]
+                index += 2
+                while index + 1 < len(pattern):
+                    if pattern[index] == closing_delimiter and pattern[index + 1] == "]":
+                        index += 2
+                        break
+                    index += 1
+                continue
+            if character == "]":
+                in_character_class = False
+            index += 1
+            continue
+
+        if character == "[":
             in_character_class = True
-        elif character == "]" and in_character_class:
-            in_character_class = False
-        elif character == "{" and not in_character_class:
-            closing_brace = pattern.find("}", index + 1)
-            if closing_brace != -1:
-                minimum, separator, maximum = pattern[index + 1 : closing_brace].partition(",")
-                if (
-                    separator
-                    and minimum.isascii()
-                    and maximum.isascii()
-                    and minimum.isdecimal()
-                    and maximum.isdecimal()
-                    and minimum != maximum
-                ):
+        elif character == "{":
+            quantifier = _variable_range_quantifier_end(pattern, index)
+            if quantifier is not None:
+                end_index, is_variable = quantifier
+                if is_variable:
                     quantifier_count += 1
                     if quantifier_count > MAX_VARIABLE_RANGE_QUANTIFIERS:
-                        return True
-                index = closing_brace
+                        raise PatternValidationError(_too_complex_message())
+                index = end_index
+                continue
         index += 1
-
-    return False
 
 
 def _re2_error_detail(e: re2.error) -> str:
@@ -169,8 +211,7 @@ def compile_pattern(
     """
     if len(pattern) > max_length:
         raise PatternValidationError(_too_long_message(len(pattern), max_length, limit_was_clamped))
-    if _has_too_many_variable_range_quantifiers(pattern):
-        raise PatternValidationError(_too_complex_message())
+    _validate_variable_range_quantifier_limit(pattern)
 
     try:
         return re2.compile(pattern, _build_options())

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -26,6 +26,29 @@ from law_scrapper_mcp.config import (
 RE2_MAX_MEM_BYTES = 2 * 1024 * 1024
 MAX_VARIABLE_RANGE_QUANTIFIERS = 4
 
+# Exact ASCII class names from RE2's syntax reference. Only a complete
+# `[:name:]` / `[:^name:]` token is skipped inside a bracket expression —
+# arbitrary forward scans for `[.` / `[=` / incomplete `[:` delimiters are
+# refused so they cannot hide variable-range quantifiers from this preflight.
+POSIX_CLASS_NAMES = frozenset(
+    {
+        "alnum",
+        "alpha",
+        "ascii",
+        "blank",
+        "cntrl",
+        "digit",
+        "graph",
+        "lower",
+        "print",
+        "punct",
+        "space",
+        "upper",
+        "word",
+        "xdigit",
+    }
+)
+
 CompiledPattern = Any
 
 SUPPORTED_SYNTAX_HINT = (
@@ -100,15 +123,42 @@ def _variable_range_quantifier_end(pattern: str, opening_brace_index: int) -> tu
     return cursor + 1, int(minimum) != int(pattern[maximum_start:cursor])
 
 
+def _posix_class_token_end(pattern: str, opening_bracket_index: int) -> int | None:
+    """Return the end index after a complete `[:name:]` or `[:^name:]` token.
+
+    Incomplete or unknown nested bracket forms return None so the caller can
+    treat the opening `[` as ordinary class content. This avoids open-ended
+    delimiter scans that can skip past real character-class closers.
+    """
+    if opening_bracket_index + 1 >= len(pattern) or pattern[opening_bracket_index + 1] != ":":
+        return None
+
+    cursor = opening_bracket_index + 2
+    if cursor < len(pattern) and pattern[cursor] == "^":
+        cursor += 1
+
+    name_start = cursor
+    while cursor < len(pattern) and "a" <= pattern[cursor] <= "z":
+        cursor += 1
+    name = pattern[name_start:cursor]
+    if name not in POSIX_CLASS_NAMES:
+        return None
+    if cursor + 1 >= len(pattern) or pattern[cursor] != ":" or pattern[cursor + 1] != "]":
+        return None
+    return cursor + 2
+
+
 def _validate_variable_range_quantifier_limit(pattern: str) -> None:
     r"""Validate range quantifiers with a forward-only lexical scan.
 
     This deliberately performs only lexical recognition; RE2 remains the
     authority for regex syntax validation. The scanner models escaped
-    characters, POSIX character-class tokens, and bracket-expression state so
+    characters, exact POSIX `[:name:]` tokens, and bracket-expression state so
     literals such as `\{1,900}` and `[[:alpha:]{1,900}]` are not counted as
     quantifiers. Quoted literals (`\Q...\E`) are excluded from the documented
-    subset and rejected before they can hide range quantifiers.
+    subset and rejected before they can hide range quantifiers. Incomplete
+    collating/equivalence forms (`[.`, `[=`) are ordinary class content so a
+    real `]` can close the class and expose subsequent ranges to counting.
     """
     quantifier_count = 0
     in_character_class = False
@@ -123,15 +173,11 @@ def _validate_variable_range_quantifier_limit(pattern: str) -> None:
             continue
 
         if in_character_class:
-            if character == "[" and index + 1 < len(pattern) and pattern[index + 1] in {":", ".", "="}:
-                closing_delimiter = pattern[index + 1]
-                index += 2
-                while index + 1 < len(pattern):
-                    if pattern[index] == closing_delimiter and pattern[index + 1] == "]":
-                        index += 2
-                        break
-                    index += 1
-                continue
+            if character == "[":
+                posix_end = _posix_class_token_end(pattern, index)
+                if posix_end is not None:
+                    index = posix_end
+                    continue
             if character == "]":
                 in_character_class = False
             index += 1

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -1,12 +1,4 @@
-"""Kompilacja wzorców regex dostarczonych przez klienta.
-
-Jedyne miejsce w projekcie, które kompiluje wzorzec pochodzący od wywołującego
-narzędzie MCP. Silnikiem jest RE2 (`google-re2`), który gwarantuje złożoność
-liniową względem długości wejścia — katastroficzny nawrót jest tu niemożliwy
-strukturalnie, a nie mitygowany limitami czy timeoutem.
-
-Kontekst: ustalenie F01 audytu `docs/mcp-audit-2026-08-06.md`, decyzje D1-D3 i D5
-specyfikacji `docs/superpowers/specs/2026-08-07-klaster-1.md`.
+"""Compile client-supplied regex patterns.
 """
 
 from __future__ import annotations
@@ -20,27 +12,8 @@ from law_scrapper_mcp.config import (
     MAX_PATTERN_LENGTH_FLOOR,
 )
 
-# Parametr klasy "bezpieczeństwo" (D3): stała w kodzie, celowo NIE konfigurowalna
-# przez zmienną środowiskową. Domyślna wartość biblioteki RE2 to również 8 MiB
-# (`re2.Options().max_mem == 8388608`), więc ta stała musi być NIŻSZA od
-# domyślnej, żeby cokolwiek realnie ograniczać. Powód: skompilowane wzorce
-# trafiają do globalnego `functools.lru_cache(maxsize=128)` wewnątrz pakietu
-# `google-re2` — przy limicie 8 MiB sufit tego cache'u to ~1 GiB pamięci
-# utrzymywanej przez legalne, niezłośliwe wzorce klienta. Przy 2 MiB sufit
-# spada do ~256 MiB.
-#
-# 2 MiB (a nie 1 MiB) dobrane empirycznie: `\p{L}` to ogromna klasa Unicode,
-# więc powtórzenia tej klasy są dla RE2 najdroższe pamięciowo ze wszystkich
-# konstrukcji w obsługiwanym podzbiorze składni. Przy 1 MiB granica
-# `\p{L}{0,n}` leżała przy n≈55 — odrzucała niewinne wzorce w stylu
-# `\p{L}{0,200}(?:zdrow|apteka)\p{L}{0,200}`. Przy 2 MiB granica dla
-# `\p{L}{0,n}` to n≈111 (zmierzone: n=111 kompiluje się, n=112 już nie).
-# Wzorce klasy `.`, `\w`, `[a-ząćęłńóśźż]` uderzają najpierw we własny limit
-# powtórzeń RE2 (1000), więc dla nich obie wartości max_mem są równoważne.
 RE2_MAX_MEM_BYTES = 2 * 1024 * 1024
 
-# Skompilowany wzorzec RE2 (`re2._Regexp`). Pakiet `google-re2` nie dostarcza
-# stubów typów, więc alias jest jawnym `Any` zamiast fikcyjnej nazwy typu.
 CompiledPattern = Any
 
 SUPPORTED_SYNTAX_HINT = (
@@ -52,31 +25,29 @@ SUPPORTED_SYNTAX_HINT = (
 
 
 class PatternValidationError(ValueError):
-    """Wzorzec odrzucony przed uruchomieniem dopasowania.
+    """Raised when a pattern is rejected before matching runs.
 
-    Dziedziczy po ValueError, ponieważ warstwa narzędzi traktuje ValueError jako
-    błąd wejścia użytkownika, a nie awarię serwera.
+    Subclasses ValueError because the tools layer treats ValueError as a
+    user-input error rather than a server failure.
     """
 
 
 def _build_options() -> Any:
-    """Zbuduj opcje RE2 wspólne dla wszystkich wzorców od klienta."""
+    """Build RE2 options shared by all client-supplied patterns."""
     options = re2.Options()
-    # RE2 nie eksponuje stałej odpowiadającej re.IGNORECASE (D1).
+    # RE2 does not expose a constant equivalent to re.IGNORECASE.
     options.case_sensitive = False
-    # Warstwa absl zapisuje błędy parsowania bezpośrednio na stderr, omijając
-    # logging_config.py i zanieczyszczając logi JSON (D5).
     options.log_errors = False
     options.max_mem = RE2_MAX_MEM_BYTES
     return options
 
 
 def _is_pattern_too_large(e: re2.error) -> bool:
-    """Rozpoznaj przekroczenie budżetu pamięci kompilacji (`RE2_MAX_MEM_BYTES`).
+    """Detect a compilation memory-budget overrun (`RE2_MAX_MEM_BYTES`).
 
-    RE2 sygnalizuje to tym samym typem wyjątku co błąd składni (`re2.error`),
-    więc trzeba rozróżnić po treści komunikatu, żeby nie sugerować klientowi
-    poprawy składni, gdy problemem jest wyłącznie złożoność wzorca (U4).
+    RE2 signals this with the same exception type as a syntax error (`re2.error`),
+    so the message text must be inspected to avoid suggesting a syntax fix when
+    the only problem is pattern complexit.
     """
     if not e.args:
         return False
@@ -85,14 +56,13 @@ def _is_pattern_too_large(e: re2.error) -> bool:
 
 
 def _re2_error_detail(e: re2.error) -> str:
-    """Wydobądź czytelny opis błędu składni z wyjątku `re2.error`.
+    """Extract a readable syntax-error description from a `re2.error`.
 
-    Warstwa C++ RE2 zwraca komunikat jako `bytes` (`e.args[0]`), bo wzorzec
-    jest kodowany do UTF-8 zanim trafi poza Pythona — interpolowanie tego
-    surowo dawałoby polskim znakom repr w stylu `b'...\\xc5\\xbc...'` w
-    komunikacie błędu, co myli model językowy będący klientem tego narzędzia
-    (U3). Dekodujemy z `errors="replace"`, żeby formatowanie komunikatu błędu
-    nigdy samo nie rzuciło wyjątku.
+    The C++ RE2 layer returns the message as `bytes` (`e.args[0]`) because the
+    pattern is UTF-8-encoded before leaving Python — interpolating that raw
+    value would produce Polish-character reprs like `b'...\\xc5\\xbc...'` in the
+    error message, which confuses the language-model client of this tool.
+    Decode with `errors="replace"` so error formatting never raises on its own.
     """
     if not e.args:
         return str(e)
@@ -127,19 +97,19 @@ def compile_pattern(
     max_length: int,
     limit_was_clamped: bool = False,
 ) -> CompiledPattern:
-    """Zwaliduj i skompiluj wzorzec pochodzący od klienta.
+    """Validate and compile a client-supplied pattern.
 
     Args:
-        pattern: Surowy wzorzec przekazany przez wywołującego narzędzie.
-        max_length: Efektywny limit długości wzorca (po przycięciu do widełek).
-        limit_was_clamped: Czy `max_length` powstał z przycięcia konfiguracji.
-            Wpływa wyłącznie na treść komunikatu błędu (D3.1).
+        pattern: Raw pattern passed by the tool caller.
+        max_length: Effective pattern length limit (after clamping to the range).
+        limit_was_clamped: Whether `max_length` came from a clamped configuration.
+            Affects only the error message text (D3.1).
 
     Raises:
-        PatternValidationError: Wzorzec przekracza limit długości, używa składni
-            spoza podzbioru obsługiwanego przez RE2, przekracza budżet pamięci
-            kompilacji (`RE2_MAX_MEM_BYTES`), albo zawiera znaki, których nie
-            da się zakodować w UTF-8 — np. samotny surogat UTF-16 (U1).
+        PatternValidationError: Pattern exceeds the length limit, uses syntax
+            outside the RE2-supported subset, exceeds the compilation memory
+            budget (`RE2_MAX_MEM_BYTES`), or contains characters that cannot be
+            encoded as UTF-8 — e.g. a lone UTF-16 surrogate (U1).
     """
     if len(pattern) > max_length:
         raise PatternValidationError(_too_long_message(len(pattern), max_length, limit_was_clamped))
@@ -147,9 +117,6 @@ def compile_pattern(
     try:
         return re2.compile(pattern, _build_options())
     except (re2.error, UnicodeError) as e:
-        # `str.encode("utf-8")` wewnątrz `re2/__init__.py` rzuca UnicodeError
-        # (np. dla samotnych surogatów) zanim cokolwiek dotknie warstwy C++,
-        # więc ten wyjątek nigdy nie jest instancją `re2.error` (U1).
         if isinstance(e, re2.error):
             if _is_pattern_too_large(e):
                 raise PatternValidationError(_too_complex_message()) from e

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -1,5 +1,4 @@
-"""Compile client-supplied regex patterns.
-"""
+"""Compile client-supplied regex patterns."""
 
 from __future__ import annotations
 

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -1,4 +1,16 @@
-"""Compile client-supplied regex patterns."""
+r"""Compile client-supplied regex patterns.
+
+RE2 provides linear-time matching, but its compilation work can still grow
+quickly for many concatenated variable range quantifiers. Before calling RE2,
+this module rejects patterns with more than four unescaped `{min,max}`
+quantifiers where `min != max`. Four was calibrated to keep the slow shape
+below 50 ms at the 2 MiB compiled-program budget; eight already takes about
+120 ms and twenty about 700 ms on the supported baseline.
+
+The 2 MiB `max_mem` budget is deliberately below RE2's 8 MiB default. The
+Python binding caches compiled patterns, so retaining the default would allow
+the cache to retain substantially more memory for client-supplied patterns.
+"""
 
 from __future__ import annotations
 
@@ -12,12 +24,14 @@ from law_scrapper_mcp.config import (
 )
 
 RE2_MAX_MEM_BYTES = 2 * 1024 * 1024
+MAX_VARIABLE_RANGE_QUANTIFIERS = 4
 
 CompiledPattern = Any
 
 SUPPORTED_SYNTAX_HINT = (
     "Obsługiwany podzbiór składni: alternatywa (a|b), klasy znaków "
-    r"([a-z], \d, \p{L}, [[:alpha:]]), kwantyfikatory (*, +, ?, {n,m}), "
+    r"([a-z], \d, \p{L}, [[:alpha:]]), kwantyfikatory (*, +, ?, {n,m}; "
+    f"maksymalnie {MAX_VARIABLE_RANGE_QUANTIFIERS} zmienne zakresy), "
     r"kotwice (^, $), grupy nieprzechwytujące. Lookaround ((?=...), (?<=...), "
     r"(?!...)) oraz backreferencje (\1) nie są obsługiwane."
 )
@@ -46,12 +60,54 @@ def _is_pattern_too_large(e: re2.error) -> bool:
 
     RE2 signals this with the same exception type as a syntax error (`re2.error`),
     so the message text must be inspected to avoid suggesting a syntax fix when
-    the only problem is pattern complexit.
+    the only problem is pattern complexity.
     """
     if not e.args:
         return False
     detail = e.args[0]
     return isinstance(detail, bytes) and b"pattern too large" in detail
+
+
+def _has_too_many_variable_range_quantifiers(pattern: str) -> bool:
+    r"""Count unescaped `{min,max}` quantifiers outside character classes.
+
+    This deliberately performs only lexical recognition; RE2 remains the
+    authority for regex syntax validation. Skipping escapes and character
+    classes prevents literals such as `\{1,900}` and `[{1,900}]` from being
+    counted as quantifiers.
+    """
+    quantifier_count = 0
+    in_character_class = False
+    index = 0
+
+    while index < len(pattern):
+        character = pattern[index]
+        if character == "\\":
+            index += 2
+            continue
+        if character == "[" and not in_character_class:
+            in_character_class = True
+        elif character == "]" and in_character_class:
+            in_character_class = False
+        elif character == "{" and not in_character_class:
+            closing_brace = pattern.find("}", index + 1)
+            if closing_brace != -1:
+                minimum, separator, maximum = pattern[index + 1 : closing_brace].partition(",")
+                if (
+                    separator
+                    and minimum.isascii()
+                    and maximum.isascii()
+                    and minimum.isdecimal()
+                    and maximum.isdecimal()
+                    and minimum != maximum
+                ):
+                    quantifier_count += 1
+                    if quantifier_count > MAX_VARIABLE_RANGE_QUANTIFIERS:
+                        return True
+                index = closing_brace
+        index += 1
+
+    return False
 
 
 def _re2_error_detail(e: re2.error) -> str:
@@ -75,7 +131,8 @@ def _too_complex_message() -> str:
     return (
         "Wzorzec jest zbyt złożony: przekracza budżet pamięci kompilacji silnika "
         "wyszukiwania. Uprość wzorzec — zmniejsz liczbę alternatyw albo zawęź "
-        "kwantyfikatory takie jak {n,m}."
+        f"kwantyfikatory takie jak {{n,m}}. Dozwolone są najwyżej "
+        f"{MAX_VARIABLE_RANGE_QUANTIFIERS} zmienne kwantyfikatory zakresowe."
     )
 
 
@@ -112,6 +169,8 @@ def compile_pattern(
     """
     if len(pattern) > max_length:
         raise PatternValidationError(_too_long_message(len(pattern), max_length, limit_was_clamped))
+    if _has_too_many_variable_range_quantifiers(pattern):
+        raise PatternValidationError(_too_complex_message())
 
     try:
         return re2.compile(pattern, _build_options())

--- a/src/law_scrapper_mcp/services/pattern_matching.py
+++ b/src/law_scrapper_mcp/services/pattern_matching.py
@@ -159,7 +159,7 @@ def compile_pattern(
         pattern: Raw pattern passed by the tool caller.
         max_length: Effective pattern length limit (after clamping to the range).
         limit_was_clamped: Whether `max_length` came from a clamped configuration.
-            Affects only the error message text (D3.1).
+            Affects only the error message text
 
     Raises:
         PatternValidationError: Pattern exceeds the length limit, uses syntax

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Any
 
 from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput
+from law_scrapper_mcp.services.pattern_matching import CompiledPattern, compile_pattern
 
 logger = logging.getLogger(__name__)
 
@@ -38,12 +38,25 @@ class FilterHit:
 class ResultStore:
     """In-memory store for search/browse results with grep-like filtering."""
 
-    def __init__(self, max_sets: int = 20, ttl: int = 3600):
+    def __init__(
+        self,
+        max_sets: int = 20,
+        ttl: int = 3600,
+        *,
+        max_pattern_length: int = 512,
+        pattern_length_limit_clamped: bool = False,
+        max_records: int = 100,
+    ):
         self._store: dict[str, StoredResultSet] = {}
         self._max_sets = max_sets
         self._ttl = ttl
         self._counter = 0
         self._lock = asyncio.Lock()
+        # Polityka filtrowania wstrzykiwana z konfiguracji (server.py). Publiczna,
+        # bo server i testy muszą móc sprawdzić, co faktycznie obowiązuje.
+        self.max_pattern_length = max_pattern_length
+        self.pattern_length_limit_clamped = pattern_length_limit_clamped
+        self.max_records = max_records
 
     async def store(
         self,
@@ -118,6 +131,11 @@ class ResultStore:
         if rs is None:
             raise ResultSetNotFoundError(result_set_id)
 
+        # D4: odmowa wykonania zamiast wyniku częściowego. Dzięki temu brak
+        # dopasowania zawsze oznacza przeszukanie całego zestawu.
+        if len(rs.results) > self.max_records:
+            raise ResultSetTooLargeError(result_set_id, len(rs.results), self.max_records)
+
         filtered = list(rs.results)
         original_count = len(filtered)
 
@@ -131,13 +149,13 @@ class ResultStore:
         if year_equals is not None:
             filtered = [r for r in filtered if r.year == year_equals]
 
-        # Regex pattern filter
+        # Filtr wzorcem — silnik RE2, złożoność liniowa (F01, D1)
         if pattern is not None:
-            try:
-                compiled = re.compile(pattern, re.IGNORECASE)
-            except re.error as e:
-                raise ValueError(f"Invalid regex pattern: {e}") from e
-
+            compiled = compile_pattern(
+                pattern,
+                max_length=self.max_pattern_length,
+                limit_was_clamped=self.pattern_length_limit_clamped,
+            )
             filtered = [r for r in filtered if _match_field(r, field, compiled)]
 
         # Date range filter
@@ -181,6 +199,25 @@ class ResultSetNotFoundError(Exception):
         )
 
 
+class ResultSetTooLargeError(Exception):
+    """Zestaw wyników przekracza limit pojedynczego wywołania filter_results."""
+
+    def __init__(self, result_set_id: str, size: int, limit: int):
+        self.result_set_id = result_set_id
+        self.size = size
+        self.limit = limit
+        super().__init__(
+            f"Zestaw wyników '{result_set_id}' zawiera {size} rekordów, "
+            f"a limit pojedynczego wywołania filter_results wynosi {limit}. "
+            f"Zawęź zestaw przy wyszukiwaniu: search_legal_acts z parametrem "
+            f"limit={limit}, węższe kryteria w browse_acts, albo — dla "
+            f"track_legal_changes, które nie ma parametru limit — zawęź "
+            f"date_from/date_to lub dodaj keywords. Wynik częściowy nie jest "
+            f"zwracany, aby brak dopasowania zawsze oznaczał przeszukanie "
+            f"całego zestawu."
+        )
+
+
 # --- Helper functions ---
 
 
@@ -189,7 +226,7 @@ _DATE_FIELDS = {"promulgation_date", "effective_date"}
 _SORTABLE_FIELDS = {"title", "eli", "year", "pos", "status", "type", "promulgation_date", "effective_date"}
 
 
-def _match_field(act: ActSummaryOutput, field: str, compiled: re.Pattern[str]) -> bool:
+def _match_field(act: ActSummaryOutput, field: str, compiled: CompiledPattern) -> bool:
     """Check if a field value matches the compiled regex."""
     if field not in _SEARCHABLE_FIELDS:
         # Default to searching title

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -52,8 +52,6 @@ class ResultStore:
         self._ttl = ttl
         self._counter = 0
         self._lock = asyncio.Lock()
-        # Polityka filtrowania wstrzykiwana z konfiguracji (server.py). Publiczna,
-        # bo server i testy muszą móc sprawdzić, co faktycznie obowiązuje.
         self.max_pattern_length = max_pattern_length
         self.pattern_length_limit_clamped = pattern_length_limit_clamped
         self.max_records = max_records
@@ -131,8 +129,6 @@ class ResultStore:
         if rs is None:
             raise ResultSetNotFoundError(result_set_id)
 
-        # D4: odmowa wykonania zamiast wyniku częściowego. Dzięki temu brak
-        # dopasowania zawsze oznacza przeszukanie całego zestawu.
         if len(rs.results) > self.max_records:
             raise ResultSetTooLargeError(result_set_id, len(rs.results), self.max_records)
 
@@ -149,7 +145,7 @@ class ResultStore:
         if year_equals is not None:
             filtered = [r for r in filtered if r.year == year_equals]
 
-        # Filtr wzorcem — silnik RE2, złożoność liniowa (F01, D1)
+        # Pattern filter — RE2 engine, linear-time matching
         if pattern is not None:
             compiled = compile_pattern(
                 pattern,
@@ -200,7 +196,7 @@ class ResultSetNotFoundError(Exception):
 
 
 class ResultSetTooLargeError(Exception):
-    """Zestaw wyników przekracza limit pojedynczego wywołania filter_results."""
+    """Raised when a result set exceeds the per-call filter_results limit."""
 
     def __init__(self, result_set_id: str, size: int, limit: int):
         self.result_set_id = result_set_id

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -15,15 +15,19 @@ from law_scrapper_mcp.client.exceptions import (
     InvalidEliError,
 )
 from law_scrapper_mcp.models.tool_outputs import EnrichedResponse
-from law_scrapper_mcp.services.result_store import ResultSetNotFoundError
+from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
 
 logger = logging.getLogger(__name__)
 
+# _classify_error iteruje ten słownik w kolejności wstawienia i zwraca kategorię
+# przy PIERWSZYM pasującym isinstance — podklasy muszą więc stać PRZED swoimi
+# nadklasami (np. przed wpisem ValueError), inaczej staną się cicho nieosiągalne.
 _ERROR_CATEGORIES: dict[type[Exception], str] = {
     ActNotFoundError: "not_found",
     InvalidEliError: "validation",
     DocumentNotLoadedError: "precondition",
     ResultSetNotFoundError: "precondition",
+    ResultSetTooLargeError: "precondition",
     ContentNotAvailableError: "not_found",
     ApiUnavailableError: "unavailable",
     ValueError: "validation",

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -33,7 +33,11 @@ _ERROR_CATEGORIES: dict[type[Exception], str] = {
 
 
 def _classify_error(exc: Exception) -> str:
-    """Classify exception into error category."""
+    """Classify an exception into an error category.
+
+    `_ERROR_CATEGORIES` is evaluated in insertion order. Subclasses must
+    appear before their base classes; otherwise a broader category wins first.
+    """
     for exc_type, category in _ERROR_CATEGORIES.items():
         if isinstance(exc, exc_type):
             return category

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -19,9 +19,6 @@ from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, Resul
 
 logger = logging.getLogger(__name__)
 
-# _classify_error iteruje ten słownik w kolejności wstawienia i zwraca kategorię
-# przy PIERWSZYM pasującym isinstance — podklasy muszą więc stać PRZED swoimi
-# nadklasami (np. przed wpisem ValueError), inaczej staną się cicho nieosiągalne.
 _ERROR_CATEGORIES: dict[type[Exception], str] = {
     ActNotFoundError: "not_found",
     InvalidEliError: "validation",

--- a/src/law_scrapper_mcp/tools/filter_results.py
+++ b/src/law_scrapper_mcp/tools/filter_results.py
@@ -12,6 +12,7 @@ from law_scrapper_mcp.models.tool_outputs import (
     ResultSetInfo,
     ResultSetListOutput,
 )
+from law_scrapper_mcp.services.pattern_matching import SUPPORTED_SYNTAX_HINT
 from law_scrapper_mcp.tools.error_handling import handle_tool_errors
 
 logger = logging.getLogger(__name__)
@@ -37,13 +38,13 @@ def register(mcp: FastMCP) -> None:
         ],
         pattern: Annotated[
             str | None,
-            "Wzorzec regex do przeszukania pola (obsługuje OR: 'podatek|VAT|akcyza'). "
-            "Wielkość liter jest ignorowana. Przykłady: "
-            "'zdrow|Minister Zdrowia|apteka|lekar', 'budżet.*państw', 'transport|drogow'",
+            f"Wzorzec wyszukiwania w składni RE2. Wielkość liter jest ignorowana. {SUPPORTED_SYNTAX_HINT} "
+            "Przykłady: 'zdrow|Minister Zdrowia|apteka|lekar', 'budżet.*państw', "
+            r"'transport|drogow', '\p{L}+ o ochronie'",
         ] = None,
         field: Annotated[
             str,
-            "Pole do przeszukania wzorcem regex. Dostępne: 'title' (domyślne), 'eli', 'status', 'type', 'publisher'.",
+            "Pole do przeszukania wzorcem RE2. Dostępne: 'title' (domyślne), 'eli', 'status', 'type', 'publisher'.",
         ] = "title",
         type_equals: Annotated[
             str | None,
@@ -95,6 +96,11 @@ def register(mcp: FastMCP) -> None:
         Wymaga result_set_id zwróconego przez te narzędzia. Przefiltrowane wyniki
         zapisywane są jako nowy zestaw (nowe result_set_id), który można filtrować dalej.
 
+        Limit rozmiaru wejścia: pojedyncze wywołanie przetwarza maksymalnie 100 rekordów
+        (wartość domyślna, konfigurowalna przez operatora). Większy zestaw kończy się
+        błędem, a nie wynikiem częściowym — dzięki temu brak dopasowania zawsze oznacza
+        przeszukanie całego zestawu. Zawęź wyszukiwanie przed filtrowaniem.
+
         Kiedy użyć: Po search_legal_acts/browse_acts/track_legal_changes aby zawęzić wyniki.
         Kiedy NIE używać: Gdy potrzebujesz nowych wyników z API → użyj search_legal_acts.
 
@@ -104,6 +110,7 @@ def register(mcp: FastMCP) -> None:
         - filter_results(result_set_id="rs_1", pattern="podatek|VAT", type_equals="Ustawa") - Ustawy podatkowe
         - filter_results(result_set_id="rs_1", date_field="promulgation_date", date_from="2024-01-01", date_to="2024-06-30") - Ogłoszone w I połowie 2024
         - filter_results(result_set_id="rs_1", sort_by="promulgation_date", sort_desc=True, limit=10) - 10 najnowszych
+        - filter_results(result_set_id="rs_1", pattern="\\p{L}+ o ochronie") - Wzorzec z klasą unikodową
         """
         assert ctx is not None
         result_store = ctx.lifespan_context["result_store"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -158,7 +158,7 @@ class TestSettingsValidation:
 
 
 class TestPatternFilterSettings:
-    """Testy parametrów filtrowania wyników (klaster 1, D3/D3.1)."""
+    """Tests for result-filtering settings"""
 
     def test_defaults(self):
         settings = Settings()
@@ -187,9 +187,9 @@ class TestPatternFilterSettings:
         assert settings.max_pattern_length_was_clamped is True
 
     def test_out_of_range_value_does_not_block_startup(self, monkeypatch):
-        """Konfiguracja spoza widełek nie może przerwać startu serwera (D3.1)."""
+        """Out-of-range configuration must not abort server startup"""
         monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "10000")
-        settings = Settings()  # nie rzuca
+        settings = Settings()  # must not raise
         assert settings.effective_max_pattern_length == 4096
 
     def test_filter_max_records_from_env(self, monkeypatch):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
-from law_scrapper_mcp.config import Settings
+from law_scrapper_mcp.config import (
+    FILTER_MAX_RECORDS_FLOOR,
+    MAX_PATTERN_LENGTH_CEILING,
+    MAX_PATTERN_LENGTH_FLOOR,
+    Settings,
+    log_pattern_limit_clamping,
+)
 
 
 class TestSettingsDefaults:
@@ -147,3 +155,91 @@ class TestSettingsValidation:
         monkeypatch.setenv("LAW_MCP_CACHE_SEARCH_TTL", "invalid")
         with pytest.raises((ValueError, TypeError)):
             Settings()
+
+
+class TestPatternFilterSettings:
+    """Testy parametrów filtrowania wyników (klaster 1, D3/D3.1)."""
+
+    def test_defaults(self):
+        settings = Settings()
+        assert settings.max_pattern_length == 512
+        assert settings.filter_max_records == 100
+        assert settings.effective_max_pattern_length == 512
+        assert settings.max_pattern_length_was_clamped is False
+
+    def test_value_within_range_is_used_as_is(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "1024")
+        settings = Settings()
+        assert settings.effective_max_pattern_length == 1024
+        assert settings.max_pattern_length_was_clamped is False
+
+    def test_value_above_ceiling_is_clamped_down(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "10000")
+        settings = Settings()
+        assert settings.max_pattern_length == 10000
+        assert settings.effective_max_pattern_length == MAX_PATTERN_LENGTH_CEILING == 4096
+        assert settings.max_pattern_length_was_clamped is True
+
+    def test_value_below_floor_is_clamped_up(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "8")
+        settings = Settings()
+        assert settings.effective_max_pattern_length == MAX_PATTERN_LENGTH_FLOOR == 64
+        assert settings.max_pattern_length_was_clamped is True
+
+    def test_out_of_range_value_does_not_block_startup(self, monkeypatch):
+        """Konfiguracja spoza widełek nie może przerwać startu serwera (D3.1)."""
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "10000")
+        settings = Settings()  # nie rzuca
+        assert settings.effective_max_pattern_length == 4096
+
+    def test_filter_max_records_from_env(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_FILTER_MAX_RECORDS", "250")
+        settings = Settings()
+        assert settings.filter_max_records == 250
+
+    @pytest.mark.parametrize("value", [MAX_PATTERN_LENGTH_FLOOR, MAX_PATTERN_LENGTH_CEILING])
+    def test_value_exactly_on_boundary_is_not_clamped(self, monkeypatch, value):
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", str(value))
+        settings = Settings()
+        assert settings.effective_max_pattern_length == value
+        assert settings.max_pattern_length_was_clamped is False
+
+    def test_filter_max_records_zero_is_clamped_to_floor(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_FILTER_MAX_RECORDS", "0")
+        settings = Settings()
+        assert settings.filter_max_records == 0
+        assert settings.effective_filter_max_records == FILTER_MAX_RECORDS_FLOOR == 1
+
+    def test_filter_max_records_negative_is_clamped_to_floor(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_FILTER_MAX_RECORDS", "-5")
+        settings = Settings()
+        assert settings.filter_max_records == -5
+        assert settings.effective_filter_max_records == 1
+
+    def test_filter_max_records_within_range_is_used_as_is(self, monkeypatch):
+        monkeypatch.setenv("LAW_MCP_FILTER_MAX_RECORDS", "250")
+        settings = Settings()
+        assert settings.filter_max_records == 250
+        assert settings.effective_filter_max_records == 250
+
+
+class TestPatternLimitClampingLog:
+    def test_warning_lists_configured_and_effective_values(self, monkeypatch, caplog):
+        monkeypatch.setenv("LAW_MCP_MAX_PATTERN_LENGTH", "10000")
+        settings = Settings()
+        log = logging.getLogger("test_clamping")
+
+        with caplog.at_level(logging.WARNING, logger="test_clamping"):
+            log_pattern_limit_clamping(settings, log)
+
+        assert "10000" in caplog.text
+        assert "wartości efektywnej 4096" in caplog.text
+
+    def test_no_warning_when_value_within_range(self, caplog):
+        settings = Settings()
+        log = logging.getLogger("test_clamping")
+
+        with caplog.at_level(logging.WARNING, logger="test_clamping"):
+            log_pattern_limit_clamping(settings, log)
+
+        assert caplog.text == ""

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -441,3 +441,36 @@ class TestEdgeCases:
 
         await document_store.load("DU/2024/1", "Second version", sections2)
         assert len(await document_store.get_toc("DU/2024/1")) == 2
+
+
+class TestSearchTreatsQueryLiterally:
+    """Guard przeciw regresji F51 — `query` nie może stać się surowym wzorcem."""
+
+    async def test_catastrophic_pattern_is_treated_as_literal_text(self, document_store: DocumentStore):
+        """Wzorzec katastroficzny jest WEWNĄTRZ treści dokumentu, a asercja dotyczy
+        pozycji trafienia — nie samego faktu braku wyniku. Dzięki temu regresja
+        (usunięcie re.escape) daje natychmiastowy FAIL na złej pozycji zamiast
+        zawieszać przebieg: `pytest.mark.timeout` nie chroni tego przypadku, bo
+        `re` nie zwalnia GIL-a podczas backtrackingu, a wątek-timer nigdy nie
+        dostaje sterowania."""
+        markdown = "Art. 1. Zabroniony wzorzec (.+)+! jest tu zwykłym tekstem!"
+        sections = [Section(id="art_1", title="Art. 1.", level=2, start_pos=0)]
+        await document_store.load("DU/2024/1", markdown, sections)
+
+        hits = await document_store.search("DU/2024/1", "(.+)+!")
+
+        assert len(hits) == 1
+        assert hits[0].match_start == markdown.index("(.+)+!")
+
+    async def test_regex_metacharacters_match_only_literally(self, document_store: DocumentStore):
+        """Metaznaki regex ('(', '.') w query mają działać jak zwykłe znaki — grupa
+        i kropka nie mogą zostać zinterpretowane jako wzorzec."""
+        markdown = "Art. 1. Stawka wynosi 23% (dwadzieścia trzy procent)."
+        sections = [Section(id="art_1", title="Art. 1.", level=2, start_pos=0)]
+        await document_store.load("DU/2024/1", markdown, sections)
+
+        literal_hits = await document_store.search("DU/2024/1", "(dwadzieścia")
+        wildcard_hits = await document_store.search("DU/2024/1", "23.")
+
+        assert len(literal_hits) == 1
+        assert wildcard_hits == []  # kropka nie jest metaznakiem — "23." nie występuje

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -444,15 +444,15 @@ class TestEdgeCases:
 
 
 class TestSearchTreatsQueryLiterally:
-    """Guard przeciw regresji F51 — `query` nie może stać się surowym wzorcem."""
+    """Regression guard — `query` must not be treated as a raw pattern."""
 
     async def test_catastrophic_pattern_is_treated_as_literal_text(self, document_store: DocumentStore):
-        """Wzorzec katastroficzny jest WEWNĄTRZ treści dokumentu, a asercja dotyczy
-        pozycji trafienia — nie samego faktu braku wyniku. Dzięki temu regresja
-        (usunięcie re.escape) daje natychmiastowy FAIL na złej pozycji zamiast
-        zawieszać przebieg: `pytest.mark.timeout` nie chroni tego przypadku, bo
-        `re` nie zwalnia GIL-a podczas backtrackingu, a wątek-timer nigdy nie
-        dostaje sterowania."""
+        """The catastrophic pattern is INSIDE the document text; the assertion is
+        on the hit position — not merely on a miss. A regression that drops
+        `re.escape` then fails immediately on the wrong position instead of
+        hanging the run: `pytest.mark.timeout` cannot protect this case because
+        `re` does not release the GIL during backtracking, so the timer thread
+        never gets scheduled."""
         markdown = "Art. 1. Zabroniony wzorzec (.+)+! jest tu zwykłym tekstem!"
         sections = [Section(id="art_1", title="Art. 1.", level=2, start_pos=0)]
         await document_store.load("DU/2024/1", markdown, sections)
@@ -463,8 +463,8 @@ class TestSearchTreatsQueryLiterally:
         assert hits[0].match_start == markdown.index("(.+)+!")
 
     async def test_regex_metacharacters_match_only_literally(self, document_store: DocumentStore):
-        """Metaznaki regex ('(', '.') w query mają działać jak zwykłe znaki — grupa
-        i kropka nie mogą zostać zinterpretowane jako wzorzec."""
+        """Regex metacharacters ('(', '.') in query must act as literal characters —
+        the group and the dot must not be interpreted as a pattern."""
         markdown = "Art. 1. Stawka wynosi 23% (dwadzieścia trzy procent)."
         sections = [Section(id="art_1", title="Art. 1.", level=2, start_pos=0)]
         await document_store.load("DU/2024/1", markdown, sections)
@@ -473,4 +473,4 @@ class TestSearchTreatsQueryLiterally:
         wildcard_hits = await document_store.search("DU/2024/1", "23.")
 
         assert len(literal_hits) == 1
-        assert wildcard_hits == []  # kropka nie jest metaznakiem — "23." nie występuje
+        assert wildcard_hits == []  # dot is not a metacharacter — "23." does not occur

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,0 +1,54 @@
+"""Tests for the shared MCP tool error classification."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
+from law_scrapper_mcp.tools.error_handling import _classify_error, handle_tool_errors
+
+
+class TestClassifyError:
+    """Regresja U1 — ResultSetTooLargeError musi klasyfikować się jak precondition."""
+
+    def test_result_set_not_found_is_precondition(self) -> None:
+        assert _classify_error(ResultSetNotFoundError("rs_1")) == "precondition"
+
+    def test_result_set_too_large_is_precondition(self) -> None:
+        assert _classify_error(ResultSetTooLargeError("rs_1", 500, 100)) == "precondition"
+
+
+class TestHandleToolErrorsPublicSurface:
+    """U1b — test przez publiczną powierzchnię `handle_tool_errors`, nie przez `_classify_error`.
+
+    `_classify_error` łapie tylko przypadkowe usunięcie wpisu ze słownika.
+    Realnym objawem usterki był `exc_info=True` w logach (nadmiarowy traceback
+    dla sytuacji, którą klient może naprawić) i `error_category: "internal"`
+    widziany przez klienta zamiast `"precondition"` — obie rzeczy sprawdzane tu.
+    """
+
+    async def test_result_set_too_large_is_precondition_without_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        @handle_tool_errors(default_factory=lambda e, kw: {})
+        async def failing_tool() -> str:
+            raise ResultSetTooLargeError("rs_1", 500, 100)
+
+        with caplog.at_level(logging.ERROR, logger="law_scrapper_mcp.tools.error_handling"):
+            out = await failing_tool()
+
+        payload = json.loads(out)
+        assert payload["metadata"]["error_category"] == "precondition"
+
+        assert caplog.records
+        # `handle_tool_errors` przekazuje `exc_info=(category == "internal")`.
+        # Stdlib `logging` przechowuje w `LogRecord.exc_info` dosłownie to, co
+        # przekazano, gdy jest falsy — czyli literalne `False`, nie `None`
+        # (zweryfikowane niezależnie: `Logger.error(..., exc_info=False)` daje
+        # `record.exc_info is False`). Funkcjonalny skutek jest ten sam —
+        # `Formatter.format` sprawdza `if record.exc_info:` i przy `False`
+        # nie dołącza tracebacku — dlatego sprawdzamy falsy, nie `is None`.
+        assert not caplog.records[-1].exc_info

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -12,7 +12,7 @@ from law_scrapper_mcp.tools.error_handling import _classify_error, handle_tool_e
 
 
 class TestClassifyError:
-    """Regresja U1 — ResultSetTooLargeError musi klasyfikować się jak precondition."""
+    """ResultSetTooLargeError must classify as precondition"""
 
     def test_result_set_not_found_is_precondition(self) -> None:
         assert _classify_error(ResultSetNotFoundError("rs_1")) == "precondition"
@@ -22,12 +22,12 @@ class TestClassifyError:
 
 
 class TestHandleToolErrorsPublicSurface:
-    """U1b — test przez publiczną powierzchnię `handle_tool_errors`, nie przez `_classify_error`.
+    """Exercise the public `handle_tool_errors` surface, not `_classify_error`.
 
-    `_classify_error` łapie tylko przypadkowe usunięcie wpisu ze słownika.
-    Realnym objawem usterki był `exc_info=True` w logach (nadmiarowy traceback
-    dla sytuacji, którą klient może naprawić) i `error_category: "internal"`
-    widziany przez klienta zamiast `"precondition"` — obie rzeczy sprawdzane tu.
+    `_classify_error` alone only catches accidental removal of a dict entry.
+    The real failure mode was `exc_info=True` in logs (excess traceback for a
+    client-fixable situation) and `error_category: "internal"` seen by the
+    client instead of `"precondition"` — both are checked here.
     """
 
     async def test_result_set_too_large_is_precondition_without_traceback(
@@ -44,11 +44,11 @@ class TestHandleToolErrorsPublicSurface:
         assert payload["metadata"]["error_category"] == "precondition"
 
         assert caplog.records
-        # `handle_tool_errors` przekazuje `exc_info=(category == "internal")`.
-        # Stdlib `logging` przechowuje w `LogRecord.exc_info` dosłownie to, co
-        # przekazano, gdy jest falsy — czyli literalne `False`, nie `None`
-        # (zweryfikowane niezależnie: `Logger.error(..., exc_info=False)` daje
-        # `record.exc_info is False`). Funkcjonalny skutek jest ten sam —
-        # `Formatter.format` sprawdza `if record.exc_info:` i przy `False`
-        # nie dołącza tracebacku — dlatego sprawdzamy falsy, nie `is None`.
+        # `handle_tool_errors` passes `exc_info=(category == "internal")`.
+        # Stdlib `logging` stores in `LogRecord.exc_info` exactly what was
+        # passed when falsy — a literal `False`, not `None` (independently
+        # verified: `Logger.error(..., exc_info=False)` yields
+        # `record.exc_info is False`). The functional outcome is the same —
+        # `Formatter.format` checks `if record.exc_info:` and with `False`
+        # skips the traceback — so we assert falsy, not `is None`.
         assert not caplog.records[-1].exc_info

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import httpx
+import pytest
 from fastmcp import Client
 
 from law_scrapper_mcp.server import app, lifespan
@@ -63,3 +65,91 @@ async def test_lifespan_yields_services() -> None:
         assert ctx["metadata_service"] is not None
         assert ctx["search_service"] is not None
         assert ctx["act_service"] is not None
+
+
+async def test_lifespan_result_store_receives_configured_limits(monkeypatch) -> None:
+    """Wartości niedomyślne, celowo — z dwóch powodów naraz.
+
+    512/False/100 to jednocześnie domyślne wartości `Settings` I domyślne argumenty
+    konstruktora `ResultStore`, więc test na wartościach domyślnych przechodzi
+    również po usunięciu wstrzyknięcia (fałszywy pozytyw) i jest wrażliwy na
+    ambientne `LAW_MCP_MAX_PATTERN_LENGTH`/`LAW_MCP_FILTER_MAX_RECORDS` w środowisku
+    uruchamiającym (fałszywy negatyw). Wartości 256/42 nie pokrywają się z żadnym
+    z tych dwóch źródeł, więc test pada, jeśli wstrzyknięcie zniknie z server.py.
+    """
+    from law_scrapper_mcp import server as server_module
+
+    monkeypatch.setattr(server_module.settings, "max_pattern_length", 256)
+    monkeypatch.setattr(server_module.settings, "filter_max_records", 42)
+
+    async with lifespan(app) as ctx:
+        store = ctx["result_store"]
+        assert store.max_pattern_length == 256
+        assert store.pattern_length_limit_clamped is False
+        assert store.max_records == 42
+
+
+async def test_lifespan_result_store_uses_clamped_limit(monkeypatch) -> None:
+    """Konfiguracja spoza widełek dociera do ResultStore jako wartość efektywna."""
+    from law_scrapper_mcp import server as server_module
+
+    monkeypatch.setattr(server_module.settings, "max_pattern_length", 10000)
+    monkeypatch.setattr(server_module.settings, "filter_max_records", 7)
+
+    async with lifespan(app) as ctx:
+        store = ctx["result_store"]
+
+        assert store.max_pattern_length == 4096
+        assert store.pattern_length_limit_clamped is True
+        assert store.max_records == 7
+
+
+async def test_lifespan_result_store_floors_zero_record_limit(monkeypatch) -> None:
+    """Podłoga z Taska 3 musi zadziałać, a nie zostać obejściem surowego pola.
+
+    Bez niej `LAW_MCP_FILTER_MAX_RECORDS=0` czyniłby filter_results trwale
+    niesprawnym: każde wywołanie na niepustym zestawie kończyłoby się odmową.
+    Ten test pada, jeśli server.py wstrzyknie `settings.filter_max_records`
+    zamiast `settings.effective_filter_max_records`.
+    """
+    from law_scrapper_mcp import server as server_module
+
+    monkeypatch.setattr(server_module.settings, "filter_max_records", 0)
+
+    async with lifespan(app) as ctx:
+        assert ctx["result_store"].max_records == 1
+
+
+async def test_lifespan_warns_about_clamped_pattern_limit(monkeypatch, caplog) -> None:
+    """Fakt przycięcia jest widoczny w logu przy starcie (D3.1, punkt 1)."""
+    import logging
+
+    from law_scrapper_mcp import server as server_module
+
+    monkeypatch.setattr(server_module.settings, "max_pattern_length", 10000)
+
+    with caplog.at_level(logging.WARNING):
+        async with lifespan(app):
+            pass
+
+    assert "10000" in caplog.text
+    assert "4096" in caplog.text
+
+
+async def test_lifespan_closes_client_when_body_raises() -> None:
+    """Wyjątek w ciele `async with lifespan(app)` nie może pominąć sprzątania.
+
+    Bez `try/finally` wokół `yield` błąd wewnątrz bloku (np. nieudana asercja
+    w teście, albo awaria w produkcji) pomijał `await client.close()` i zostawiał
+    otwarty `httpx.AsyncClient`. Asercja sprawdza publiczny stan
+    `httpx.AsyncClient.is_closed`, nie sam fakt wywołania close().
+    """
+    httpx_client: httpx.AsyncClient | None = None
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with lifespan(app) as ctx:
+            httpx_client = ctx["client"]._client
+            raise RuntimeError("boom")
+
+    assert httpx_client is not None
+    assert httpx_client.is_closed is True

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -68,14 +68,14 @@ async def test_lifespan_yields_services() -> None:
 
 
 async def test_lifespan_result_store_receives_configured_limits(monkeypatch) -> None:
-    """Wartości niedomyślne, celowo — z dwóch powodów naraz.
+    """Use non-default values on purpose.
 
-    512/False/100 to jednocześnie domyślne wartości `Settings` I domyślne argumenty
-    konstruktora `ResultStore`, więc test na wartościach domyślnych przechodzi
-    również po usunięciu wstrzyknięcia (fałszywy pozytyw) i jest wrażliwy na
-    ambientne `LAW_MCP_MAX_PATTERN_LENGTH`/`LAW_MCP_FILTER_MAX_RECORDS` w środowisku
-    uruchamiającym (fałszywy negatyw). Wartości 256/42 nie pokrywają się z żadnym
-    z tych dwóch źródeł, więc test pada, jeśli wstrzyknięcie zniknie z server.py.
+    512/False/100 are both the `Settings` defaults AND the `ResultStore`
+    constructor defaults, so a defaults-only test still passes after the
+    injection is removed (false positive) and is sensitive to ambient
+    `LAW_MCP_MAX_PATTERN_LENGTH`/`LAW_MCP_FILTER_MAX_RECORDS` in the runner
+    environment (false negative). Values 256/42 match neither source, so the
+    test fails if the injection disappears from server.py.
     """
     from law_scrapper_mcp import server as server_module
 
@@ -90,7 +90,7 @@ async def test_lifespan_result_store_receives_configured_limits(monkeypatch) -> 
 
 
 async def test_lifespan_result_store_uses_clamped_limit(monkeypatch) -> None:
-    """Konfiguracja spoza widełek dociera do ResultStore jako wartość efektywna."""
+    """Out-of-range configuration reaches ResultStore as the effective value."""
     from law_scrapper_mcp import server as server_module
 
     monkeypatch.setattr(server_module.settings, "max_pattern_length", 10000)
@@ -105,12 +105,12 @@ async def test_lifespan_result_store_uses_clamped_limit(monkeypatch) -> None:
 
 
 async def test_lifespan_result_store_floors_zero_record_limit(monkeypatch) -> None:
-    """Podłoga z Taska 3 musi zadziałać, a nie zostać obejściem surowego pola.
+    """The Task 3 floor must apply, not be bypassed via the raw field.
 
-    Bez niej `LAW_MCP_FILTER_MAX_RECORDS=0` czyniłby filter_results trwale
-    niesprawnym: każde wywołanie na niepustym zestawie kończyłoby się odmową.
-    Ten test pada, jeśli server.py wstrzyknie `settings.filter_max_records`
-    zamiast `settings.effective_filter_max_records`.
+    Without it, `LAW_MCP_FILTER_MAX_RECORDS=0` would permanently break
+    filter_results: every call on a non-empty set would be refused. This test
+    fails if server.py injects `settings.filter_max_records` instead of
+    `settings.effective_filter_max_records`.
     """
     from law_scrapper_mcp import server as server_module
 
@@ -121,7 +121,7 @@ async def test_lifespan_result_store_floors_zero_record_limit(monkeypatch) -> No
 
 
 async def test_lifespan_warns_about_clamped_pattern_limit(monkeypatch, caplog) -> None:
-    """Fakt przycięcia jest widoczny w logu przy starcie (D3.1, punkt 1)."""
+    """Clamping must be visible in the startup log"""
     import logging
 
     from law_scrapper_mcp import server as server_module
@@ -137,12 +137,12 @@ async def test_lifespan_warns_about_clamped_pattern_limit(monkeypatch, caplog) -
 
 
 async def test_lifespan_closes_client_when_body_raises() -> None:
-    """Wyjątek w ciele `async with lifespan(app)` nie może pominąć sprzątania.
+    """An exception inside `async with lifespan(app)` must not skip cleanup.
 
-    Bez `try/finally` wokół `yield` błąd wewnątrz bloku (np. nieudana asercja
-    w teście, albo awaria w produkcji) pomijał `await client.close()` i zostawiał
-    otwarty `httpx.AsyncClient`. Asercja sprawdza publiczny stan
-    `httpx.AsyncClient.is_closed`, nie sam fakt wywołania close().
+    Without `try/finally` around `yield`, an error in the block (e.g. a failed
+    assertion in a test, or a production failure) skipped `await client.close()`
+    and left an open `httpx.AsyncClient`. The assertion checks the public
+    `httpx.AsyncClient.is_closed` state, not merely that close() was called.
     """
     httpx_client: httpx.AsyncClient | None = None
 

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from time import perf_counter
 
 import pytest
+import re2
+
+from law_scrapper_mcp.services.pattern_matching import (
+    SUPPORTED_SYNTAX_HINT,
+    PatternValidationError,
+    compile_pattern,
+)
 
 # Wzorzec z PoC audytu: pod silnikiem `re` nie wraca dla łańcuchów tej długości.
 CATASTROPHIC_PATTERN = "(.+)+!"
@@ -27,8 +34,6 @@ def test_long_title_is_representative() -> None:
 @pytest.mark.timeout(5)  # druga warstwa
 def test_re2_engine_is_available_and_linear() -> None:
     """Silnik RE2 kompiluje wzorzec z PoC i zwraca brak dopasowania natychmiast."""
-    import re2
-
     options = re2.Options()
     options.case_sensitive = False
     options.log_errors = False
@@ -47,3 +52,145 @@ def test_re2_engine_is_available_and_linear() -> None:
     # Kontrola pozytywna na tych samych options — bez niej test przeszedłby
     # także dla silnika, który nigdy niczego nie dopasowuje.
     assert re2.compile("Ministra", options).search(LONG_TITLE) is not None
+
+
+# Trzy wzorce udokumentowane w docstringu filter_results.
+DOCUMENTED_PATTERNS = [
+    "zdrow|Minister Zdrowia|apteka|lekar",
+    "budżet.*państw",
+    "podatek|VAT|akcyza",
+]
+
+
+class TestCompilePatternSupportedSyntax:
+    @pytest.mark.parametrize("pattern", DOCUMENTED_PATTERNS)
+    def test_documented_patterns_compile(self, pattern: str) -> None:
+        assert compile_pattern(pattern, max_length=512) is not None
+
+    def test_matching_is_case_insensitive(self) -> None:
+        compiled = compile_pattern("minister zdrowia", max_length=512)
+        assert compiled.search("Rozporządzenie Ministra Zdrowia") is None
+        assert compiled.search("Rozporządzenie MINISTER ZDROWIA") is not None
+
+    def test_unicode_property_matches_polish_diacritics(self) -> None:
+        compiled = compile_pattern(r"\p{L}+", max_length=512)
+        assert compiled.search("żółć") is not None
+
+    def test_posix_class_is_supported(self) -> None:
+        compiled = compile_pattern("[[:alpha:]]+", max_length=512)
+        assert compiled.search("ustawa") is not None
+
+    @pytest.mark.timeout(5)
+    def test_catastrophic_pattern_returns_immediately(self) -> None:
+        compiled = compile_pattern(CATASTROPHIC_PATTERN, max_length=512)
+        assert compiled.search(LONG_TITLE) is None
+
+
+class TestCompilePatternRejections:
+    @pytest.mark.parametrize(
+        "pattern",
+        ["(?=foo)bar", "(?<=foo)bar", "(?!foo)bar", r"(a)\1"],
+    )
+    def test_lookaround_and_backreference_are_rejected(self, pattern: str) -> None:
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern(pattern, max_length=512)
+
+        message = str(exc_info.value)
+        assert "nie jest obsługiwany" in message
+        assert "lookaround" in message.lower()
+
+    def test_pattern_over_limit_is_rejected(self) -> None:
+        with pytest.raises(PatternValidationError, match="za długi"):
+            compile_pattern("a" * 513, max_length=512)
+
+    def test_length_is_checked_before_compilation(self) -> None:
+        """Wzorzec zarazem za długi i składniowo błędny daje błąd DŁUGOŚCI."""
+        pattern = "(" * 600  # > 512 znaków i niedomknięte nawiasy
+
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern(pattern, max_length=512)
+
+        assert "za długi" in str(exc_info.value)
+        assert "nie jest obsługiwany" not in str(exc_info.value)
+
+    def test_length_error_reports_effective_limit_when_clamped(self) -> None:
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern("a" * 5000, max_length=4096, limit_was_clamped=True)
+
+        message = str(exc_info.value)
+        assert "4096" in message
+        assert "przycięcia" in message
+
+    def test_length_error_omits_clamping_note_when_not_clamped(self) -> None:
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern("a" * 600, max_length=512)
+
+        assert "przycięcia" not in str(exc_info.value)
+
+    def test_syntax_error_message_decodes_polish_diacritics(self) -> None:
+        """U3: komunikat błędu ma czytelny znak, nie jego reprezentację bajtową.
+
+        `re2.error` niesie komunikat C++ jako `bytes` w `e.args[0]`
+        (`re2/__init__.py`: `raise error(self._regexp.error())`). Bez
+        dekodowania interpolacja `{e}` dałaby repr w stylu `b'...\\xc5\\xbc-a'`
+        zamiast czytelnego `ż-a` — myląc model językowy będący klientem tego
+        narzędzia. Zdekodowana treść zweryfikowana empirycznie: RE2 dla
+        `"[ż-a]"` cytuje obrażający fragment jako
+        `invalid character class range: ż-a`.
+        """
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern("[ż-a]", max_length=512)
+
+        message = str(exc_info.value)
+        assert "ż" in message
+        assert "\\xc5\\xbc" not in message
+        assert "b'" not in message
+
+    def test_lone_surrogate_is_rejected(self) -> None:
+        """U1: kodowanie UTF-8 rzuca UnicodeError zanim RE2 zobaczy wzorzec.
+
+        `re2/__init__.py` koduje wzorzec do UTF-8 przed przekazaniem do
+        warstwy C++ — samotny surogat UTF-16 nie da się tak zakodować, więc
+        wyjątek powstaje na granicy Python->Python i NIE jest instancją
+        `re2.error`. Bez poszerzenia klauzuli `except` ten wyjątek
+        przechodziłby przez `compile_pattern` niezłapany.
+        """
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern("a\ud800b", max_length=512)
+
+        assert "nie jest obsługiwany" in str(exc_info.value)
+
+    def test_pattern_too_large_is_rejected_with_complexity_message(self) -> None:
+        """U4: przekroczenie budżetu pamięci to inny problem niż zła składnia.
+
+        `.{1000}` powtórzone 15 razy (105 znaków) jest składniowo poprawne,
+        ale przy `RE2_MAX_MEM_BYTES = 2 MiB` przekracza budżet kompilacji —
+        wartość dobrana empirycznie TUŻ POWYŻEJ progu (n=14/98 znaków nadal
+        się kompiluje, n=15/105 już nie). Kalibracja jest celowo ciasna: pełni
+        funkcję strażnika samej stałej `RE2_MAX_MEM_BYTES` — gdyby ktoś
+        podniósł ją z powrotem do 8 MiB, ten wzorzec znów by się skompilował
+        i test głośno by padł, zamiast milcząco przestać cokolwiek sprawdzać.
+        Komunikat musi mówić o złożoności, nie o składni, i nie może zawierać
+        `SUPPORTED_SYNTAX_HINT` — inaczej klient dostaje instrukcję usunięcia
+        lookaroundów/backreferencji, których wzorzec w ogóle nie zawiera.
+        """
+        pattern = ".{1000}" * 15
+
+        with pytest.raises(PatternValidationError) as exc_info:
+            compile_pattern(pattern, max_length=512)
+
+        message = str(exc_info.value)
+        assert "złożon" in message
+        assert SUPPORTED_SYNTAX_HINT not in message
+        assert "nie jest obsługiwany" not in message
+
+
+class TestCompilePatternDoesNotPolluteStderr:
+    def test_rejected_pattern_writes_nothing_to_stderr(self, capfd) -> None:
+        """absl pisze z warstwy C++, więc łapiemy na poziomie deskryptora (capfd)."""
+        with pytest.raises(PatternValidationError):
+            compile_pattern("(?<=foo)bar", max_length=512)
+
+        captured = capfd.readouterr()
+        assert "re2.cc" not in captured.err
+        assert captured.err == ""

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -1,4 +1,4 @@
-"""Testy kompilacji wzorców dostarczonych przez klienta (klaster 1 — F01)."""
+"""Tests for compiling client-supplied patterns"""
 
 from __future__ import annotations
 
@@ -13,11 +13,8 @@ from law_scrapper_mcp.services.pattern_matching import (
     compile_pattern,
 )
 
-# Wzorzec z PoC audytu: pod silnikiem `re` nie wraca dla łańcuchów tej długości.
 CATASTROPHIC_PATTERN = "(.+)+!"
 
-# Tytuł o realnej długości. Audyt zmierzył na 50 aktach z 2024 r.:
-# min 70, śr. 135, maks. 495 znaków.
 LONG_TITLE = (
     "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
     "zmieniające rozporządzenie w sprawie szczegółowego zakresu i formy projektu "
@@ -27,13 +24,13 @@ LONG_TITLE = (
 
 
 def test_long_title_is_representative() -> None:
-    """Test PoC ma sens tylko na łańcuchu powyżej progu wykrywalnego zamrożenia."""
+    """The PoC test is meaningful only on a string above the detectable-freeze threshold."""
     assert len(LONG_TITLE) > 250
 
 
-@pytest.mark.timeout(5)  # druga warstwa
+@pytest.mark.timeout(5)  # secondary layer
 def test_re2_engine_is_available_and_linear() -> None:
-    """Silnik RE2 kompiluje wzorzec z PoC i zwraca brak dopasowania natychmiast."""
+    """RE2 compiles the PoC pattern and returns a miss immediately."""
     options = re2.Options()
     options.case_sensitive = False
     options.log_errors = False
@@ -41,20 +38,20 @@ def test_re2_engine_is_available_and_linear() -> None:
 
     compiled = re2.compile(CATASTROPHIC_PATTERN, options)
 
-    # `re` trzyma GIL podczas backtrackingu, więc wątek-timer pytest-timeout
-    # (metoda "thread", domyślna na Windows) nigdy nie dostaje sterowania —
-    # marker sam w sobie nie jest wiarygodną bramką dla tej klasy awarii.
-    # Mierzymy czas jawnie wewnątrz testu jako pierwszą, rozstrzygającą warstwę.
+    # `re` holds the GIL during backtracking, so the pytest-timeout timer
+    # thread (method "thread", default on Windows) never gets scheduled —
+    # the marker alone is not a reliable gate for this failure class.
+    # Measure time explicitly inside the test as the primary, decisive layer.
     start = perf_counter()
     assert compiled.search(LONG_TITLE) is None
     assert perf_counter() - start < 0.5
 
-    # Kontrola pozytywna na tych samych options — bez niej test przeszedłby
-    # także dla silnika, który nigdy niczego nie dopasowuje.
+    # Positive control on the same options — without it the test would also
+    # pass for an engine that never matches anything.
     assert re2.compile("Ministra", options).search(LONG_TITLE) is not None
 
 
-# Trzy wzorce udokumentowane w docstringu filter_results.
+# Three patterns documented in the filter_results docstring.
 DOCUMENTED_PATTERNS = [
     "zdrow|Minister Zdrowia|apteka|lekar",
     "budżet.*państw",
@@ -104,8 +101,8 @@ class TestCompilePatternRejections:
             compile_pattern("a" * 513, max_length=512)
 
     def test_length_is_checked_before_compilation(self) -> None:
-        """Wzorzec zarazem za długi i składniowo błędny daje błąd DŁUGOŚCI."""
-        pattern = "(" * 600  # > 512 znaków i niedomknięte nawiasy
+        """A pattern that is both too long and syntactically invalid yields a LENGTH error."""
+        pattern = "(" * 600  # > 512 chars and unclosed parentheses
 
         with pytest.raises(PatternValidationError) as exc_info:
             compile_pattern(pattern, max_length=512)
@@ -128,14 +125,14 @@ class TestCompilePatternRejections:
         assert "przycięcia" not in str(exc_info.value)
 
     def test_syntax_error_message_decodes_polish_diacritics(self) -> None:
-        """U3: komunikat błędu ma czytelny znak, nie jego reprezentację bajtową.
+        """The error message must show a readable character, not its byte repr.
 
-        `re2.error` niesie komunikat C++ jako `bytes` w `e.args[0]`
-        (`re2/__init__.py`: `raise error(self._regexp.error())`). Bez
-        dekodowania interpolacja `{e}` dałaby repr w stylu `b'...\\xc5\\xbc-a'`
-        zamiast czytelnego `ż-a` — myląc model językowy będący klientem tego
-        narzędzia. Zdekodowana treść zweryfikowana empirycznie: RE2 dla
-        `"[ż-a]"` cytuje obrażający fragment jako
+        `re2.error` carries the C++ message as `bytes` in `e.args[0]`
+        (`re2/__init__.py`: `raise error(self._regexp.error())`). Without
+        decoding, interpolating `{e}` would produce a repr like
+        `b'...\\xc5\\xbc-a'` instead of readable `ż-a` — confusing the
+        language-model client of this tool. Empirically verified decoded
+        content: for `"[ż-a]"`, RE2 quotes the offending fragment as
         `invalid character class range: ż-a`.
         """
         with pytest.raises(PatternValidationError) as exc_info:
@@ -147,13 +144,13 @@ class TestCompilePatternRejections:
         assert "b'" not in message
 
     def test_lone_surrogate_is_rejected(self) -> None:
-        """U1: kodowanie UTF-8 rzuca UnicodeError zanim RE2 zobaczy wzorzec.
+        """UTF-8 encoding raises UnicodeError before RE2 sees the pattern.
 
-        `re2/__init__.py` koduje wzorzec do UTF-8 przed przekazaniem do
-        warstwy C++ — samotny surogat UTF-16 nie da się tak zakodować, więc
-        wyjątek powstaje na granicy Python->Python i NIE jest instancją
-        `re2.error`. Bez poszerzenia klauzuli `except` ten wyjątek
-        przechodziłby przez `compile_pattern` niezłapany.
+        `re2/__init__.py` encodes the pattern to UTF-8 before handing it to the
+        C++ layer — a lone UTF-16 surrogate cannot be so encoded, so the
+        exception arises on the Python->Python boundary and is NOT an instance
+        of `re2.error`. Without widening the `except` clause this exception
+        would propagate through `compile_pattern` uncaught.
         """
         with pytest.raises(PatternValidationError) as exc_info:
             compile_pattern("a\ud800b", max_length=512)
@@ -161,18 +158,18 @@ class TestCompilePatternRejections:
         assert "nie jest obsługiwany" in str(exc_info.value)
 
     def test_pattern_too_large_is_rejected_with_complexity_message(self) -> None:
-        """U4: przekroczenie budżetu pamięci to inny problem niż zła składnia.
+        """U4: exceeding the memory budget is a different problem from bad syntax.
 
-        `.{1000}` powtórzone 15 razy (105 znaków) jest składniowo poprawne,
-        ale przy `RE2_MAX_MEM_BYTES = 2 MiB` przekracza budżet kompilacji —
-        wartość dobrana empirycznie TUŻ POWYŻEJ progu (n=14/98 znaków nadal
-        się kompiluje, n=15/105 już nie). Kalibracja jest celowo ciasna: pełni
-        funkcję strażnika samej stałej `RE2_MAX_MEM_BYTES` — gdyby ktoś
-        podniósł ją z powrotem do 8 MiB, ten wzorzec znów by się skompilował
-        i test głośno by padł, zamiast milcząco przestać cokolwiek sprawdzać.
-        Komunikat musi mówić o złożoności, nie o składni, i nie może zawierać
-        `SUPPORTED_SYNTAX_HINT` — inaczej klient dostaje instrukcję usunięcia
-        lookaroundów/backreferencji, których wzorzec w ogóle nie zawiera.
+        `.{1000}` repeated 15 times (105 chars) is syntactically valid but at
+        `RE2_MAX_MEM_BYTES = 2 MiB` exceeds the compilation budget — a value
+        chosen empirically JUST ABOVE the threshold (n=14/98 chars still
+        compiles, n=15/105 does not). The calibration is intentionally tight:
+        it guards the `RE2_MAX_MEM_BYTES` constant itself — if someone raised
+        it back to 8 MiB, this pattern would compile again and the test would
+        fail loudly instead of silently stopping to check anything.
+        The message must talk about complexity, not syntax, and must not
+        include `SUPPORTED_SYNTAX_HINT` — otherwise the client gets instructions
+        to remove lookarounds/backreferences the pattern does not contain.
         """
         pattern = ".{1000}" * 15
 
@@ -187,7 +184,7 @@ class TestCompilePatternRejections:
 
 class TestCompilePatternDoesNotPolluteStderr:
     def test_rejected_pattern_writes_nothing_to_stderr(self, capfd) -> None:
-        """absl pisze z warstwy C++, więc łapiemy na poziomie deskryptora (capfd)."""
+        """absl writes from the C++ layer, so we catch at the descriptor level (capfd)."""
         with pytest.raises(PatternValidationError):
             compile_pattern("(?<=foo)bar", max_length=512)
 

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -1,0 +1,49 @@
+"""Testy kompilacji wzorców dostarczonych przez klienta (klaster 1 — F01)."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+import pytest
+
+# Wzorzec z PoC audytu: pod silnikiem `re` nie wraca dla łańcuchów tej długości.
+CATASTROPHIC_PATTERN = "(.+)+!"
+
+# Tytuł o realnej długości. Audyt zmierzył na 50 aktach z 2024 r.:
+# min 70, śr. 135, maks. 495 znaków.
+LONG_TITLE = (
+    "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
+    "zmieniające rozporządzenie w sprawie szczegółowego zakresu i formy projektu "
+    "budowlanego oraz warunków technicznych, jakim powinny odpowiadać budynki "
+    "i ich usytuowanie, w zakresie wymagań ochrony przeciwpożarowej"
+)
+
+
+def test_long_title_is_representative() -> None:
+    """Test PoC ma sens tylko na łańcuchu powyżej progu wykrywalnego zamrożenia."""
+    assert len(LONG_TITLE) > 250
+
+
+@pytest.mark.timeout(5)  # druga warstwa
+def test_re2_engine_is_available_and_linear() -> None:
+    """Silnik RE2 kompiluje wzorzec z PoC i zwraca brak dopasowania natychmiast."""
+    import re2
+
+    options = re2.Options()
+    options.case_sensitive = False
+    options.log_errors = False
+    options.max_mem = 8 * 1024 * 1024
+
+    compiled = re2.compile(CATASTROPHIC_PATTERN, options)
+
+    # `re` trzyma GIL podczas backtrackingu, więc wątek-timer pytest-timeout
+    # (metoda "thread", domyślna na Windows) nigdy nie dostaje sterowania —
+    # marker sam w sobie nie jest wiarygodną bramką dla tej klasy awarii.
+    # Mierzymy czas jawnie wewnątrz testu jako pierwszą, rozstrzygającą warstwę.
+    start = perf_counter()
+    assert compiled.search(LONG_TITLE) is None
+    assert perf_counter() - start < 0.5
+
+    # Kontrola pozytywna na tych samych options — bez niej test przeszedłby
+    # także dla silnika, który nigdy niczego nie dopasowuje.
+    assert re2.compile("Ministra", options).search(LONG_TITLE) is not None

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -124,6 +124,20 @@ class TestCompilePatternRejections:
 
         assert "przycięcia" not in str(exc_info.value)
 
+    def test_many_bounded_ranges_are_rejected_before_compilation(self) -> None:
+        """Concatenated range quantifiers must not monopolize the event loop."""
+        pattern = "a{1,900}" * 62
+        start = perf_counter()
+
+        with pytest.raises(PatternValidationError, match="złożony"):
+            compile_pattern(pattern, max_length=512)
+
+        assert perf_counter() - start < 0.5
+
+    def test_four_variable_ranges_remain_supported(self) -> None:
+        """The structural guard permits the documented, bounded use case."""
+        assert compile_pattern("a{1,2}b{3,5}c{0,3}d{1,4}", max_length=512)
+
     def test_syntax_error_message_decodes_polish_diacritics(self) -> None:
         """The error message must show a readable character, not its byte repr.
 

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -16,7 +16,13 @@ from law_scrapper_mcp.services.pattern_matching import (
 )
 
 CATASTROPHIC_PATTERN = "(.+)+!"
-COMPILE_TIMEOUT_SECONDS = 1
+COMPILE_TIMEOUT_SECONDS = 3
+EXPENSIVE_RANGE_PATTERNS = [
+    "a{1,900}" * 62,
+    r"\Q[\E" + "a{1,900}" * 62,
+    "[a[.b]" + "a{1,900}" * 62 + ".]",
+    "[a[=b]" + "a{1,900}" * 62 + "=]",
+]
 
 LONG_TITLE = (
     "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
@@ -105,6 +111,11 @@ class TestCompilePatternSupportedSyntax:
         compiled = compile_pattern("[[:alpha:]]+", max_length=512)
         assert compiled.search("ustawa") is not None
 
+    def test_negated_posix_class_is_supported(self) -> None:
+        compiled = compile_pattern("[[:^digit:]]+", max_length=512)
+        assert compiled.search("ustawa") is not None
+        assert compiled.search("2024") is None
+
     @pytest.mark.timeout(5)
     def test_catastrophic_pattern_returns_immediately(self) -> None:
         compiled = compile_pattern(CATASTROPHIC_PATTERN, max_length=512)
@@ -152,20 +163,9 @@ class TestCompilePatternRejections:
 
         assert "przycięcia" not in str(exc_info.value)
 
-    def test_many_bounded_ranges_are_rejected_before_compilation(self) -> None:
-        """Concatenated range quantifiers must not monopolize the event loop."""
-        pattern = "a{1,900}" * 62
-        start = perf_counter()
-
-        with pytest.raises(PatternValidationError, match="złożony"):
-            compile_pattern(pattern, max_length=512)
-
-        assert perf_counter() - start < 0.5
-
-    def test_quoted_literal_bypass_is_rejected_before_compilation(self) -> None:
-        """Quoted literals must not hide ranges from the compile-time DoS guard."""
-        pattern = r"\Q[\E" + "a{1,900}" * 62
-
+    @pytest.mark.parametrize("pattern", EXPENSIVE_RANGE_PATTERNS)
+    def test_expensive_range_patterns_are_rejected_in_an_isolated_process(self, pattern: str) -> None:
+        """Known expensive shapes must be rejected before RE2 compilation begins."""
         result = _compile_in_subprocess(pattern)
 
         assert result.returncode == 0, result.stderr

--- a/tests/unit/test_services/test_pattern_matching.py
+++ b/tests/unit/test_services/test_pattern_matching.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from time import perf_counter
 
 import pytest
@@ -14,6 +16,7 @@ from law_scrapper_mcp.services.pattern_matching import (
 )
 
 CATASTROPHIC_PATTERN = "(.+)+!"
+COMPILE_TIMEOUT_SECONDS = 1
 
 LONG_TITLE = (
     "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
@@ -21,6 +24,31 @@ LONG_TITLE = (
     "budowlanego oraz warunków technicznych, jakim powinny odpowiadać budynki "
     "i ich usytuowanie, w zakresie wymagań ochrony przeciwpożarowej"
 )
+
+
+def _compile_in_subprocess(pattern: str) -> subprocess.CompletedProcess[str]:
+    """Run compilation in a process that can be terminated on a regression."""
+    script = """
+import sys
+from law_scrapper_mcp.services.pattern_matching import PatternValidationError, compile_pattern
+
+try:
+    compile_pattern(sys.stdin.read(), max_length=512)
+except PatternValidationError:
+    raise SystemExit(0)
+raise SystemExit(1)
+"""
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            input=pattern,
+            capture_output=True,
+            encoding="utf-8",
+            timeout=COMPILE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"compile_pattern() did not finish within {COMPILE_TIMEOUT_SECONDS} second in an isolated process.")
 
 
 def test_long_title_is_representative() -> None:
@@ -134,9 +162,48 @@ class TestCompilePatternRejections:
 
         assert perf_counter() - start < 0.5
 
+    def test_quoted_literal_bypass_is_rejected_before_compilation(self) -> None:
+        """Quoted literals must not hide ranges from the compile-time DoS guard."""
+        pattern = r"\Q[\E" + "a{1,900}" * 62
+
+        result = _compile_in_subprocess(pattern)
+
+        assert result.returncode == 0, result.stderr
+
     def test_four_variable_ranges_remain_supported(self) -> None:
         """The structural guard permits the documented, bounded use case."""
         assert compile_pattern("a{1,2}b{3,5}c{0,3}d{1,4}", max_length=512)
+
+    def test_five_variable_ranges_are_rejected(self) -> None:
+        """The first range above the documented limit is rejected."""
+        with pytest.raises(PatternValidationError, match="złożony"):
+            compile_pattern("a{1,2}b{3,5}c{0,3}d{1,4}e{5,9}", max_length=512)
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "[[:alpha:]{1,2}]" * 5,
+            r"[\{\]]" * 5,
+            r"\{1,2\}" * 5,
+        ],
+    )
+    def test_literal_braces_do_not_count_as_variable_ranges(self, pattern: str) -> None:
+        """POSIX classes and escaped metacharacters retain their literal meaning."""
+        assert compile_pattern(pattern, max_length=512) is not None
+
+    @pytest.mark.parametrize("pattern", [r"\Qliteral\E", r"\Qunterminated", r"\E"])
+    def test_quoted_literal_constructs_are_rejected(self, pattern: str) -> None:
+        """The supported subset excludes quoted literals before RE2 compilation."""
+        with pytest.raises(PatternValidationError, match="Cytowane literały"):
+            compile_pattern(pattern, max_length=512)
+
+    def test_many_unmatched_braces_are_scanned_in_linear_time(self) -> None:
+        """Malformed braces must not cause repeated suffix scans in the preflight."""
+        start = perf_counter()
+
+        compile_pattern("{" * 4096, max_length=4096)
+
+        assert perf_counter() - start < 0.5
 
     def test_syntax_error_message_decodes_polish_diacritics(self) -> None:
         """The error message must show a readable character, not its byte repr.

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -210,7 +210,7 @@ class TestResultStoreFiltering:
         assert original == 5
 
 
-# Tytuł o realnej długości — audyt zmierzył maks. 495 znaków na aktach z 2024 r.
+# Title of realistic length — audit measured max 495 characters on 2024 acts.
 _REALISTIC_LONG_TITLE = (
     "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
     "zmieniające rozporządzenie w sprawie szczegółowego zakresu i formy projektu "
@@ -220,20 +220,20 @@ _REALISTIC_LONG_TITLE = (
 
 
 class TestResultStoreReDoSRegression:
-    """Regresja F01 — wzorzec katastroficzny nie może zamrozić procesu."""
+    """Catastrophic pattern must not freeze the process"""
 
     async def test_filter_engine_is_re2_not_re(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        """Asercja silnika na BEZPIECZNYM wzorcu, wykonana PRZED testem katastroficznym (U3b).
+        """Engine assertion on a SAFE pattern, run BEFORE the catastrophic test.
 
-        Umyślnie osobny test i osobny, nieszkodliwy wzorzec ("Ustawa"): gdyby
-        `compile_pattern` przestał być importowalny albo wewnętrznie wrócił do
-        `re`, ten test albo od razu rzuci `AttributeError` przy wejściu w
-        `patch(...)`, albo skończy się natychmiast — nie zawiesi joba CI, w
-        przeciwieństwie do umieszczenia tej samej asercji w środku bloku `with`
-        wokół wzorca katastroficznego (gdzie kod po `filter_results` nigdy nie
-        zostałby osiągnięty przy regresji do `re`).
+        Intentionally a separate test and a separate harmless pattern ("Ustawa"):
+        if `compile_pattern` became unimportable or fell back to `re` internally,
+        this test would either raise `AttributeError` immediately on entering
+        `patch(...)`, or finish at once — it would not hang the CI job, unlike
+        placing the same assertion inside the `with` block around the
+        catastrophic pattern (where code after `filter_results` would never be
+        reached on a regression to `re`).
         """
         rs_id = await store.store(sample_results, "test", 5)
 
@@ -250,7 +250,7 @@ class TestResultStoreReDoSRegression:
         ):
             await store.filter_results(rs_id, pattern="Ustawa")
 
-        assert captured, "compile_pattern nie został wywołany"
+        assert captured, "compile_pattern was not called"
         assert type(captured[0]).__module__.startswith("re2")
 
     @pytest.mark.timeout(5)
@@ -273,15 +273,15 @@ class TestResultStoreReDoSRegression:
         wildcard, _ = await store.filter_results(rs_id, pattern="Ustawa.*danych")
         taxes, _ = await store.filter_results(rs_id, pattern="podatek|VAT|akcyza")
 
-        assert len(health) == 2  # dwa tytuły z "Zdrowia" — dopasowanie bez względu na wielkość liter
+        assert len(health) == 2  # two titles with "Zdrowia" — case-insensitive match
         assert len(wildcard) == 1
-        # Fixture zawiera "Ustawa o podatku dochodowym", a wzorzec szuka "podatek".
-        # Zero trafień jest zachowaniem identycznym ze stanem sprzed zmiany silnika.
+        # Fixture has "Ustawa o podatku dochodowym"; the pattern looks for "podatek".
+        # Zero hits matches pre-engine-change behaviour.
         assert len(taxes) == 0
 
     @pytest.mark.timeout(5)
     async def test_alternation_matches_when_form_agrees(self, store: ResultStore) -> None:
-        """Kontrola pozytywna dla wzorca z alternatywą — bez niej test powyżej jest ślepy."""
+        """Positive control for an alternation pattern — without it the test above is blind."""
         results = [_make_act("DU/2024/9", "Ustawa o podatek akcyza VAT")]
         rs_id = await store.store(results, "test", 1)
 
@@ -307,7 +307,7 @@ class TestResultStoreReDoSRegression:
             await store.filter_results(rs_id, pattern="a" * 65)
 
     async def test_pattern_at_limit_is_accepted(self, sample_results: list[ActSummaryOutput]) -> None:
-        """Granica: wzorzec o długości dokładnie równej limitowi nie jest odrzucany."""
+        """Boundary: a pattern whose length equals the limit exactly is not rejected."""
         store = ResultStore(max_sets=5, ttl=60, max_pattern_length=64)
         rs_id = await store.store(sample_results, "test", 5)
 
@@ -317,7 +317,7 @@ class TestResultStoreReDoSRegression:
 
 
 class TestResultStoreRecordCap:
-    """D4 — odmowa wykonania zamiast wyniku częściowego."""
+    """Refuse the call instead of returning a partial result"""
 
     async def test_oversized_set_is_refused(self, sample_results: list[ActSummaryOutput]) -> None:
         store = ResultStore(max_sets=5, ttl=60, max_records=3)
@@ -331,7 +331,7 @@ class TestResultStoreRecordCap:
         assert "Zawęź" in str(exc_info.value)
 
     async def test_refusal_applies_without_pattern_too(self, sample_results: list[ActSummaryOutput]) -> None:
-        """Odmowa dotyczy wywołania, nie tylko ścieżki regex."""
+        """Refusal applies to the call, not only to the regex path."""
         store = ResultStore(max_sets=5, ttl=60, max_records=3)
         rs_id = await store.store(sample_results, "test", 5)
 

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 import pytest
 
 from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput
-from law_scrapper_mcp.services.pattern_matching import PatternValidationError, compile_pattern
+from law_scrapper_mcp.services.pattern_matching import (
+    CompiledPattern,
+    PatternValidationError,
+    compile_pattern,
+)
 from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError, ResultStore
 
 
@@ -237,10 +241,19 @@ class TestResultStoreReDoSRegression:
         """
         rs_id = await store.store(sample_results, "test", 5)
 
-        captured: list[object] = []
+        captured: list[CompiledPattern] = []
 
-        def _spy_compile_pattern(*args: object, **kwargs: object) -> object:
-            compiled = compile_pattern(*args, **kwargs)
+        def _spy_compile_pattern(
+            pattern: str,
+            *,
+            max_length: int,
+            limit_was_clamped: bool = False,
+        ) -> CompiledPattern:
+            compiled = compile_pattern(
+                pattern,
+                max_length=max_length,
+                limit_was_clamped=limit_was_clamped,
+            )
             captured.append(compiled)
             return compiled
 

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import time
+from unittest.mock import patch
 
 import pytest
 
 from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput
-from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultStore
+from law_scrapper_mcp.services.pattern_matching import PatternValidationError, compile_pattern
+from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError, ResultStore
 
 
 def _make_act(
@@ -183,7 +185,7 @@ class TestResultStoreFiltering:
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
         rs_id = await store.store(sample_results, "test", 5)
-        with pytest.raises(ValueError, match="Invalid regex"):
+        with pytest.raises(PatternValidationError, match="nie jest obsługiwany"):
             await store.filter_results(rs_id, pattern="[invalid")
 
     async def test_filter_invalid_field_defaults_to_title(
@@ -206,3 +208,141 @@ class TestResultStoreFiltering:
         filtered, original = await store.filter_results(rs_id)
         assert len(filtered) == 5
         assert original == 5
+
+
+# Tytuł o realnej długości — audyt zmierzył maks. 495 znaków na aktach z 2024 r.
+_REALISTIC_LONG_TITLE = (
+    "Rozporządzenie Ministra Rozwoju i Technologii z dnia 12 kwietnia 2024 r. "
+    "zmieniające rozporządzenie w sprawie szczegółowego zakresu i formy projektu "
+    "budowlanego oraz warunków technicznych, jakim powinny odpowiadać budynki "
+    "i ich usytuowanie, w zakresie wymagań ochrony przeciwpożarowej"
+)
+
+
+class TestResultStoreReDoSRegression:
+    """Regresja F01 — wzorzec katastroficzny nie może zamrozić procesu."""
+
+    async def test_filter_engine_is_re2_not_re(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        """Asercja silnika na BEZPIECZNYM wzorcu, wykonana PRZED testem katastroficznym (U3b).
+
+        Umyślnie osobny test i osobny, nieszkodliwy wzorzec ("Ustawa"): gdyby
+        `compile_pattern` przestał być importowalny albo wewnętrznie wrócił do
+        `re`, ten test albo od razu rzuci `AttributeError` przy wejściu w
+        `patch(...)`, albo skończy się natychmiast — nie zawiesi joba CI, w
+        przeciwieństwie do umieszczenia tej samej asercji w środku bloku `with`
+        wokół wzorca katastroficznego (gdzie kod po `filter_results` nigdy nie
+        zostałby osiągnięty przy regresji do `re`).
+        """
+        rs_id = await store.store(sample_results, "test", 5)
+
+        captured: list[object] = []
+
+        def _spy_compile_pattern(*args: object, **kwargs: object) -> object:
+            compiled = compile_pattern(*args, **kwargs)
+            captured.append(compiled)
+            return compiled
+
+        with patch(
+            "law_scrapper_mcp.services.result_store.compile_pattern",
+            side_effect=_spy_compile_pattern,
+        ):
+            await store.filter_results(rs_id, pattern="Ustawa")
+
+        assert captured, "compile_pattern nie został wywołany"
+        assert type(captured[0]).__module__.startswith("re2")
+
+    @pytest.mark.timeout(5)
+    async def test_catastrophic_pattern_returns_promptly(self, store: ResultStore) -> None:
+        results = [_make_act(f"DU/2024/{i}", _REALISTIC_LONG_TITLE) for i in range(1, 11)]
+        rs_id = await store.store(results, "test", len(results))
+
+        filtered, original = await store.filter_results(rs_id, pattern="(.+)+!", field="title")
+
+        assert filtered == []
+        assert original == 10
+
+    @pytest.mark.timeout(5)
+    async def test_documented_patterns_still_work(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        rs_id = await store.store(sample_results, "test", 5)
+
+        health, _ = await store.filter_results(rs_id, pattern="zdrow|Minister Zdrowia|apteka|lekar")
+        wildcard, _ = await store.filter_results(rs_id, pattern="Ustawa.*danych")
+        taxes, _ = await store.filter_results(rs_id, pattern="podatek|VAT|akcyza")
+
+        assert len(health) == 2  # dwa tytuły z "Zdrowia" — dopasowanie bez względu na wielkość liter
+        assert len(wildcard) == 1
+        # Fixture zawiera "Ustawa o podatku dochodowym", a wzorzec szuka "podatek".
+        # Zero trafień jest zachowaniem identycznym ze stanem sprzed zmiany silnika.
+        assert len(taxes) == 0
+
+    @pytest.mark.timeout(5)
+    async def test_alternation_matches_when_form_agrees(self, store: ResultStore) -> None:
+        """Kontrola pozytywna dla wzorca z alternatywą — bez niej test powyżej jest ślepy."""
+        results = [_make_act("DU/2024/9", "Ustawa o podatek akcyza VAT")]
+        rs_id = await store.store(results, "test", 1)
+
+        filtered, _ = await store.filter_results(rs_id, pattern="podatek|VAT|akcyza")
+
+        assert len(filtered) == 1
+
+    async def test_lookaround_is_rejected_with_polish_message(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        rs_id = await store.store(sample_results, "test", 5)
+
+        with pytest.raises(PatternValidationError) as exc_info:
+            await store.filter_results(rs_id, pattern="(?<=Ustawa)o")
+
+        assert "nie jest obsługiwany" in str(exc_info.value)
+
+    async def test_pattern_over_limit_is_rejected(self, sample_results: list[ActSummaryOutput]) -> None:
+        store = ResultStore(max_sets=5, ttl=60, max_pattern_length=64)
+        rs_id = await store.store(sample_results, "test", 5)
+
+        with pytest.raises(PatternValidationError, match="za długi"):
+            await store.filter_results(rs_id, pattern="a" * 65)
+
+    async def test_pattern_at_limit_is_accepted(self, sample_results: list[ActSummaryOutput]) -> None:
+        """Granica: wzorzec o długości dokładnie równej limitowi nie jest odrzucany."""
+        store = ResultStore(max_sets=5, ttl=60, max_pattern_length=64)
+        rs_id = await store.store(sample_results, "test", 5)
+
+        filtered, _ = await store.filter_results(rs_id, pattern="a" * 64)
+
+        assert filtered == []
+
+
+class TestResultStoreRecordCap:
+    """D4 — odmowa wykonania zamiast wyniku częściowego."""
+
+    async def test_oversized_set_is_refused(self, sample_results: list[ActSummaryOutput]) -> None:
+        store = ResultStore(max_sets=5, ttl=60, max_records=3)
+        rs_id = await store.store(sample_results, "test", 5)
+
+        with pytest.raises(ResultSetTooLargeError) as exc_info:
+            await store.filter_results(rs_id, pattern="Ustawa")
+
+        assert exc_info.value.size == 5
+        assert exc_info.value.limit == 3
+        assert "Zawęź" in str(exc_info.value)
+
+    async def test_refusal_applies_without_pattern_too(self, sample_results: list[ActSummaryOutput]) -> None:
+        """Odmowa dotyczy wywołania, nie tylko ścieżki regex."""
+        store = ResultStore(max_sets=5, ttl=60, max_records=3)
+        rs_id = await store.store(sample_results, "test", 5)
+
+        with pytest.raises(ResultSetTooLargeError):
+            await store.filter_results(rs_id, type_equals="Ustawa")
+
+    async def test_set_at_limit_is_processed(self, sample_results: list[ActSummaryOutput]) -> None:
+        store = ResultStore(max_sets=5, ttl=60, max_records=5)
+        rs_id = await store.store(sample_results, "test", 5)
+
+        filtered, original = await store.filter_results(rs_id, type_equals="Ustawa")
+
+        assert original == 5
+        assert len(filtered) == 2

--- a/tests/unit/test_tool_descriptions.py
+++ b/tests/unit/test_tool_descriptions.py
@@ -1,4 +1,4 @@
-"""Testy opisów narzędzi widocznych dla klienta MCP (klaster 1, D7)."""
+"""Tests for MCP-visible tool descriptions"""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ async def _get_tool(mcp_client, name: str):
 
 
 def _parse_tool_result(result: Any) -> dict[str, Any]:
-    """Wydobądź payload JSON z wyniku `call_tool` FastMCP."""
+    """Extract the JSON payload from a FastMCP `call_tool` result."""
     if hasattr(result, "data") and result.data is not None:
         if isinstance(result.data, dict):
             return result.data
@@ -40,13 +40,14 @@ class TestFilterResultsDescriptions:
         assert "100" in (tool.description or "")
 
     async def test_unsupported_pattern_surfaces_polish_error(self, mcp_client) -> None:
-        """Kryterium 3 na poziomie protokołu: klient dostaje komunikat, nie ciszę.
+        """Criterion 3 at the protocol level: the client gets a message, not silence.
 
-        Zestaw wyników musi realnie istnieć (utworzony przez search_legal_acts),
-        bo `services/result_store.py` waliduje `result_set_id` przed kompilacją
-        wzorca — z nieistniejącym zestawem `compile_pattern` nigdy nie jest wołane
-        i test przechodzi wyłącznie gałęzią "zestaw nie istnieje", bez sprawdzenia
-        ścieżki, którą deklaruje (walidacja składni RE2 w PatternValidationError).
+        The result set must actually exist (created via search_legal_acts),
+        because `services/result_store.py` validates `result_set_id` before
+        compiling the pattern — with a missing set, `compile_pattern` is never
+        called and the test would pass only via the "set not found" branch,
+        without exercising the path it claims to cover (RE2 syntax validation
+        in PatternValidationError).
         """
         search = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
         search_payload = _parse_tool_result(search)

--- a/tests/unit/test_tool_descriptions.py
+++ b/tests/unit/test_tool_descriptions.py
@@ -1,0 +1,61 @@
+"""Testy opisów narzędzi widocznych dla klienta MCP (klaster 1, D7)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+async def _get_tool(mcp_client, name: str):
+    tools = await mcp_client.list_tools()
+    return next(tool for tool in tools if tool.name == name)
+
+
+def _parse_tool_result(result: Any) -> dict[str, Any]:
+    """Wydobądź payload JSON z wyniku `call_tool` FastMCP."""
+    if hasattr(result, "data") and result.data is not None:
+        if isinstance(result.data, dict):
+            return result.data
+        if isinstance(result.data, str):
+            return json.loads(result.data)
+
+    if result.content:
+        return json.loads(result.content[0].text)
+
+    raise ValueError(f"Unexpected tool result format: {result!r}")
+
+
+class TestFilterResultsDescriptions:
+    async def test_pattern_description_names_supported_subset(self, mcp_client) -> None:
+        tool = await _get_tool(mcp_client, "filter_results")
+        description = tool.inputSchema["properties"]["pattern"]["description"]
+
+        assert "lookaround" in description.lower()
+        assert "backrefer" in description.lower()
+        assert r"\p{L}" in description
+
+    async def test_tool_description_mentions_record_limit(self, mcp_client) -> None:
+        tool = await _get_tool(mcp_client, "filter_results")
+
+        assert "100" in (tool.description or "")
+
+    async def test_unsupported_pattern_surfaces_polish_error(self, mcp_client) -> None:
+        """Kryterium 3 na poziomie protokołu: klient dostaje komunikat, nie ciszę.
+
+        Zestaw wyników musi realnie istnieć (utworzony przez search_legal_acts),
+        bo `services/result_store.py` waliduje `result_set_id` przed kompilacją
+        wzorca — z nieistniejącym zestawem `compile_pattern` nigdy nie jest wołane
+        i test przechodzi wyłącznie gałęzią "zestaw nie istnieje", bez sprawdzenia
+        ścieżki, którą deklaruje (walidacja składni RE2 w PatternValidationError).
+        """
+        search = await mcp_client.call_tool("search_legal_acts", {"year": 2024})
+        search_payload = _parse_tool_result(search)
+        result_set_id = search_payload["data"]["result_set_id"]
+
+        result = await mcp_client.call_tool(
+            "filter_results",
+            {"result_set_id": result_set_id, "pattern": "(?<=Ustawa)o"},
+        )
+
+        raw = str(result)
+        assert "nie jest obsługiwany" in raw

--- a/uv.lock
+++ b/uv.lock
@@ -485,6 +485,36 @@ server = [
 ]
 
 [[package]]
+name = "google-re2"
+version = "1.1.20251105"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/60/805c654ba53d685513df955ee745f71920fe8e6a284faf0f9b9dc19b659c/google_re2-1.1.20251105.tar.gz", hash = "sha256:1db14a292ee8303b91e91e7c37e05ac17d3c467f29416c79ac70a78be3e65bda", size = 11676, upload-time = "2025-11-05T14:58:07.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/b9/c441722196598fc3de0f654606ad9975a968c71dc27f516b5a4c9ebb94fd/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9f3cf610e857a7d6f02916cf2b7fc159a5429b8bcb23164500d46e5e233f2924", size = 485549, upload-time = "2025-11-05T14:57:36.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/87/cf588255e5ada1dfb555cc96de35be78438bb0b6faba64df5fe91cecc224/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a21c2807bf4d5d00f206a4ecb3b043aad674e28c451b697b740280f608872078", size = 518840, upload-time = "2025-11-05T14:57:38.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/da66e4ca9be0c51546efc6fb39cf1683c4be8245d8199cb54a9808e8d5fa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8314144eefeee7b88b742081c2038418f677e63901039ca9dbfbc0c5bb6d2911", size = 487037, upload-time = "2025-11-05T14:57:39.467Z" },
+    { url = "https://files.pythonhosted.org/packages/75/dd/24ba65692dd58dca6ff178428551f4e9b776d1489a1251f5c8539e598baa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:28a46be978e53c772139d0f5c9ba69f53563fcdd4225407e4d34d51208b828f1", size = 520285, upload-time = "2025-11-05T14:57:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/61/12/cfdbb92bed24af6474970a75a26145c424f98cfbcc633fdd185985f0efe0/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e", size = 482981, upload-time = "2025-11-05T14:57:41.928Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bf/5fc32ded9279e69a87b88d7261e7e77e2e26325d4e27ca1303a3215e430a/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1920b15dc9b1bdfeca5aa2c60900373c6f27cd1056d53cd299456ea5540a6fff", size = 510366, upload-time = "2025-11-05T14:57:43.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/71/f927ddc7aef1b8d7ccc8a649c335d311f29f3dea658209e30e37720e4891/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87", size = 572390, upload-time = "2025-11-05T14:57:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8c/23075e589038284c9487f41cde531d35873f9da622fb4ac7d1d97bd9086e/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b", size = 591386, upload-time = "2025-11-05T14:57:45.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/858453ef689f6b9895cd02b466836a9d1a6e4ba535d1a275b01bf73baa1d/google_re2-1.1.20251105-1-cp313-cp313-win32.whl", hash = "sha256:67c5c73d7ebcf3f0e0a3b528b41bd8c6c04900f1598aebf05bbdf15a06cf5f9a", size = 433807, upload-time = "2025-11-05T14:57:46.92Z" },
+    { url = "https://files.pythonhosted.org/packages/08/24/6ea87fe682e115ffd296e91eb5c5a266349d1ee8414ce8ece3f99ec1ac84/google_re2-1.1.20251105-1-cp313-cp313-win_amd64.whl", hash = "sha256:0bcba63ad3ea8926fb0c71bb5044e33d405bb9395f5b5444393cd5f28f0bf6d3", size = 491734, upload-time = "2025-11-05T14:57:48.304Z" },
+    { url = "https://files.pythonhosted.org/packages/34/85/32ba71b06f3cf5f9856ae95b3d6463b971742453631a5ae2c5be338ea377/google_re2-1.1.20251105-1-cp313-cp313-win_arm64.whl", hash = "sha256:64ee189ea857f2126c5e42073cfa9b03e9f4cbaf073edbedb575059074841aa0", size = 642654, upload-time = "2025-11-05T14:57:49.602Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7f/7eb238bdcd06182b5f427afd305cf413b7cf4ea71047308bbf35912cf923/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:cc151cf6a585d9ebe711da32b23683fcff40f78db8c8587c7f4b209ef4658809", size = 484719, upload-time = "2025-11-05T14:57:51.326Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/62/eed28eab67f939f4b9383c47b1db11638ade6ac30785c15cb960de85ba43/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7e2186d2c90488c1e11895343941f35ca2f58e9ba6c6b034fd531abe22ef77cc", size = 517698, upload-time = "2025-11-05T14:57:52.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/16/a1e6768513f788bf9c67a1cfe379ef34a793983eee46e4b653e42b558b78/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:41be22359c3dceb582937739b4365dd8e279de24ad0a5b10e653503abaff2ed7", size = 486421, upload-time = "2025-11-05T14:57:53.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/7a97ffd36d451e5a8bfaff2f9022b14807795d588f98227ff96e8da99856/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:f3168d7bbac247c862ea85b2f3c011d3a04bedcb6892b37f14d488f4133b206e", size = 519037, upload-time = "2025-11-05T14:57:55.078Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/8b6f7d94bb689dafdf60de8dd8f8f6296ad40d4d15c933fcda4da7a3a06b/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b", size = 483373, upload-time = "2025-11-05T14:57:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a6/16a09e03d1de128f821869e4252688c21319f5017d9209f4d0e71ea5c951/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:0476b07421b8882b279d5ceb5b760c15c62d581ded95274697fc1227e3869ee6", size = 510167, upload-time = "2025-11-05T14:57:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9d/213dce5de401527369fb5af11096b18c06001d9eb71f3318fe5eba1ec706/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81", size = 573176, upload-time = "2025-11-05T14:57:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/03/be/a8def96aa4a80b233e105767d22e3de961dcde5a04f0a05cb4f3ddb4df78/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116", size = 591483, upload-time = "2025-11-05T14:58:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -685,6 +715,7 @@ version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "google-re2" },
     { name = "httpx" },
     { name = "markdownify" },
     { name = "pdfplumber" },
@@ -708,6 +739,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "google-re2", specifier = ">=1.1.20251105" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "markdownify", specifier = ">=0.14" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
@@ -1519,8 +1551,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

This PR eliminates the **Regular Expression Denial of Service (ReDoS)** vulnerability in `filter_results` where attacker-supplied patterns like `(.+)+!` could permanently freeze the server.

## The Problem

**Before this fix:**
- `filter_results(pattern="(.+)+!", ...)` freezes the server for ~40 seconds and makes `/health` unreachable
- Attack vector: any caller can provide a regex pattern, no authentication required
- Root cause: synchronous `re.compile()` with catastrophic backtracking on the event loop

**After this fix:**
- Patterns are compiled with **RE2** (guarantees linear-time complexity)
- Same pattern now executes in <1ms
- Unsupported syntax (lookaround, backreferences) is rejected before execution with a validation error

## Changes

**8 commits implementing the fix:**

1. **Dependency**: Add `google-re2>=1.1.20251105`
2. **New module**: `services/pattern_matching.py` — single place to safely compile client-supplied patterns with RE2
3. **Configuration**: New settings `LAW_MCP_MAX_PATTERN_LENGTH` (default 512, range 64–4096, clamped with startup warning) and `LAW_MCP_FILTER_MAX_RECORDS` (default 100)
4. **Core fix**: Replace `re.compile()` with `re2.compile()` in `ResultStore.filter_results()`; cap result set size with fail-fast error
5. **Startup**: Inject configuration limits into services; warn if pattern length is clamped
6. **Cleanup**: Remove dead exception handler in `DocumentStore.search()`
7. **Documentation**: Update `filter_results` description to list supported regex subset and record limit
8. **History**: Record changes in CHANGELOG.md

## Test Results

✅ **Unit tests**: 247 passed (was 190, +57 new tests for all 8 tasks)
✅ **Integration tests**: 41 passed
✅ **Quality**: `ruff check`, `ruff format --check`, `mypy` all pass

Regression test `test_catastrophic_pattern_returns_promptly` has a 5-second timeout and fails on the unpatched code.

## Behavioral Changes

- Patterns longer than `LAW_MCP_MAX_PATTERN_LENGTH` (default 512, configurable) are now rejected before compilation
- Result sets larger than `LAW_MCP_FILTER_MAX_RECORDS` (default 100, configurable) now return an error instead of being processed
  - This ensures "no matches found" always means "the entire set was searched" (not just a partial subset)
- Patterns with lookaround `(?=...)`, `(?<=...)`, `(?!...)` or backreferences `\1` are rejected with a validation error

## For Reviewers

- **Security**: Verify `services/pattern_matching.py` uses RE2 API correctly, `max_mem` limit is set, errors are translated to Polish
- **Functional**: Check result-set cap enforcement in `result_store.py` and config-injection in `server.py`
- **Tests**: All new tests in `test_pattern_matching.py`, `test_result_store.py`, `test_config.py`, and `test_server.py` pass