### PR TITLE
fix(client): repair resilience layer (F10, F11, F14, F19, F20, F21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_legal_acts` i `browse_acts` zwracają `page_info`; `browse_acts` przyjmuje `offset` (klaster 2, rozszerzenie zakresu)
 - `MetadataOutput.failed_categories` — jawna lista kategorii metadanych, których nie udało się pobrać (klaster 2, L2)
 - `SearchInActOutput.context_chars_requested` / `context_chars_applied` oraz podpowiedź o przycięciu (klaster 2, L4)
+- `LAW_MCP_API_MAX_ATTEMPTS` (domyślnie 3) i `LAW_MCP_API_RETRY_BUDGET` (domyślnie 45.0 s) — nastawy pętli ponowień klienta API (klaster 4)
 
 ### Changed
+- `SejmApiClient` rozdziela żądanie na trzy warstwy (`_send` / `_execute_with_resilience` / `_request`); translacja wyjątków dzieje się poza pętlą ponowień (klaster 4, F10)
+- Wyłącznik obwodu ma kontrakt `try_acquire` / `release_success` / `release_failure` / `release_probe`; licznik sond rośnie w chwili wpuszczenia, nie po zakończeniu żądania (klaster 4, F21)
+- HTTP 500 i 504 podnoszą `ApiUnavailableError` zamiast ogólnego `SejmApiError` — typ zgadza się teraz z klasyfikacją wyłącznika. `ApiUnavailableError` dziedziczy po `SejmApiError`, więc istniejące bloki `except` łapią tak samo jak dotąd (klaster 4, F19/D7)
 - `search_in_act` buduje kontekst i ustala sekcję wyłącznie dla trafień bieżącej strony; mapowanie sekcji korzysta z wyszukiwania binarnego (klaster 2, L1)
 - `get_system_metadata(category="all")` pobiera pięć kategorii współbieżnie zamiast sekwencyjnie, w granicach semafora klienta (klaster 2, L2)
 - Opis `context_chars` w `inputSchema` narzędzia `search_in_act` podaje granicę 2000 znaków i skutek jej przekroczenia (klaster 2, L4)
@@ -21,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Awaria pobrania pojedynczej kategorii metadanych nie zaniża już cicho `total_count` (klaster 2, L2)
 - `SearchOutput.total_count` jest podnoszony do liczby faktycznie zwróconych rekordów, gdy API Sejmu poda `count` mniejszy od własnej odpowiedzi (klaster 2, Task 8)
+- Błędy statusowe 5xx są ponawiane — dotąd przechwycenie wyjątku przed polityką ponawiania sprawiało, że ponawiany był wyłącznie timeout (klaster 4, F10)
+- Błędy transportowe inne niż timeout (`ConnectError`, `ReadError`, `RemoteProtocolError`) są obsługiwane i nie docierają do warstwy `services/` jako surowe wyjątki `httpx` (klaster 4, F11)
+- Jedna nieudana operacja zwiększa licznik wyłącznika o 1, nie o liczbę prób; sekwencja ponowień ma budżet czasu i przerywa się, gdy równoległy ruch otworzy obwód (klaster 4, F20)
+- Awaria potwierdzona wcześniej w sekwencji jest księgowana także wtedy, gdy wyłącznik odmówi wpuszczenia kolejnej próby — bez tego 5xx zaobserwowane w HALF_OPEN nie przeprowadzało obwodu z powrotem do OPEN (klaster 4, review)
+- `httpx.LocalProtocolError` (źle zbudowane żądanie po naszej stronie) nie jest już ponawiany ani liczony jako awaria wyłącznika — ponowienie odtwarzałoby to samo zepsute żądanie, a wyłącznik otwierałby się przeciwko zdrowemu API (klaster 4, review)
+- `LAW_MCP_API_MAX_ATTEMPTS` i `LAW_MCP_API_RETRY_BUDGET` są walidowane (`ge=1` / `gt=0`); wartość 0 dawała dotąd cichą pętlę zerową bez wysłania żądania (klaster 4, review)
+
+### Removed
+- Zależność `tenacity` — jawna pętla ponowień w `client/sejm_client.py` zastąpiła dekorator `@retry` (klaster 4, D9)
 
 ## [3.0.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,32 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `list_loaded_documents` i `list_result_sets` przyjmują `limit`/`offset` i zwracają `page_info` (klaster 2, L3)
-- `search_legal_acts` i `browse_acts` zwracają `page_info`; `browse_acts` przyjmuje `offset` (klaster 2, rozszerzenie zakresu)
-- `MetadataOutput.failed_categories` — jawna lista kategorii metadanych, których nie udało się pobrać (klaster 2, L2)
-- `SearchInActOutput.context_chars_requested` / `context_chars_applied` oraz podpowiedź o przycięciu (klaster 2, L4)
-- `LAW_MCP_API_MAX_ATTEMPTS` (domyślnie 3) i `LAW_MCP_API_RETRY_BUDGET` (domyślnie 45.0 s) — nastawy pętli ponowień klienta API (klaster 4)
+- `list_loaded_documents` and `list_result_sets` accept `limit`/`offset` and return `page_info` (cluster 2, L3)
+- `search_legal_acts` and `browse_acts` return `page_info`; `browse_acts` accepts `offset` (cluster 2, scope extension)
+- `MetadataOutput.failed_categories` — an explicit list of metadata categories that could not be fetched (cluster 2, L2)
+- `SearchInActOutput.context_chars_requested` / `context_chars_applied`, plus a hint when the context was trimmed (cluster 2, L4)
+- `LAW_MCP_API_MAX_ATTEMPTS` (default 3) and `LAW_MCP_API_RETRY_BUDGET` (default 45.0 s) — settings for the API client retry loop (cluster 4)
 
 ### Changed
-- `SejmApiClient` rozdziela żądanie na trzy warstwy (`_send` / `_execute_with_resilience` / `_request`); translacja wyjątków dzieje się poza pętlą ponowień (klaster 4, F10)
-- Wyłącznik obwodu ma kontrakt `try_acquire` / `release_success` / `release_failure` / `release_probe`; licznik sond rośnie w chwili wpuszczenia, nie po zakończeniu żądania (klaster 4, F21)
-- HTTP 500 i 504 podnoszą `ApiUnavailableError` zamiast ogólnego `SejmApiError` — typ zgadza się teraz z klasyfikacją wyłącznika. `ApiUnavailableError` dziedziczy po `SejmApiError`, więc istniejące bloki `except` łapią tak samo jak dotąd (klaster 4, F19/D7)
-- `search_in_act` buduje kontekst i ustala sekcję wyłącznie dla trafień bieżącej strony; mapowanie sekcji korzysta z wyszukiwania binarnego (klaster 2, L1)
-- `get_system_metadata(category="all")` pobiera pięć kategorii współbieżnie zamiast sekwencyjnie, w granicach semafora klienta (klaster 2, L2)
-- Opis `context_chars` w `inputSchema` narzędzia `search_in_act` podaje granicę 2000 znaków i skutek jej przekroczenia (klaster 2, L4)
+- `SejmApiClient` splits a request into three layers (`_send` / `_execute_with_resilience` / `_request`); exception translation happens outside the retry loop (cluster 4, F10)
+- The circuit breaker gains a `try_acquire` / `release_success` / `release_failure` / `release_probe` contract; the probe counter grows on admission, not on request completion (cluster 4, F21)
+- HTTP 500 and 504 raise `ApiUnavailableError` instead of a generic `SejmApiError`, so the exception type matches the breaker's classification. `ApiUnavailableError` inherits from `SejmApiError`, so existing `except` blocks catch exactly as before (cluster 4, F19/D7)
+- `search_in_act` builds context and resolves sections only for hits on the current page; section mapping uses binary search (cluster 2, L1)
+- `get_system_metadata(category="all")` fetches the five categories concurrently instead of sequentially, within the client semaphore (cluster 2, L2)
+- The `context_chars` description in the `search_in_act` `inputSchema` states the 2000-character limit and the effect of exceeding it (cluster 2, L4)
 
 ### Fixed
-- Awaria pobrania pojedynczej kategorii metadanych nie zaniża już cicho `total_count` (klaster 2, L2)
-- `SearchOutput.total_count` jest podnoszony do liczby faktycznie zwróconych rekordów, gdy API Sejmu poda `count` mniejszy od własnej odpowiedzi (klaster 2, Task 8)
-- Błędy statusowe 5xx są ponawiane — dotąd przechwycenie wyjątku przed polityką ponawiania sprawiało, że ponawiany był wyłącznie timeout (klaster 4, F10)
-- Błędy transportowe inne niż timeout (`ConnectError`, `ReadError`, `RemoteProtocolError`) są obsługiwane i nie docierają do warstwy `services/` jako surowe wyjątki `httpx` (klaster 4, F11)
-- Jedna nieudana operacja zwiększa licznik wyłącznika o 1, nie o liczbę prób; sekwencja ponowień ma budżet czasu i przerywa się, gdy równoległy ruch otworzy obwód (klaster 4, F20)
-- Awaria potwierdzona wcześniej w sekwencji jest księgowana także wtedy, gdy wyłącznik odmówi wpuszczenia kolejnej próby — bez tego 5xx zaobserwowane w HALF_OPEN nie przeprowadzało obwodu z powrotem do OPEN (klaster 4, review)
-- `httpx.LocalProtocolError` (źle zbudowane żądanie po naszej stronie) nie jest już ponawiany ani liczony jako awaria wyłącznika — ponowienie odtwarzałoby to samo zepsute żądanie, a wyłącznik otwierałby się przeciwko zdrowemu API (klaster 4, review)
-- `LAW_MCP_API_MAX_ATTEMPTS` i `LAW_MCP_API_RETRY_BUDGET` są walidowane (`ge=1` / `gt=0`); wartość 0 dawała dotąd cichą pętlę zerową bez wysłania żądania (klaster 4, review)
+- A failure to fetch a single metadata category no longer silently understates `total_count` (cluster 2, L2)
+- `SearchOutput.total_count` is raised to the number of records actually returned when the Sejm API reports a `count` lower than its own response (cluster 2, Task 8)
+- 5xx status errors are retried — until now the exception was intercepted before the retry policy could see it, so only timeouts were ever retried (cluster 4, F10)
+- Transport errors other than timeouts (`ConnectError`, `ReadError`, `RemoteProtocolError`) are handled and no longer reach the `services/` layer as raw `httpx` exceptions (cluster 4, F11)
+- One failed operation increments the breaker counter by 1 rather than by the number of attempts; the retry sequence has a time budget and aborts when concurrent traffic opens the circuit (cluster 4, F20)
+- A failure confirmed earlier in a sequence is booked even when the breaker refuses admission for a later attempt — without this, a 5xx observed in HALF_OPEN never drove the circuit back to OPEN (cluster 4, review)
+- `httpx.LocalProtocolError` (a malformed request built on our own side) is no longer retried or counted as a breaker failure — a retry would rebuild the same broken request, and the breaker would open against a healthy API (cluster 4, review)
+- `LAW_MCP_API_MAX_ATTEMPTS` and `LAW_MCP_API_RETRY_BUDGET` are validated (`ge=1` / `gt=0`); a value of 0 previously produced a silent zero-iteration loop that sent no request at all (cluster 4, review)
+- The `User-Agent` header reports the real server version and a contact address instead of a hardcoded `law-scrapper-mcp/2.0`, so the Sejm API administrator can flag a problem by some route other than a ban (cluster 8, F52)
 
 ### Removed
-- Zależność `tenacity` — jawna pętla ponowień w `client/sejm_client.py` zastąpiła dekorator `@retry` (klaster 4, D9)
+- The `tenacity` dependency — an explicit retry loop in `client/sejm_client.py` replaced the `@retry` decorator (cluster 4, D9)
+- The `LAW_MCP_API_MAX_RETRIES` setting — it had no production consumer, because the attempt count was hardcoded in the `tenacity` decorator. Use `LAW_MCP_API_MAX_ATTEMPTS` instead; unknown `LAW_MCP_`-prefixed variables are ignored, so setting the old name raises no error (cluster 16, F38)
 
 ## [3.0.0] - 2026-08-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,4 +105,8 @@ src/law_scrapper_mcp/
 - Configuration via environment variables with `LAW_MCP_` prefix
 - Logging to stderr, format configurable via `LAW_MCP_LOG_FORMAT` (text/json)
 - All exception messages in Polish
+- Docstrings and code comments in English — including tests. Polish is reserved for strings an
+  agent or end user actually reads: tool parameter descriptions, the "Kiedy użyć" trees inside
+  tool docstrings, and exception messages. A module in `client/` or `services/` with Polish
+  docstrings is a convention violation, not a style preference
 - asyncio.Lock for all in-memory stores (Cache, DocumentStore, ResultStore)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,10 @@ src/law_scrapper_mcp/
 - Configuration via environment variables with `LAW_MCP_` prefix
 - Logging to stderr, format configurable via `LAW_MCP_LOG_FORMAT` (text/json)
 - All exception messages in Polish
-- Docstrings and code comments in English — including tests. Polish is reserved for strings an
-  agent or end user actually reads: tool parameter descriptions, the "Kiedy użyć" trees inside
-  tool docstrings, and exception messages. A module in `client/` or `services/` with Polish
-  docstrings is a convention violation, not a style preference
+- English everywhere except the agent-facing surface: docstrings, code comments (tests included),
+  commit messages, PR text, `README.md` and `CHANGELOG.md`. Polish is reserved for strings an
+  agent or end user actually reads — tool parameter descriptions, the "Kiedy użyć" trees inside
+  tool docstrings, and exception messages. A Polish docstring in `client/` or `services/`, or a
+  Polish `CHANGELOG` entry, is a convention violation, not a style preference. Match the file's
+  convention, not the nearest neighbouring lines — that is how both drifts started
 - asyncio.Lock for all in-memory stores (Cache, DocumentStore, ResultStore)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ src/law_scrapper_mcp/
 - **Pagination**: `PageInfo` model exposed as the `page_info` field with `limit`/`offset` on list and content tools (defaults: 20 items, 10,000 chars; maxima: 100 items, 50,000 chars)
 - **TTL cache**: Async API response cache with configurable TTL (metadata=24h, search=10min)
 - **Error handling**: `@handle_tool_errors` re-raises `ToolExecutionError` so failures surface as `is_error=True`
-- **Async throughout**: httpx.AsyncClient with retry (tenacity), semaphore rate limiting, asyncio.Lock
+- **Async throughout**: httpx.AsyncClient with an explicit retry loop (budget-bounded, `client/failure_policy.py`), semaphore rate limiting, asyncio.Lock
 - **Official MCP SDK**: Tools access lifespan resources via `ctx.request_context.lifespan_context`; HTTP via `streamable_http_app(stateless_http=True, streamable_http_path="/mcp")`
 
 **Tool categories** (13 tools total):

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_PORT` | `7683` | HTTP server port (when using streamable-http) |
 | `LAW_MCP_API_TIMEOUT` | `30.0` | HTTP request timeout in seconds |
 | `LAW_MCP_API_MAX_CONCURRENT` | `10` | Maximum concurrent API requests |
-| `LAW_MCP_API_MAX_RETRIES` | `3` | Maximum API request retries |
+| `LAW_MCP_API_MAX_ATTEMPTS` | `3` | Attempts per operation, retries included |
+| `LAW_MCP_API_RETRY_BUDGET` | `45.0` | Seconds the retry sequence of one operation may plan to wait |
 | `LAW_MCP_CACHE_METADATA_TTL` | `86400` | Metadata cache TTL (24 hours) |
 | `LAW_MCP_CACHE_SEARCH_TTL` | `600` | Search results cache TTL (10 minutes) |
 | `LAW_MCP_CACHE_BROWSE_TTL` | `3600` | Browse results cache TTL (1 hour) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "mcp[cli]==2.0.0",
     "google-re2>=1.1.20251105",
     "httpx>=0.28",
-    "tenacity>=9.0",
     "pydantic>=2.12",
     "pydantic-settings>=2.7",
     "python-dateutil>=2.9",

--- a/src/law_scrapper_mcp/client/circuit_breaker.py
+++ b/src/law_scrapper_mcp/client/circuit_breaker.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-import time
 from enum import StrEnum
+from time import monotonic
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,12 @@ class CircuitBreaker:
         CLOSED  — normal operation, failures are counted
         OPEN    — all requests rejected immediately
         HALF_OPEN — limited test requests allowed to probe recovery
+
+    Synchronization:
+        Sekcje krytyczne nie zawierają `await`, więc pętla zdarzeń nie może ich
+        przerwać w połowie — stan jest atomowy z konstrukcji i nie wymaga
+        `asyncio.Lock`. Warunek jest przypięty testem; dodanie `await` do
+        którejkolwiek z metod `try_acquire` / `release_*` unieważnia to założenie.
     """
 
     def __init__(
@@ -40,47 +46,74 @@ class CircuitBreaker:
         self._failure_count = 0
         self._last_failure_time: float = 0.0
         self._half_open_successes = 0
+        self._half_open_in_flight = 0
 
     @property
     def state(self) -> CircuitState:
-        """Current circuit breaker state."""
-        if self._state == CircuitState.OPEN and time.monotonic() - self._last_failure_time >= self._recovery_timeout:
-            self._state = CircuitState.HALF_OPEN
-            self._half_open_successes = 0
-            logger.info("Circuit breaker transitioning to HALF_OPEN")
+        """Bieżący stan wyłącznika.
+
+        Odczyt jest wolny od efektów ubocznych — przejście OPEN → HALF_OPEN
+        wykonuje wyłącznie `try_acquire()`.
+        """
         return self._state
 
     @property
     def failure_count(self) -> int:
-        """Current failure count."""
+        """Bieżąca liczba zarejestrowanych awarii."""
         return self._failure_count
 
-    def can_execute(self) -> bool:
-        """Check if a request is allowed."""
-        current_state = self.state
-        if current_state == CircuitState.CLOSED:
+    def try_acquire(self) -> bool:
+        """Poproś o zgodę na wykonanie żądania.
+
+        W stanie HALF_OPEN licznik sond rośnie w chwili wpuszczenia, nie po
+        zakończeniu żądania — dzięki temu nie istnieje moment, w którym sonda
+        została dopuszczona, ale nie jest policzona.
+
+        Returns:
+            True, jeśli żądanie wolno wysłać.
+        """
+        if self._state == CircuitState.OPEN and monotonic() - self._last_failure_time >= self._recovery_timeout:
+            self._state = CircuitState.HALF_OPEN
+            self._half_open_in_flight = 0
+            self._half_open_successes = 0
+            logger.info("Circuit breaker transitioning to HALF_OPEN")
+
+        if self._state == CircuitState.CLOSED:
             return True
-        if current_state == CircuitState.HALF_OPEN:
-            return self._half_open_successes < self._half_open_max_calls
+
+        if self._state == CircuitState.HALF_OPEN:
+            if self._half_open_in_flight >= self._half_open_max_calls:
+                return False
+            self._half_open_in_flight += 1
+            return True
+
         return False
 
-    def record_success(self) -> None:
-        """Record a successful request."""
+    def release_success(self) -> None:
+        """Zwolnij sondę po udanym żądaniu."""
         if self._state == CircuitState.HALF_OPEN:
+            self._release_slot()
             self._half_open_successes += 1
             if self._half_open_successes >= self._half_open_max_calls:
                 self._state = CircuitState.CLOSED
                 self._failure_count = 0
+                self._half_open_in_flight = 0
+                self._half_open_successes = 0
                 logger.info("Circuit breaker CLOSED after successful recovery")
         elif self._state == CircuitState.CLOSED:
             self._failure_count = 0
 
-    def record_failure(self) -> None:
-        """Record a failed request."""
+    def release_failure(self) -> None:
+        """Zwolnij sondę i zarejestruj awarię operacji.
+
+        Wołane najwyżej raz na operację użytkownika, po wyczerpaniu prób —
+        próg awarii liczy nieudane żądania, nie nieudane próby sieciowe.
+        """
         self._failure_count += 1
-        self._last_failure_time = time.monotonic()
+        self._last_failure_time = monotonic()
 
         if self._state == CircuitState.HALF_OPEN:
+            self._release_slot()
             self._state = CircuitState.OPEN
             logger.warning("Circuit breaker re-OPENED from HALF_OPEN after failure")
         elif self._failure_count >= self._failure_threshold:
@@ -91,8 +124,33 @@ class CircuitBreaker:
                 self._failure_threshold,
             )
 
+    def release_probe(self) -> None:
+        """Zwolnij sondę bez werdyktu.
+
+        Używane tam, gdzie zdarzenie nie jest ani sukcesem, ani awarią serwera —
+        na przykład przy HTTP 429 albo po próbie, po której nastąpi ponowienie.
+        """
+        self._release_slot()
+
+    def _release_slot(self) -> None:
+        if self._state == CircuitState.HALF_OPEN:
+            self._half_open_in_flight = max(0, self._half_open_in_flight - 1)
+
+    def can_execute(self) -> bool:
+        """Przestarzałe: delegat do `try_acquire()`, usuwany w Task 3."""
+        return self.try_acquire()
+
+    def record_success(self) -> None:
+        """Przestarzałe: delegat do `release_success()`, usuwany w Task 3."""
+        self.release_success()
+
+    def record_failure(self) -> None:
+        """Przestarzałe: delegat do `release_failure()`, usuwany w Task 3."""
+        self.release_failure()
+
     def reset(self) -> None:
-        """Reset the circuit breaker to closed state."""
+        """Przywróć wyłącznik do stanu zamkniętego."""
         self._state = CircuitState.CLOSED
         self._failure_count = 0
         self._half_open_successes = 0
+        self._half_open_in_flight = 0

--- a/src/law_scrapper_mcp/client/circuit_breaker.py
+++ b/src/law_scrapper_mcp/client/circuit_breaker.py
@@ -26,10 +26,10 @@ class CircuitBreaker:
         HALF_OPEN — limited test requests allowed to probe recovery
 
     Synchronization:
-        Sekcje krytyczne nie zawierają `await`, więc pętla zdarzeń nie może ich
-        przerwać w połowie — stan jest atomowy z konstrukcji i nie wymaga
-        `asyncio.Lock`. Warunek jest przypięty testem; dodanie `await` do
-        którejkolwiek z metod `try_acquire` / `release_*` unieważnia to założenie.
+        Critical sections contain no `await`, so the event loop cannot interrupt
+        them halfway — the state is atomic by construction and needs no
+        `asyncio.Lock`. The condition is pinned by a test; adding `await` to any
+        of `try_acquire` / `release_*` invalidates the assumption.
 
         Acquire/release pairing limitation (known, accepted):
         `release_success()`, `release_failure()`, and `release_probe()` determine
@@ -60,27 +60,27 @@ class CircuitBreaker:
 
     @property
     def state(self) -> CircuitState:
-        """Bieżący stan wyłącznika.
+        """Current breaker state.
 
-        Odczyt jest wolny od efektów ubocznych — przejście OPEN → HALF_OPEN
-        wykonuje wyłącznie `try_acquire()`.
+        Reading is free of side effects — the OPEN → HALF_OPEN transition is
+        performed by `try_acquire()` alone.
         """
         return self._state
 
     @property
     def failure_count(self) -> int:
-        """Bieżąca liczba zarejestrowanych awarii."""
+        """Current number of recorded failures."""
         return self._failure_count
 
     def try_acquire(self) -> bool:
-        """Poproś o zgodę na wykonanie żądania.
+        """Ask for permission to perform a request.
 
-        W stanie HALF_OPEN licznik sond rośnie w chwili wpuszczenia, nie po
-        zakończeniu żądania — dzięki temu nie istnieje moment, w którym sonda
-        została dopuszczona, ale nie jest policzona.
+        In HALF_OPEN the probe counter grows on admission, not on completion —
+        so there is no moment in which a probe has been admitted but not yet
+        counted.
 
         Returns:
-            True, jeśli żądanie wolno wysłać.
+            True if the request may be sent.
         """
         if self._state == CircuitState.OPEN and monotonic() - self._last_failure_time >= self._recovery_timeout:
             self._state = CircuitState.HALF_OPEN
@@ -100,7 +100,7 @@ class CircuitBreaker:
         return False
 
     def release_success(self) -> None:
-        """Zwolnij sondę po udanym żądaniu."""
+        """Release a probe after a successful request."""
         if self._state == CircuitState.HALF_OPEN:
             self._release_slot()
             self._half_open_successes += 1
@@ -114,10 +114,11 @@ class CircuitBreaker:
             self._failure_count = 0
 
     def release_failure(self) -> None:
-        """Zwolnij sondę i zarejestruj awarię operacji.
+        """Release a probe and record an operation failure.
 
-        Wołane najwyżej raz na operację użytkownika, po wyczerpaniu prób —
-        próg awarii liczy nieudane żądania, nie nieudane próby sieciowe.
+        Called at most once per user operation — either once attempts run out, or
+        when the breaker refuses admission while a failure is already confirmed.
+        The failure threshold counts failed operations, not failed network attempts.
         """
         self._failure_count += 1
         self._last_failure_time = monotonic()
@@ -135,10 +136,10 @@ class CircuitBreaker:
             )
 
     def release_probe(self) -> None:
-        """Zwolnij sondę bez werdyktu.
+        """Release a probe without a verdict.
 
-        Używane tam, gdzie zdarzenie nie jest ani sukcesem, ani awarią serwera —
-        na przykład przy HTTP 429 albo po próbie, po której nastąpi ponowienie.
+        Used where the event is neither a success nor a server failure — for
+        example on HTTP 429, or after an attempt that will be retried.
         """
         self._release_slot()
 
@@ -147,7 +148,7 @@ class CircuitBreaker:
             self._half_open_in_flight = max(0, self._half_open_in_flight - 1)
 
     def reset(self) -> None:
-        """Przywróć wyłącznik do stanu zamkniętego."""
+        """Restore the breaker to the closed state."""
         self._state = CircuitState.CLOSED
         self._failure_count = 0
         self._half_open_successes = 0

--- a/src/law_scrapper_mcp/client/circuit_breaker.py
+++ b/src/law_scrapper_mcp/client/circuit_breaker.py
@@ -146,18 +146,6 @@ class CircuitBreaker:
         if self._state == CircuitState.HALF_OPEN:
             self._half_open_in_flight = max(0, self._half_open_in_flight - 1)
 
-    def can_execute(self) -> bool:
-        """Przestarzałe: delegat do `try_acquire()`, usuwany w Task 3."""
-        return self.try_acquire()
-
-    def record_success(self) -> None:
-        """Przestarzałe: delegat do `release_success()`, usuwany w Task 3."""
-        self.release_success()
-
-    def record_failure(self) -> None:
-        """Przestarzałe: delegat do `release_failure()`, usuwany w Task 3."""
-        self.release_failure()
-
     def reset(self) -> None:
         """Przywróć wyłącznik do stanu zamkniętego."""
         self._state = CircuitState.CLOSED

--- a/src/law_scrapper_mcp/client/circuit_breaker.py
+++ b/src/law_scrapper_mcp/client/circuit_breaker.py
@@ -30,6 +30,16 @@ class CircuitBreaker:
         przerwać w połowie — stan jest atomowy z konstrukcji i nie wymaga
         `asyncio.Lock`. Warunek jest przypięty testem; dodanie `await` do
         którejkolwiek z metod `try_acquire` / `release_*` unieważnia to założenie.
+
+        Acquire/release pairing limitation (known, accepted):
+        `release_success()`, `release_failure()`, and `release_probe()` determine
+        their behavior based on the breaker's *current* state at release time, not
+        the state when `try_acquire()` was called. A request admitted while CLOSED
+        but completing after the breaker transitions to HALF_OPEN will be treated
+        as a HALF_OPEN release, decrementing a probe slot it never held and — for
+        `release_success()` — counting toward recovery without having passed through
+        HALF_OPEN admission. This is a known architectural limitation, not a bug to
+        silently hide.
     """
 
     def __init__(

--- a/src/law_scrapper_mcp/client/exceptions.py
+++ b/src/law_scrapper_mcp/client/exceptions.py
@@ -27,12 +27,12 @@ class ActNotFoundError(SejmApiError):
 
 
 class ApiUnavailableError(SejmApiError):
-    """API jest chwilowo niedostępne.
+    """API is temporarily unavailable.
 
-    Obejmuje całe 5xx, błędy transportowe oraz odrzucenie przez otwarty
-    wyłącznik obwodu — dokładnie te zdarzenia, które wyłącznik liczy jako
-    awarię. Dziedziczy po `SejmApiError`, więc istniejące bloki
-    `except SejmApiError` łapią je tak samo jak dotąd.
+    Covers the whole 5xx range, transport errors and rejection by an open
+    circuit breaker — exactly the events the breaker counts as a failure.
+    Inherits from `SejmApiError`, so existing `except SejmApiError` blocks catch
+    them just as before.
     """
 
 

--- a/src/law_scrapper_mcp/client/exceptions.py
+++ b/src/law_scrapper_mcp/client/exceptions.py
@@ -27,9 +27,13 @@ class ActNotFoundError(SejmApiError):
 
 
 class ApiUnavailableError(SejmApiError):
-    """API is temporarily unavailable."""
+    """API jest chwilowo niedostępne.
 
-    pass
+    Obejmuje całe 5xx, błędy transportowe oraz odrzucenie przez otwarty
+    wyłącznik obwodu — dokładnie te zdarzenia, które wyłącznik liczy jako
+    awarię. Dziedziczy po `SejmApiError`, więc istniejące bloki
+    `except SejmApiError` łapią je tak samo jak dotąd.
+    """
 
 
 class ContentNotAvailableError(LawScrapperError):

--- a/src/law_scrapper_mcp/client/failure_policy.py
+++ b/src/law_scrapper_mcp/client/failure_policy.py
@@ -1,8 +1,8 @@
-"""Czysta polityka klasyfikacji błędów żądań do API Sejmu.
+"""Pure failure-classification policy for Sejm API requests.
 
-Moduł nie dotyka sieci, zegara ani stanu współdzielonego — dzięki temu cała
-polityka ponawiania jest testowalna offline, łącznie z przemiataniem wszystkich
-kodów statusu. Warstwa sieciowa (`sejm_client`) tylko odczytuje werdykt.
+The module touches neither the network, the clock, nor shared state, which keeps
+the whole retry policy testable offline — including a sweep over every status
+code. The network layer (`sejm_client`) only reads the verdict.
 """
 
 from __future__ import annotations
@@ -18,13 +18,13 @@ DEFAULT_BACKOFF_CAP = 10.0
 
 @dataclass(frozen=True)
 class Verdict:
-    """Werdykt polityki dla pojedynczej nieudanej próby.
+    """Policy verdict for a single failed attempt.
 
     Attributes:
-        retryable: Czy próbę wolno powtórzyć.
-        breaker_failure: Czy zdarzenie liczy się jako awaria wyłącznika obwodu.
-        retry_after: Czas oczekiwania narzucony przez serwer, w sekundach.
-        rate_limited: Czy serwer zgłosił przekroczenie limitu (HTTP 429).
+        retryable: Whether the attempt may be repeated.
+        breaker_failure: Whether the event counts as a circuit breaker failure.
+        retry_after: Wait time imposed by the server, in seconds.
+        rate_limited: Whether the server reported a rate limit (HTTP 429).
     """
 
     retryable: bool
@@ -34,10 +34,10 @@ class Verdict:
 
 
 def _parse_retry_after(raw: str | None) -> float | None:
-    """Odczytaj nagłówek Retry-After wyrażony w sekundach.
+    """Read a Retry-After header expressed in seconds.
 
-    Wariant z datą HTTP jest świadomie pomijany — API Sejmu go nie zwraca,
-    a nieodczytany nagłówek bezpiecznie degraduje się do zwykłego backoffu.
+    The HTTP-date form is deliberately skipped — the Sejm API does not return
+    it, and an unparsed header degrades safely into the ordinary backoff.
     """
     if raw is None:
         return None
@@ -51,13 +51,13 @@ def _parse_retry_after(raw: str | None) -> float | None:
 
 
 def classify_failure(exc: httpx.HTTPError) -> Verdict:
-    """Zaklasyfikuj nieudaną próbę żądania.
+    """Classify a failed request attempt.
 
     Args:
-        exc: Wyjątek podniesiony przez warstwę `httpx`.
+        exc: Exception raised by the `httpx` layer.
 
     Returns:
-        Werdykt mówiący, czy ponawiać i czy liczyć awarię wyłącznika.
+        A verdict stating whether to retry and whether to book a breaker failure.
     """
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
@@ -73,12 +73,15 @@ def classify_failure(exc: httpx.HTTPError) -> Verdict:
             return Verdict(retryable=True, breaker_failure=True, retry_after=retry_after)
         return Verdict(retryable=False, breaker_failure=False)
 
-    # UnsupportedProtocol to błąd konfiguracji, nie sieciowy — nie ponawiaj.
-    if isinstance(exc, httpx.UnsupportedProtocol):
+    # Both are faults on our side of the wire, not the server's: UnsupportedProtocol
+    # is a configuration error, LocalProtocolError means we built a malformed request.
+    # A retry would rebuild the same broken request, so it only costs Sejm traffic —
+    # and booking it as a breaker failure would open the circuit against a healthy API.
+    if isinstance(exc, httpx.UnsupportedProtocol | httpx.LocalProtocolError):
         return Verdict(retryable=False, breaker_failure=False)
 
-    # TimeoutException jest w httpx podklasą TransportError, więc F11 i dotychczasowe
-    # zachowanie dla timeoutów obsługuje jedna gałąź.
+    # TimeoutException is an httpx subclass of TransportError, so a single branch
+    # covers both F11 and the previous behaviour for timeouts.
     if isinstance(exc, httpx.TransportError):
         return Verdict(retryable=True, breaker_failure=True)
 
@@ -91,14 +94,14 @@ def backoff(
     base: float = DEFAULT_BACKOFF_BASE,
     cap: float = DEFAULT_BACKOFF_CAP,
 ) -> float:
-    """Zwróć opóźnienie wykładnicze przed próbą numer `attempt` + 1.
+    """Return the exponential delay preceding attempt number `attempt` + 1.
 
     Args:
-        attempt: Numer właśnie zakończonej próby, liczony od 1.
-        base: Opóźnienie po pierwszej nieudanej próbie, w sekundach.
-        cap: Górne ograniczenie opóźnienia, w sekundach.
+        attempt: Number of the attempt just finished, counted from 1.
+        base: Delay after the first failed attempt, in seconds.
+        cap: Upper bound on the delay, in seconds.
 
     Returns:
-        Liczba sekund oczekiwania.
+        Number of seconds to wait.
     """
     return min(base * (2 ** (attempt - 1)), cap)

--- a/src/law_scrapper_mcp/client/failure_policy.py
+++ b/src/law_scrapper_mcp/client/failure_policy.py
@@ -1,0 +1,103 @@
+"""Czysta polityka klasyfikacji błędów żądań do API Sejmu.
+
+Moduł nie dotyka sieci, zegara ani stanu współdzielonego — dzięki temu cała
+polityka ponawiania jest testowalna offline, łącznie z przemiataniem wszystkich
+kodów statusu. Warstwa sieciowa (`sejm_client`) tylko odczytuje werdykt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+DEFAULT_BACKOFF_BASE = 1.0
+DEFAULT_BACKOFF_CAP = 10.0
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """Werdykt polityki dla pojedynczej nieudanej próby.
+
+    Attributes:
+        retryable: Czy próbę wolno powtórzyć.
+        breaker_failure: Czy zdarzenie liczy się jako awaria wyłącznika obwodu.
+        retry_after: Czas oczekiwania narzucony przez serwer, w sekundach.
+        rate_limited: Czy serwer zgłosił przekroczenie limitu (HTTP 429).
+    """
+
+    retryable: bool
+    breaker_failure: bool
+    retry_after: float | None = None
+    rate_limited: bool = False
+
+
+def _parse_retry_after(raw: str | None) -> float | None:
+    """Odczytaj nagłówek Retry-After wyrażony w sekundach.
+
+    Wariant z datą HTTP jest świadomie pomijany — API Sejmu go nie zwraca,
+    a nieodczytany nagłówek bezpiecznie degraduje się do zwykłego backoffu.
+    """
+    if raw is None:
+        return None
+    try:
+        seconds = float(raw.strip())
+    except ValueError:
+        return None
+    if seconds < 0:
+        return None
+    return seconds
+
+
+def classify_failure(exc: httpx.HTTPError) -> Verdict:
+    """Zaklasyfikuj nieudaną próbę żądania.
+
+    Args:
+        exc: Wyjątek podniesiony przez warstwę `httpx`.
+
+    Returns:
+        Werdykt mówiący, czy ponawiać i czy liczyć awarię wyłącznika.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+        if status == 429:
+            return Verdict(
+                retryable=True,
+                breaker_failure=False,
+                retry_after=retry_after,
+                rate_limited=True,
+            )
+        if 500 <= status <= 599:
+            return Verdict(retryable=True, breaker_failure=True, retry_after=retry_after)
+        return Verdict(retryable=False, breaker_failure=False)
+
+    # UnsupportedProtocol to błąd konfiguracji, nie sieciowy — nie ponawiaj.
+    if isinstance(exc, httpx.UnsupportedProtocol):
+        return Verdict(retryable=False, breaker_failure=False)
+
+    # TimeoutException jest w httpx podklasą TransportError, więc F11 i dotychczasowe
+    # zachowanie dla timeoutów obsługuje jedna gałąź.
+    if isinstance(exc, httpx.TransportError):
+        return Verdict(retryable=True, breaker_failure=True)
+
+    return Verdict(retryable=False, breaker_failure=False)
+
+
+def backoff(
+    attempt: int,
+    *,
+    base: float = DEFAULT_BACKOFF_BASE,
+    cap: float = DEFAULT_BACKOFF_CAP,
+) -> float:
+    """Zwróć opóźnienie wykładnicze przed próbą numer `attempt` + 1.
+
+    Args:
+        attempt: Numer właśnie zakończonej próby, liczony od 1.
+        base: Opóźnienie po pierwszej nieudanej próbie, w sekundach.
+        cap: Górne ograniczenie opóźnienia, w sekundach.
+
+    Returns:
+        Liczba sekund oczekiwania.
+    """
+    return min(base * (2 ** (attempt - 1)), cap)

--- a/src/law_scrapper_mcp/client/failure_policy.py
+++ b/src/law_scrapper_mcp/client/failure_policy.py
@@ -7,6 +7,7 @@ kodów statusu. Warstwa sieciowa (`sejm_client`) tylko odczytuje werdykt.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import httpx
@@ -44,7 +45,7 @@ def _parse_retry_after(raw: str | None) -> float | None:
         seconds = float(raw.strip())
     except ValueError:
         return None
-    if seconds < 0:
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return seconds
 

--- a/src/law_scrapper_mcp/client/sejm_client.py
+++ b/src/law_scrapper_mcp/client/sejm_client.py
@@ -17,6 +17,11 @@ from law_scrapper_mcp.client.exceptions import (
 )
 from law_scrapper_mcp.client.failure_policy import backoff, classify_failure
 
+# Deliberately carries no version: a hardcoded one drifts, and a client built
+# without settings has no honest version to claim. Production passes
+# `Settings.user_agent`, which derives both name and version from configuration.
+DEFAULT_USER_AGENT = "law-scrapper-mcp"
+
 
 async def _delay(seconds: float) -> None:
     """Sole waiting point of the retry loop.
@@ -39,6 +44,7 @@ class SejmApiClient:
         circuit_breaker: CircuitBreaker | None = None,
         max_attempts: int = 3,
         retry_budget: float = 45.0,
+        user_agent: str = DEFAULT_USER_AGENT,
     ):
         self._client: httpx.AsyncClient | None = None
         self._cache = cache
@@ -47,6 +53,7 @@ class SejmApiClient:
         self._circuit_breaker = circuit_breaker or CircuitBreaker()
         self._max_attempts = max_attempts
         self._retry_budget = retry_budget
+        self._user_agent = user_agent
 
     async def start(self) -> None:
         """Initialize the HTTP client."""
@@ -54,7 +61,7 @@ class SejmApiClient:
             self._client = httpx.AsyncClient(
                 timeout=httpx.Timeout(connect=5.0, read=self._timeout, write=10.0, pool=10.0),
                 headers={
-                    "User-Agent": "law-scrapper-mcp/2.0",
+                    "User-Agent": self._user_agent,
                     "Accept": "application/json",
                 },
                 follow_redirects=True,

--- a/src/law_scrapper_mcp/client/sejm_client.py
+++ b/src/law_scrapper_mcp/client/sejm_client.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from time import monotonic
 from typing import Any
 
 import httpx
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
@@ -20,6 +15,15 @@ from law_scrapper_mcp.client.exceptions import (
     ApiUnavailableError,
     SejmApiError,
 )
+from law_scrapper_mcp.client.failure_policy import backoff, classify_failure
+
+
+async def _delay(seconds: float) -> None:
+    """Jedyny punkt oczekiwania w pętli ponowień.
+
+    Wydzielone, żeby testy mogły podmienić opóźnienie zamiast je odczekiwać.
+    """
+    await asyncio.sleep(seconds)
 
 
 class SejmApiClient:
@@ -33,12 +37,16 @@ class SejmApiClient:
         timeout: float = 30.0,
         max_concurrent: int = 10,
         circuit_breaker: CircuitBreaker | None = None,
+        max_attempts: int = 3,
+        retry_budget: float = 45.0,
     ):
         self._client: httpx.AsyncClient | None = None
         self._cache = cache
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._timeout = timeout
         self._circuit_breaker = circuit_breaker or CircuitBreaker()
+        self._max_attempts = max_attempts
+        self._retry_budget = retry_budget
 
     async def start(self) -> None:
         """Initialize the HTTP client."""
@@ -58,33 +66,15 @@ class SejmApiClient:
             await self._client.aclose()
             self._client = None
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(min=1, max=10),
-        retry=retry_if_exception_type((httpx.TimeoutException, httpx.HTTPStatusError)),
-    )
-    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Make HTTP request with retry logic and circuit breaker.
+    async def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Wyślij pojedyncze żądanie HTTP.
 
-        Args:
-            method: HTTP method
-            path: URL path (relative to BASE_URL)
-            **kwargs: Additional httpx request parameters
-
-        Returns:
-            HTTP response
+        Warstwa najniższa: buduje URL, pilnuje semafora i podnosi wyłącznie
+        wyjątki `httpx`. Nie ponawia i nie tłumaczy błędów.
 
         Raises:
-            ActNotFoundError: If resource not found (404)
-            ApiUnavailableError: If API is unavailable (502, 503) or circuit breaker open
-            SejmApiError: For other HTTP errors
+            httpx.HTTPError: Dowolny błąd transportowy lub statusowy.
         """
-        if not self._circuit_breaker.can_execute():
-            raise ApiUnavailableError(
-                "API Sejmu tymczasowo niedostępne (circuit breaker otwarty)",
-                status_code=503,
-            )
-
         if self._client is None:
             await self.start()
 
@@ -93,30 +83,107 @@ class SejmApiClient:
         url = f"{self.BASE_URL}/{path.lstrip('/')}"
 
         async with self._semaphore:
+            response = await self._client.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response
+
+    async def _execute_with_resilience(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Wykonaj żądanie z ponawianiem, budżetem czasu i księgowaniem wyłącznika.
+
+        Warstwa środkowa widzi wyłącznie surowe wyjątki `httpx`, więc żaden blok
+        `except` nie może zmienić typu, zanim polityka zdąży go ocenić.
+
+        Jedna operacja użytkownika rejestruje najwyżej jedną awarię wyłącznika,
+        a stan wyłącznika sprawdzany jest przed każdą próbą — obwód otwarty przez
+        równoległy ruch przerywa sekwencję zamiast dobijać API.
+
+        Raises:
+            ApiUnavailableError: Gdy wyłącznik nie wpuszcza żądania.
+            httpx.HTTPError: Ostatni błąd po wyczerpaniu prób lub budżetu.
+        """
+        deadline = monotonic() + self._retry_budget
+        throttled = False
+
+        for attempt in range(1, self._max_attempts + 1):
+            if not self._circuit_breaker.try_acquire():
+                raise ApiUnavailableError(
+                    "API Sejmu tymczasowo niedostępne (bezpiecznik otwarty)",
+                    status_code=503,
+                )
+
             try:
-                response = await self._client.request(method, url, **kwargs)
-                response.raise_for_status()
-                self._circuit_breaker.record_success()
+                response = await self._send(method, path, **kwargs)
+            except httpx.HTTPError as exc:
+                verdict = classify_failure(exc)
+                delay = verdict.retry_after if verdict.retry_after is not None else backoff(attempt)
+
+                give_up = (
+                    not verdict.retryable
+                    or attempt == self._max_attempts
+                    or (verdict.rate_limited and throttled)
+                    or monotonic() + delay >= deadline
+                )
+
+                if give_up:
+                    if verdict.breaker_failure:
+                        self._circuit_breaker.release_failure()
+                    else:
+                        self._circuit_breaker.release_probe()
+                    raise
+
+                self._circuit_breaker.release_probe()
+                if verdict.rate_limited:
+                    throttled = True
+                await _delay(delay)
+            else:
+                self._circuit_breaker.release_success()
                 return response
-            except httpx.TimeoutException:
-                self._circuit_breaker.record_failure()
-                raise
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 404:
-                    raise ActNotFoundError(path) from e
-                elif e.response.status_code in (502, 503):
-                    self._circuit_breaker.record_failure()
-                    raise ApiUnavailableError(
-                        f"API temporarily unavailable: {e.response.status_code}",
-                        status_code=e.response.status_code,
-                        url=url,
-                    ) from e
-                else:
-                    raise SejmApiError(
-                        f"HTTP {e.response.status_code}: {e.response.text}",
-                        status_code=e.response.status_code,
-                        url=url,
-                    ) from e
+
+        # Nieosiągalne: pętla zawsze kończy się przez return albo raise.
+        raise ApiUnavailableError("API Sejmu nie odpowiedziało w ramach dozwolonych prób", status_code=503)
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Wykonaj żądanie i przetłumacz błędy `httpx` na wyjątki domenowe.
+
+        Warstwa najwyższa. Translacja dzieje się na zewnątrz ponawiania, więc
+        polityka zawsze ocenia oryginalny typ wyjątku.
+
+        Args:
+            method: Metoda HTTP.
+            path: Ścieżka względem BASE_URL.
+            **kwargs: Dodatkowe parametry żądania httpx.
+
+        Returns:
+            Odpowiedź HTTP.
+
+        Raises:
+            ActNotFoundError: Gdy zasób nie istnieje (404).
+            ApiUnavailableError: Gdy API zwróciło 5xx, zawiódł transport
+                albo wyłącznik jest otwarty.
+            SejmApiError: Dla pozostałych błędów po stronie zapytania.
+        """
+        try:
+            return await self._execute_with_resilience(method, path, **kwargs)
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            url = str(exc.request.url)
+            if status == 404:
+                raise ActNotFoundError(path) from exc
+            if 500 <= status <= 599:
+                raise ApiUnavailableError(
+                    f"API Sejmu chwilowo niedostępne (HTTP {status})",
+                    status_code=status,
+                    url=url,
+                ) from exc
+            raise SejmApiError(
+                f"HTTP {status}: {exc.response.text}",
+                status_code=status,
+                url=url,
+            ) from exc
+        except httpx.TransportError as exc:
+            raise ApiUnavailableError(f"Błąd połączenia z API Sejmu: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise SejmApiError(f"Błędne żądanie do API Sejmu: {exc}") from exc
 
     async def get_json(self, path: str, params: dict[str, Any] | None = None, cache_ttl: int | None = None) -> Any:
         """Get JSON response from API with optional caching.

--- a/src/law_scrapper_mcp/client/sejm_client.py
+++ b/src/law_scrapper_mcp/client/sejm_client.py
@@ -19,9 +19,9 @@ from law_scrapper_mcp.client.failure_policy import backoff, classify_failure
 
 
 async def _delay(seconds: float) -> None:
-    """Jedyny punkt oczekiwania w pętli ponowień.
+    """Sole waiting point of the retry loop.
 
-    Wydzielone, żeby testy mogły podmienić opóźnienie zamiast je odczekiwać.
+    Extracted so that tests can substitute the delay instead of sitting it out.
     """
     await asyncio.sleep(seconds)
 
@@ -67,13 +67,13 @@ class SejmApiClient:
             self._client = None
 
     async def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Wyślij pojedyncze żądanie HTTP.
+        """Send a single HTTP request.
 
-        Warstwa najniższa: buduje URL, pilnuje semafora i podnosi wyłącznie
-        wyjątki `httpx`. Nie ponawia i nie tłumaczy błędów.
+        Lowest layer: builds the URL, guards the semaphore and raises `httpx`
+        exceptions only. It neither retries nor translates errors.
 
         Raises:
-            httpx.HTTPError: Dowolny błąd transportowy lub statusowy.
+            httpx.HTTPError: Any transport or status error.
         """
         if self._client is None:
             await self.start()
@@ -88,18 +88,18 @@ class SejmApiClient:
             return response
 
     async def _execute_with_resilience(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Wykonaj żądanie z ponawianiem, budżetem czasu i księgowaniem wyłącznika.
+        """Run a request with retries, a time budget and breaker accounting.
 
-        Warstwa środkowa widzi wyłącznie surowe wyjątki `httpx`, więc żaden blok
-        `except` nie może zmienić typu, zanim polityka zdąży go ocenić.
+        The middle layer sees raw `httpx` exceptions only, so no `except` block
+        can change the type before the policy gets to judge it.
 
-        Jedna operacja użytkownika rejestruje najwyżej jedną awarię wyłącznika,
-        a stan wyłącznika sprawdzany jest przed każdą próbą — obwód otwarty przez
-        równoległy ruch przerywa sekwencję zamiast dobijać API.
+        One user operation records at most one breaker failure, and the breaker
+        state is checked before every attempt — a circuit opened by concurrent
+        traffic aborts the sequence instead of hammering the API further.
 
         Raises:
-            ApiUnavailableError: Gdy wyłącznik nie wpuszcza żądania.
-            httpx.HTTPError: Ostatni błąd po wyczerpaniu prób lub budżetu.
+            ApiUnavailableError: When the breaker refuses admission.
+            httpx.HTTPError: The last error once attempts or budget run out.
         """
         deadline = monotonic() + self._retry_budget
         throttled = False
@@ -107,6 +107,12 @@ class SejmApiClient:
 
         for attempt in range(1, self._max_attempts + 1):
             if not self._circuit_breaker.try_acquire():
+                # A failure already confirmed earlier in this sequence must not
+                # vanish just because admission was refused before we could book
+                # it. In HALF_OPEN that loss would let a still-broken API be
+                # declared recovered by the probes that happened to succeed.
+                if breaker_failure_seen:
+                    self._circuit_breaker.release_failure()
                 raise ApiUnavailableError(
                     "API Sejmu tymczasowo niedostępne (bezpiecznik otwarty)",
                     status_code=503,
@@ -145,28 +151,28 @@ class SejmApiClient:
                 self._circuit_breaker.release_success()
                 return response
 
-        # Nieosiągalne: pętla zawsze kończy się przez return albo raise.
+        # Unreachable: the loop always exits through a return or a raise.
         raise ApiUnavailableError("API Sejmu nie odpowiedziało w ramach dozwolonych prób", status_code=503)
 
     async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Wykonaj żądanie i przetłumacz błędy `httpx` na wyjątki domenowe.
+        """Run a request and translate `httpx` errors into domain exceptions.
 
-        Warstwa najwyższa. Translacja dzieje się na zewnątrz ponawiania, więc
-        polityka zawsze ocenia oryginalny typ wyjątku.
+        Topmost layer. Translation happens outside the retry loop, so the policy
+        always judges the original exception type.
 
         Args:
-            method: Metoda HTTP.
-            path: Ścieżka względem BASE_URL.
-            **kwargs: Dodatkowe parametry żądania httpx.
+            method: HTTP method.
+            path: Path relative to BASE_URL.
+            **kwargs: Additional httpx request parameters.
 
         Returns:
-            Odpowiedź HTTP.
+            HTTP response.
 
         Raises:
-            ActNotFoundError: Gdy zasób nie istnieje (404).
-            ApiUnavailableError: Gdy API zwróciło 5xx, zawiódł transport
-                albo wyłącznik jest otwarty.
-            SejmApiError: Dla pozostałych błędów po stronie zapytania.
+            ActNotFoundError: When the resource does not exist (404).
+            ApiUnavailableError: When the API returned 5xx, transport failed,
+                or the circuit breaker is open.
+            SejmApiError: For the remaining request-side errors.
         """
         try:
             return await self._execute_with_resilience(method, path, **kwargs)

--- a/src/law_scrapper_mcp/client/sejm_client.py
+++ b/src/law_scrapper_mcp/client/sejm_client.py
@@ -103,6 +103,7 @@ class SejmApiClient:
         """
         deadline = monotonic() + self._retry_budget
         throttled = False
+        breaker_failure_seen = False
 
         for attempt in range(1, self._max_attempts + 1):
             if not self._circuit_breaker.try_acquire():
@@ -115,6 +116,8 @@ class SejmApiClient:
                 response = await self._send(method, path, **kwargs)
             except httpx.HTTPError as exc:
                 verdict = classify_failure(exc)
+                if verdict.breaker_failure:
+                    breaker_failure_seen = True
                 delay = verdict.retry_after if verdict.retry_after is not None else backoff(attempt)
 
                 give_up = (
@@ -125,7 +128,7 @@ class SejmApiClient:
                 )
 
                 if give_up:
-                    if verdict.breaker_failure:
+                    if breaker_failure_seen:
                         self._circuit_breaker.release_failure()
                     else:
                         self._circuit_breaker.release_probe()
@@ -135,6 +138,9 @@ class SejmApiClient:
                 if verdict.rate_limited:
                     throttled = True
                 await _delay(delay)
+            except BaseException:
+                self._circuit_breaker.release_probe()
+                raise
             else:
                 self._circuit_breaker.release_success()
                 return response

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -12,6 +12,10 @@ MAX_PATTERN_LENGTH_FLOOR = 64
 MAX_PATTERN_LENGTH_CEILING = 4096
 FILTER_MAX_RECORDS_FLOOR = 1
 
+# Contact channel advertised to api.sejm.gov.pl. The API is run by a state
+# institution, so its administrator needs a way to reach us that is not a ban.
+USER_AGENT_CONTACT = "https://github.com/numikel/law-scrapper-mcp"
+
 
 class Settings(BaseSettings):
     """Application settings with environment variable support."""
@@ -39,7 +43,6 @@ class Settings(BaseSettings):
     # API client
     api_timeout: float = 30.0
     api_max_concurrent: int = 10
-    api_max_retries: int = 3
     # Bounded so that a misconfigured value degrades loudly at startup instead of
     # silently turning the retry loop into zero attempts.
     api_max_attempts: int = Field(default=3, ge=1)
@@ -97,6 +100,16 @@ class Settings(BaseSettings):
     # Server info
     server_name: str = "law-scrapper-mcp"
     server_version: str = "3.0.0"
+
+    @property
+    def user_agent(self) -> str:
+        """Identity sent to api.sejm.gov.pl on every request.
+
+        Derived rather than written out, so the header cannot drift away from
+        the version the server actually reports — which is exactly what happened
+        while it was a literal in the client.
+        """
+        return f"{self.server_name}/{self.server_version} (+{USER_AGENT_CONTACT})"
 
 
 def log_pattern_limit_clamping(current: Settings, log: logging.Logger) -> None:

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -40,6 +40,8 @@ class Settings(BaseSettings):
     api_timeout: float = 30.0
     api_max_concurrent: int = 10
     api_max_retries: int = 3
+    api_max_attempts: int = 3
+    api_retry_budget: float = 45.0
 
     # Cache TTL (seconds)
     cache_metadata_ttl: int = 86400

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 MAX_PATTERN_LENGTH_FLOOR = 64
@@ -40,8 +40,10 @@ class Settings(BaseSettings):
     api_timeout: float = 30.0
     api_max_concurrent: int = 10
     api_max_retries: int = 3
-    api_max_attempts: int = 3
-    api_retry_budget: float = 45.0
+    # Bounded so that a misconfigured value degrades loudly at startup instead of
+    # silently turning the retry loop into zero attempts.
+    api_max_attempts: int = Field(default=3, ge=1)
+    api_retry_budget: float = Field(default=45.0, gt=0)
 
     # Cache TTL (seconds)
     cache_metadata_ttl: int = 86400

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -124,6 +124,7 @@ async def lifespan(_server: MCPServer[AppContext]) -> AsyncIterator[AppContext]:
         circuit_breaker=circuit_breaker,
         max_attempts=settings.api_max_attempts,
         retry_budget=settings.api_retry_budget,
+        user_agent=settings.user_agent,
     )
     await client.start()
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -122,6 +122,8 @@ async def lifespan(_server: MCPServer[AppContext]) -> AsyncIterator[AppContext]:
         timeout=settings.api_timeout,
         max_concurrent=settings.api_max_concurrent,
         circuit_breaker=circuit_breaker,
+        max_attempts=settings.api_max_attempts,
+        retry_budget=settings.api_retry_budget,
     )
     await client.start()
 

--- a/tests/unit/test_client/__init__.py
+++ b/tests/unit/test_client/__init__.py
@@ -1,0 +1,1 @@
+"""Testy warstwy klienta HTTP."""

--- a/tests/unit/test_client/test_circuit_breaker.py
+++ b/tests/unit/test_client/test_circuit_breaker.py
@@ -1,4 +1,4 @@
-"""Testy tranzycji i wyścigu wyłącznika obwodu (F14, F21, D10; kryteria 5.4-5.6)."""
+"""Circuit breaker transition and race tests (F14, F21, D10; criteria 5.4-5.6)."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def test_starts_closed_and_admits_requests() -> None:
 
 
 def test_closed_to_open_after_threshold_failures() -> None:
-    """F14: tranzycja CLOSED → OPEN."""
+    """F14: the CLOSED -> OPEN transition."""
     breaker = CircuitBreaker(failure_threshold=5)
     _open_the_breaker(breaker, failures=4)
     assert breaker.state is CircuitState.CLOSED
@@ -52,7 +52,7 @@ def test_success_in_closed_resets_failure_count() -> None:
 
 
 def test_open_to_half_open_after_recovery_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    """F14: tranzycja OPEN → HALF_OPEN, sterowana wstrzykniętym zegarem (O6)."""
+    """F14: the OPEN -> HALF_OPEN transition, driven by an injected clock (O6)."""
     now = 1000.0
     monkeypatch.setattr(breaker_module, "monotonic", lambda: now)
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
@@ -65,7 +65,7 @@ def test_open_to_half_open_after_recovery_timeout(monkeypatch: pytest.MonkeyPatc
 
 
 def test_reading_state_does_not_transition(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ustalenie 1.2: getter przestaje być mutatorem — sam odczyt nic nie zmienia."""
+    """Finding 1.2: the getter stops being a mutator — reading changes nothing."""
     now = 1000.0
     monkeypatch.setattr(breaker_module, "monotonic", lambda: now)
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
@@ -79,7 +79,7 @@ def test_reading_state_does_not_transition(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_half_open_to_closed_after_enough_successes() -> None:
-    """F14: tranzycja HALF_OPEN → CLOSED."""
+    """F14: the HALF_OPEN -> CLOSED transition."""
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
     _open_the_breaker(breaker, failures=1)
     for _ in range(3):
@@ -90,7 +90,7 @@ def test_half_open_to_closed_after_enough_successes() -> None:
 
 
 def test_half_open_to_open_on_single_failure() -> None:
-    """F14: tranzycja HALF_OPEN → OPEN."""
+    """F14: the HALF_OPEN -> OPEN transition."""
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
     _open_the_breaker(breaker, failures=1)
     assert breaker.try_acquire() is True
@@ -111,11 +111,11 @@ def test_reset_returns_to_closed() -> None:
 
 
 def test_half_open_admits_exactly_max_calls() -> None:
-    """F21: licznik sond rośnie przy wpuszczeniu, nie przy zakończeniu żądania.
+    """F21: the probe counter grows on admission, not on request completion.
 
-    Pada na kodzie sprzed zmiany: `can_execute()` czyta `_half_open_successes`,
-    który rośnie dopiero w `record_success()`, więc dziesięć sprawdzeń z rzędu
-    zwraca dziesięć zgód.
+    Red against the pre-change code: `can_execute()` reads `_half_open_successes`,
+    which only grows inside `record_success()`, so ten checks in a row return ten
+    admissions.
     """
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
     _open_the_breaker(breaker, failures=1)
@@ -127,7 +127,7 @@ def test_half_open_admits_exactly_max_calls() -> None:
 
 @pytest.mark.asyncio
 async def test_half_open_admits_exactly_max_calls_under_concurrency() -> None:
-    """F21, kryterium 5.5: dziesięć współbieżnych operacji, dokładnie trzy sondy."""
+    """F21, criterion 5.5: ten concurrent operations, exactly three probes."""
     breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
     _open_the_breaker(breaker, failures=1)
 
@@ -140,7 +140,7 @@ async def test_half_open_admits_exactly_max_calls_under_concurrency() -> None:
 
 
 def test_release_probe_frees_a_slot_without_a_verdict() -> None:
-    """D6: 429 zwalnia sondę, ale nie zmienia ani stanu, ani licznika awarii."""
+    """D6: 429 frees a probe but changes neither state nor the failure count."""
     breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=1)
     _open_the_breaker(breaker, failures=5)
     assert breaker.try_acquire() is True
@@ -162,10 +162,10 @@ def _has_await(func: Any) -> bool:
     ["try_acquire", "release_success", "release_failure", "release_probe", "reset"],
 )
 def test_critical_section_contains_no_await(name: str) -> None:
-    """D10, kryterium 5.4: atomowość bez asyncio.Lock stoi na braku await.
+    """D10, criterion 5.4: atomicity without asyncio.Lock rests on having no await.
 
-    Dodanie await do sekcji krytycznej otworzyłoby okno przeplotu, którego nie
-    strzeże żadna blokada — dlatego warunek jest przypięty testem, a nie komentarzem.
+    Adding await to a critical section would open an interleaving window guarded by
+    no lock — which is why the condition is pinned by a test, not by a comment.
     """
     method = getattr(CircuitBreaker, name)
     assert not inspect.iscoroutinefunction(method)

--- a/tests/unit/test_client/test_circuit_breaker.py
+++ b/tests/unit/test_client/test_circuit_breaker.py
@@ -1,0 +1,172 @@
+"""Testy tranzycji i wyścigu wyłącznika obwodu (F14, F21, D10; kryteria 5.4-5.6)."""
+
+from __future__ import annotations
+
+import asyncio
+import dis
+import inspect
+from typing import Any
+
+import pytest
+
+from law_scrapper_mcp.client import circuit_breaker as breaker_module
+from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker, CircuitState
+
+
+def _open_the_breaker(breaker: CircuitBreaker, failures: int = 5) -> None:
+    for _ in range(failures):
+        assert breaker.try_acquire() is True
+        breaker.release_failure()
+
+
+def test_starts_closed_and_admits_requests() -> None:
+    breaker = CircuitBreaker()
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.try_acquire() is True
+
+
+def test_closed_to_open_after_threshold_failures() -> None:
+    """F14: tranzycja CLOSED → OPEN."""
+    breaker = CircuitBreaker(failure_threshold=5)
+    _open_the_breaker(breaker, failures=4)
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.try_acquire() is True
+    breaker.release_failure()
+    assert breaker.state is CircuitState.OPEN
+    assert breaker.failure_count == 5
+
+
+def test_open_rejects_without_admitting() -> None:
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=60.0)
+    _open_the_breaker(breaker, failures=1)
+    assert breaker.try_acquire() is False
+
+
+def test_success_in_closed_resets_failure_count() -> None:
+    breaker = CircuitBreaker(failure_threshold=5)
+    _open_the_breaker(breaker, failures=3)
+    assert breaker.failure_count == 3
+    assert breaker.try_acquire() is True
+    breaker.release_success()
+    assert breaker.failure_count == 0
+
+
+def test_open_to_half_open_after_recovery_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F14: tranzycja OPEN → HALF_OPEN, sterowana wstrzykniętym zegarem (O6)."""
+    now = 1000.0
+    monkeypatch.setattr(breaker_module, "monotonic", lambda: now)
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+    _open_the_breaker(breaker, failures=1)
+    assert breaker.try_acquire() is False
+
+    now = 1031.0
+    assert breaker.try_acquire() is True
+    assert breaker.state is CircuitState.HALF_OPEN
+
+
+def test_reading_state_does_not_transition(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ustalenie 1.2: getter przestaje być mutatorem — sam odczyt nic nie zmienia."""
+    now = 1000.0
+    monkeypatch.setattr(breaker_module, "monotonic", lambda: now)
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+    _open_the_breaker(breaker, failures=1)
+
+    now = 1031.0
+    assert breaker.state is CircuitState.OPEN
+    assert breaker.state is CircuitState.OPEN
+    assert breaker.try_acquire() is True
+    assert breaker.state is CircuitState.HALF_OPEN
+
+
+def test_half_open_to_closed_after_enough_successes() -> None:
+    """F14: tranzycja HALF_OPEN → CLOSED."""
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
+    _open_the_breaker(breaker, failures=1)
+    for _ in range(3):
+        assert breaker.try_acquire() is True
+        breaker.release_success()
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.failure_count == 0
+
+
+def test_half_open_to_open_on_single_failure() -> None:
+    """F14: tranzycja HALF_OPEN → OPEN."""
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
+    _open_the_breaker(breaker, failures=1)
+    assert breaker.try_acquire() is True
+    breaker.release_failure()
+    assert breaker.state is CircuitState.OPEN
+
+
+def test_reset_returns_to_closed() -> None:
+    """F14: reset()."""
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
+    _open_the_breaker(breaker, failures=1)
+    assert breaker.try_acquire() is True
+    breaker.reset()
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.failure_count == 0
+    for _ in range(10):
+        assert breaker.try_acquire() is True
+
+
+def test_half_open_admits_exactly_max_calls() -> None:
+    """F21: licznik sond rośnie przy wpuszczeniu, nie przy zakończeniu żądania.
+
+    Pada na kodzie sprzed zmiany: `can_execute()` czyta `_half_open_successes`,
+    który rośnie dopiero w `record_success()`, więc dziesięć sprawdzeń z rzędu
+    zwraca dziesięć zgód.
+    """
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
+    _open_the_breaker(breaker, failures=1)
+
+    verdicts = [breaker.try_acquire() for _ in range(10)]
+    assert verdicts.count(True) == 3
+    assert verdicts.count(False) == 7
+
+
+@pytest.mark.asyncio
+async def test_half_open_admits_exactly_max_calls_under_concurrency() -> None:
+    """F21, kryterium 5.5: dziesięć współbieżnych operacji, dokładnie trzy sondy."""
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=3)
+    _open_the_breaker(breaker, failures=1)
+
+    async def probe() -> bool:
+        await asyncio.sleep(0)
+        return breaker.try_acquire()
+
+    verdicts = await asyncio.gather(*(probe() for _ in range(10)))
+    assert sum(verdicts) == 3
+
+
+def test_release_probe_frees_a_slot_without_a_verdict() -> None:
+    """D6: 429 zwalnia sondę, ale nie zmienia ani stanu, ani licznika awarii."""
+    breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=1)
+    _open_the_breaker(breaker, failures=5)
+    assert breaker.try_acquire() is True
+    assert breaker.try_acquire() is False
+
+    breaker.release_probe()
+    assert breaker.state is CircuitState.HALF_OPEN
+    assert breaker.failure_count == 5
+    assert breaker.try_acquire() is True
+
+
+def _has_await(func: Any) -> bool:
+    target = inspect.unwrap(func)
+    return any(instruction.opname == "GET_AWAITABLE" for instruction in dis.get_instructions(target))
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["try_acquire", "release_success", "release_failure", "release_probe", "reset"],
+)
+def test_critical_section_contains_no_await(name: str) -> None:
+    """D10, kryterium 5.4: atomowość bez asyncio.Lock stoi na braku await.
+
+    Dodanie await do sekcji krytycznej otworzyłoby okno przeplotu, którego nie
+    strzeże żadna blokada — dlatego warunek jest przypięty testem, a nie komentarzem.
+    """
+    method = getattr(CircuitBreaker, name)
+    assert not inspect.iscoroutinefunction(method)
+    assert not _has_await(method)

--- a/tests/unit/test_client/test_failure_policy.py
+++ b/tests/unit/test_client/test_failure_policy.py
@@ -45,7 +45,7 @@ def test_429_honours_numeric_retry_after() -> None:
     assert verdict.retry_after == pytest.approx(2.0)
 
 
-@pytest.mark.parametrize("raw", ["", "later", "-5", "Wed, 21 Oct 2026 07:28:00 GMT"])
+@pytest.mark.parametrize("raw", ["", "later", "-5", "Wed, 21 Oct 2026 07:28:00 GMT", "inf", "nan", "1e400"])
 def test_unparsable_retry_after_falls_back_to_backoff(raw: str) -> None:
     """Nagłówek w formacie daty lub śmieciowy nie może wywrócić klasyfikacji."""
     verdict = classify_failure(_status_error(429, {"Retry-After": raw}))

--- a/tests/unit/test_client/test_failure_policy.py
+++ b/tests/unit/test_client/test_failure_policy.py
@@ -1,4 +1,4 @@
-"""Testy czystej polityki klasyfikacji błędów (ustalenie F14, kryterium 5.6)."""
+"""Tests for the pure failure-classification policy (finding F14, criterion 5.6)."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ def _status_error(status: int, headers: dict[str, str] | None = None) -> httpx.H
 
 @pytest.mark.parametrize("status", [500, 501, 502, 503, 504, 505, 599])
 def test_5xx_is_retryable_and_counts_as_breaker_failure(status: int) -> None:
-    """F19: całe 5xx otwiera obwód, nie tylko 502/503."""
+    """F19: the whole 5xx range opens the circuit, not just 502/503."""
     verdict = classify_failure(_status_error(status))
     assert verdict.retryable is True
     assert verdict.breaker_failure is True
@@ -26,14 +26,14 @@ def test_5xx_is_retryable_and_counts_as_breaker_failure(status: int) -> None:
 
 @pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 410, 418, 422])
 def test_4xx_other_than_429_is_terminal(status: int) -> None:
-    """Błąd zapytania, nie serwera — ponawianie obciążałoby Sejm bez szansy na inny wynik."""
+    """A request error, not a server one — retrying would load Sejm for nothing."""
     verdict = classify_failure(_status_error(status))
     assert verdict.retryable is False
     assert verdict.breaker_failure is False
 
 
 def test_429_is_retryable_but_never_a_breaker_failure() -> None:
-    """D6: 429 znaczy 'my przesadzamy', nie 'Sejm padł'."""
+    """D6: 429 means "we are overdoing it", not "Sejm is down"."""
     verdict = classify_failure(_status_error(429))
     assert verdict.retryable is True
     assert verdict.breaker_failure is False
@@ -47,7 +47,7 @@ def test_429_honours_numeric_retry_after() -> None:
 
 @pytest.mark.parametrize("raw", ["", "later", "-5", "Wed, 21 Oct 2026 07:28:00 GMT", "inf", "nan", "1e400"])
 def test_unparsable_retry_after_falls_back_to_backoff(raw: str) -> None:
-    """Nagłówek w formacie daty lub śmieciowy nie może wywrócić klasyfikacji."""
+    """An HTTP-date or junk header must not upset the classification."""
     verdict = classify_failure(_status_error(429, {"Retry-After": raw}))
     assert verdict.retryable is True
     assert verdict.retry_after is None
@@ -62,12 +62,14 @@ def test_unparsable_retry_after_falls_back_to_backoff(raw: str) -> None:
         httpx.ConnectTimeout("przekroczono czas łączenia", request=REQUEST),
         httpx.ReadTimeout("przekroczono czas odczytu", request=REQUEST),
         httpx.PoolTimeout("przekroczono czas puli", request=REQUEST),
+        httpx.WriteTimeout("przekroczono czas zapisu", request=REQUEST),
         httpx.RemoteProtocolError("błąd protokołu", request=REQUEST),
         httpx.ProxyError("błąd proxy", request=REQUEST),
+        httpx.CloseError("błąd zamknięcia", request=REQUEST),
     ],
 )
 def test_transport_errors_are_retryable_failures(exc: httpx.TransportError) -> None:
-    """F11: jeden blok obejmuje timeouty i pozostałe błędy transportowe."""
+    """F11: one branch covers timeouts and the remaining transport errors."""
     verdict = classify_failure(exc)
     assert verdict.retryable is True
     assert verdict.breaker_failure is True
@@ -79,10 +81,16 @@ def test_transport_errors_are_retryable_failures(exc: httpx.TransportError) -> N
         httpx.DecodingError("błąd dekodowania", request=REQUEST),
         httpx.TooManyRedirects("za dużo przekierowań", request=REQUEST),
         httpx.UnsupportedProtocol("nieobsługiwany protokół", request=REQUEST),
+        httpx.LocalProtocolError("źle zbudowane żądanie"),
     ],
 )
 def test_non_transport_request_errors_are_terminal(exc: httpx.RequestError) -> None:
-    """Błędy kontraktu lub konfiguracji — ponowienie nigdy nie pomoże."""
+    """Contract or configuration errors — a retry can never help.
+
+    `LocalProtocolError` sits under `TransportError` in the httpx hierarchy but is
+    a fault on our side of the wire: retrying rebuilds the same malformed request,
+    costing Sejm traffic (O1) and risking a circuit opened against a healthy API.
+    """
     verdict = classify_failure(exc)
     assert verdict.retryable is False
     assert verdict.breaker_failure is False
@@ -90,7 +98,7 @@ def test_non_transport_request_errors_are_terminal(exc: httpx.RequestError) -> N
 
 @pytest.mark.parametrize("status", list(range(100, 600)))
 def test_every_status_code_has_a_defined_verdict(status: int) -> None:
-    """5.6: przemiatanie 100–599 — żaden kod nie może wypaść z klasyfikacji."""
+    """5.6: sweep 100-599 — no status code may fall out of the classification."""
     verdict = classify_failure(_status_error(status))
     assert isinstance(verdict, Verdict)
     if 500 <= status <= 599:
@@ -102,7 +110,7 @@ def test_every_status_code_has_a_defined_verdict(status: int) -> None:
 
 
 def test_verdict_is_immutable() -> None:
-    """Werdykt jest wartością, nie stanem — nikt go po drodze nie podmieni."""
+    """The verdict is a value, not state — nobody can swap it along the way."""
     verdict = classify_failure(_status_error(503))
     with pytest.raises(AttributeError):
         verdict.retryable = False  # type: ignore[misc]
@@ -113,5 +121,5 @@ def test_verdict_is_immutable() -> None:
     [(1, 1.0), (2, 2.0), (3, 4.0), (4, 8.0), (5, 10.0), (10, 10.0)],
 )
 def test_backoff_is_exponential_and_capped(attempt: int, expected: float) -> None:
-    """Zachowuje charakterystykę usuwanego wait_exponential(min=1, max=10)."""
+    """Preserves the shape of the removed wait_exponential(min=1, max=10)."""
     assert backoff(attempt) == pytest.approx(expected)

--- a/tests/unit/test_client/test_failure_policy.py
+++ b/tests/unit/test_client/test_failure_policy.py
@@ -1,0 +1,117 @@
+"""Testy czystej polityki klasyfikacji błędów (ustalenie F14, kryterium 5.6)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from law_scrapper_mcp.client.failure_policy import Verdict, backoff, classify_failure
+
+REQUEST = httpx.Request("GET", "https://api.sejm.gov.pl/eli/acts/DU/2024/1")
+
+
+def _status_error(status: int, headers: dict[str, str] | None = None) -> httpx.HTTPStatusError:
+    response = httpx.Response(status, request=REQUEST, headers=headers or {})
+    return httpx.HTTPStatusError(f"HTTP {status}", request=REQUEST, response=response)
+
+
+@pytest.mark.parametrize("status", [500, 501, 502, 503, 504, 505, 599])
+def test_5xx_is_retryable_and_counts_as_breaker_failure(status: int) -> None:
+    """F19: całe 5xx otwiera obwód, nie tylko 502/503."""
+    verdict = classify_failure(_status_error(status))
+    assert verdict.retryable is True
+    assert verdict.breaker_failure is True
+    assert verdict.rate_limited is False
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 410, 418, 422])
+def test_4xx_other_than_429_is_terminal(status: int) -> None:
+    """Błąd zapytania, nie serwera — ponawianie obciążałoby Sejm bez szansy na inny wynik."""
+    verdict = classify_failure(_status_error(status))
+    assert verdict.retryable is False
+    assert verdict.breaker_failure is False
+
+
+def test_429_is_retryable_but_never_a_breaker_failure() -> None:
+    """D6: 429 znaczy 'my przesadzamy', nie 'Sejm padł'."""
+    verdict = classify_failure(_status_error(429))
+    assert verdict.retryable is True
+    assert verdict.breaker_failure is False
+    assert verdict.rate_limited is True
+
+
+def test_429_honours_numeric_retry_after() -> None:
+    verdict = classify_failure(_status_error(429, {"Retry-After": "2"}))
+    assert verdict.retry_after == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize("raw", ["", "later", "-5", "Wed, 21 Oct 2026 07:28:00 GMT"])
+def test_unparsable_retry_after_falls_back_to_backoff(raw: str) -> None:
+    """Nagłówek w formacie daty lub śmieciowy nie może wywrócić klasyfikacji."""
+    verdict = classify_failure(_status_error(429, {"Retry-After": raw}))
+    assert verdict.retryable is True
+    assert verdict.retry_after is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("brak połączenia", request=REQUEST),
+        httpx.ReadError("błąd odczytu", request=REQUEST),
+        httpx.WriteError("błąd zapisu", request=REQUEST),
+        httpx.ConnectTimeout("przekroczono czas łączenia", request=REQUEST),
+        httpx.ReadTimeout("przekroczono czas odczytu", request=REQUEST),
+        httpx.PoolTimeout("przekroczono czas puli", request=REQUEST),
+        httpx.RemoteProtocolError("błąd protokołu", request=REQUEST),
+        httpx.ProxyError("błąd proxy", request=REQUEST),
+    ],
+)
+def test_transport_errors_are_retryable_failures(exc: httpx.TransportError) -> None:
+    """F11: jeden blok obejmuje timeouty i pozostałe błędy transportowe."""
+    verdict = classify_failure(exc)
+    assert verdict.retryable is True
+    assert verdict.breaker_failure is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.DecodingError("błąd dekodowania", request=REQUEST),
+        httpx.TooManyRedirects("za dużo przekierowań", request=REQUEST),
+        httpx.UnsupportedProtocol("nieobsługiwany protokół", request=REQUEST),
+    ],
+)
+def test_non_transport_request_errors_are_terminal(exc: httpx.RequestError) -> None:
+    """Błędy kontraktu lub konfiguracji — ponowienie nigdy nie pomoże."""
+    verdict = classify_failure(exc)
+    assert verdict.retryable is False
+    assert verdict.breaker_failure is False
+
+
+@pytest.mark.parametrize("status", list(range(100, 600)))
+def test_every_status_code_has_a_defined_verdict(status: int) -> None:
+    """5.6: przemiatanie 100–599 — żaden kod nie może wypaść z klasyfikacji."""
+    verdict = classify_failure(_status_error(status))
+    assert isinstance(verdict, Verdict)
+    if 500 <= status <= 599:
+        assert verdict.retryable and verdict.breaker_failure
+    elif status == 429:
+        assert verdict.retryable and not verdict.breaker_failure
+    else:
+        assert not verdict.retryable and not verdict.breaker_failure
+
+
+def test_verdict_is_immutable() -> None:
+    """Werdykt jest wartością, nie stanem — nikt go po drodze nie podmieni."""
+    verdict = classify_failure(_status_error(503))
+    with pytest.raises(AttributeError):
+        verdict.retryable = False  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("attempt", "expected"),
+    [(1, 1.0), (2, 2.0), (3, 4.0), (4, 8.0), (5, 10.0), (10, 10.0)],
+)
+def test_backoff_is_exponential_and_capped(attempt: int, expected: float) -> None:
+    """Zachowuje charakterystykę usuwanego wait_exponential(min=1, max=10)."""
+    assert backoff(attempt) == pytest.approx(expected)

--- a/tests/unit/test_client/test_sejm_client_resilience.py
+++ b/tests/unit/test_client/test_sejm_client_resilience.py
@@ -1,7 +1,7 @@
-"""Testy warstwy odporności klienta Sejm API (F10, F11, F19, F20; kryteria 5.1-5.4, 5.7).
+"""Sejm API client resilience tests (F10, F11, F19, F20; criteria 5.1-5.4, 5.7).
 
-Cały zestaw działa offline na respx, a oczekiwanie jest wstrzykiwane przez
-podmianę `_delay` — żaden test nie odmierza czasu rzeczywistego (O6).
+The whole suite runs offline on respx, and waiting is injected by substituting
+`_delay` — no test measures real elapsed time (O6).
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ ACT_PATH = "acts/DU/2024/1"
 
 @pytest.fixture
 def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
-    """Przechwyć żądane opóźnienia zamiast ich odczekiwać."""
+    """Capture the requested delays instead of sitting them out."""
     recorded: list[float] = []
 
     async def fake_delay(seconds: float) -> None:
@@ -63,7 +63,7 @@ async def client(breaker: CircuitBreaker) -> AsyncGenerator[SejmApiClient]:
 @pytest.mark.asyncio
 @respx.mock
 async def test_503_is_retried_until_success(client: SejmApiClient, slept: list[float]) -> None:
-    """F10, kryterium 5.1: dwie odpowiedzi 503, potem 200 — trzy żądania, dane wracają."""
+    """F10, criterion 5.1: two 503s then a 200 — three requests, data comes back."""
     route = respx.get(ACT_URL).mock(
         side_effect=[
             httpx.Response(503),
@@ -82,7 +82,7 @@ async def test_503_is_retried_until_success(client: SejmApiClient, slept: list[f
 @pytest.mark.asyncio
 @respx.mock
 async def test_500_exhausts_attempts_then_raises(client: SejmApiClient, slept: list[float]) -> None:
-    """F10 + D7, kryterium 5.1: 500 jest ponawiane i kończy się ApiUnavailableError."""
+    """F10 + D7, criterion 5.1: 500 is retried and ends as ApiUnavailableError."""
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(500))
 
     with pytest.raises(ApiUnavailableError):
@@ -94,7 +94,7 @@ async def test_500_exhausts_attempts_then_raises(client: SejmApiClient, slept: l
 @pytest.mark.asyncio
 @respx.mock
 async def test_connect_error_is_retried(client: SejmApiClient, slept: list[float]) -> None:
-    """F11, kryterium 5.2: błąd transportowy przy pierwszej próbie, sukces przy drugiej."""
+    """F11, criterion 5.2: a transport error on attempt one, success on attempt two."""
     route = respx.get(ACT_URL).mock(
         side_effect=[
             httpx.ConnectError("brak połączenia"),
@@ -109,7 +109,7 @@ async def test_connect_error_is_retried(client: SejmApiClient, slept: list[float
 @pytest.mark.asyncio
 @respx.mock
 async def test_read_error_surfaces_as_domain_exception(client: SejmApiClient, slept: list[float]) -> None:
-    """F11, kryterium 5.2: wywołujący nigdy nie widzi surowego wyjątku httpx."""
+    """F11, criterion 5.2: the caller never sees a raw httpx exception."""
     respx.get(ACT_URL).mock(side_effect=httpx.ReadError("błąd odczytu"))
 
     with pytest.raises(ApiUnavailableError):
@@ -121,7 +121,7 @@ async def test_read_error_surfaces_as_domain_exception(client: SejmApiClient, sl
 async def test_repeated_transport_error_counts_one_failure(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """F11 + F20, kryteria 5.2 i 5.4: trzy próby, dokładnie jedna awaria wyłącznika."""
+    """F11 + F20, criteria 5.2 and 5.4: three attempts, exactly one breaker failure."""
     respx.get(ACT_URL).mock(side_effect=httpx.ConnectError("brak połączenia"))
 
     with pytest.raises(ApiUnavailableError):
@@ -135,7 +135,7 @@ async def test_repeated_transport_error_counts_one_failure(
 async def test_five_failed_operations_open_the_circuit(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """F19 + F20, kryteria 5.3 i 5.4: próg 5 znaczy pięć operacji, nie dwie."""
+    """F19 + F20, criteria 5.3 and 5.4: a threshold of 5 means five operations, not two."""
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(500))
 
     for _ in range(4):
@@ -159,7 +159,7 @@ async def test_five_failed_operations_open_the_circuit(
 async def test_budget_cuts_the_retry_sequence(
     breaker: CircuitBreaker, slept: list[float], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """F20, kryterium 5.4: przekroczony budżet ucina próby, zamiast zasypiać."""
+    """F20, criterion 5.4: an exceeded budget cuts the attempts instead of sleeping."""
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(503))
     api = SejmApiClient(
         cache=TTLCache(max_entries=100),
@@ -183,7 +183,7 @@ async def test_budget_cuts_the_retry_sequence(
 @pytest.mark.asyncio
 @respx.mock
 async def test_budget_is_never_exceeded_by_planned_sleeps(client: SejmApiClient, slept: list[float]) -> None:
-    """F20, kryterium 5.4: suma zaplanowanych oczekiwań mieści się w budżecie."""
+    """F20, criterion 5.4: the planned waits sum to less than the budget."""
     respx.get(ACT_URL).mock(return_value=httpx.Response(503))
 
     with pytest.raises(ApiUnavailableError):
@@ -194,14 +194,44 @@ async def test_budget_is_never_exceeded_by_planned_sleeps(client: SejmApiClient,
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_read_timeout_is_cut_by_the_budget(breaker: CircuitBreaker, slept: list[float]) -> None:
+    """F20, criterion 5.4c: a repeated read timeout ends within the budget.
+
+    The other budget tests drive HTTP 503. This one drives an actual
+    `httpx.ReadTimeout` — the failure mode criterion 5.4c names, and the one whose
+    30 s read timeout is the reason the budget exists at all.
+    """
+    route = respx.get(ACT_URL).mock(side_effect=httpx.ReadTimeout("przekroczono czas odczytu"))
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=0.5,
+    )
+    await api.start()
+    try:
+        with pytest.raises(ApiUnavailableError):
+            await api.get_json(ACT_PATH)
+    finally:
+        await api.close()
+
+    assert route.call_count == 1
+    assert slept == []
+    assert breaker.failure_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_circuit_opened_mid_sequence_aborts_retries(
     client: SejmApiClient, breaker: CircuitBreaker, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """D2, kryterium 5.4: obwód otwarty przez równoległy ruch przerywa naszą sekwencję.
+    """D2, criterion 5.4: a circuit opened by concurrent traffic aborts our sequence.
 
-    Podmieniamy `_delay` na taki, który w trakcie oczekiwania symuluje równoległy
-    ruch dobijający wyłącznik do progu — to najwierniejsze odwzorowanie wyścigu,
-    o którym mówi D2, bez polegania na kolejności zadań.
+    We swap `_delay` for one that, while waiting, simulates concurrent traffic
+    driving the breaker to its threshold — the truest rendering of the race D2
+    describes, without relying on task ordering.
     """
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(503))
 
@@ -221,10 +251,10 @@ async def test_circuit_opened_mid_sequence_aborts_retries(
 @pytest.mark.asyncio
 @respx.mock
 async def test_half_open_admits_exactly_max_calls(slept: list[float]) -> None:
-    """F21, kryterium 5.5: dziesięć współbieżnych operacji, trzy docierają do API.
+    """F21, criterion 5.5: ten concurrent operations, three reach the API.
 
-    Wyłącznik z zerowym czasem odzysku wchodzi w HALF_OPEN przy pierwszym
-    `try_acquire()`, więc test nie musi manipulować zegarem ani polem prywatnym.
+    A breaker with a zero recovery timeout enters HALF_OPEN on the first
+    `try_acquire()`, so the test manipulates neither the clock nor a private field.
     """
     breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=3)
     api = SejmApiClient(
@@ -242,10 +272,10 @@ async def test_half_open_admits_exactly_max_calls(slept: list[float]) -> None:
     assert breaker.state is CircuitState.OPEN
 
     async def respond(request: httpx.Request) -> httpx.Response:
-        # Punkt zawieszenia jest tu konieczny: bez niego respx zwraca
-        # odpowiedź w pełni synchronicznie, więc `asyncio.gather` wykonuje
-        # dziesięć zadań kolejno (każde do końca), zanim zacznie kolejne —
-        # zero realnej współbieżności i próg HALF_OPEN nigdy nie jest napięty.
+        # A suspension point is required here: without it respx answers fully
+        # synchronously, so `asyncio.gather` runs the ten tasks one after another
+        # (each to completion) before starting the next — zero real concurrency,
+        # and the HALF_OPEN limit is never put under pressure.
         await asyncio.sleep(0)
         return httpx.Response(200, json={"ok": True})
 
@@ -270,7 +300,7 @@ async def test_half_open_admits_exactly_max_calls(slept: list[float]) -> None:
 async def test_429_retries_once_honouring_retry_after(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """D6, kryterium 5.7: jedno ponowienie po czasie z nagłówka, bez awarii wyłącznika."""
+    """D6, criterion 5.7: one retry after the header delay, no breaker failure."""
     route = respx.get(ACT_URL).mock(
         return_value=httpx.Response(429, headers={"Retry-After": "2"}),
     )
@@ -289,7 +319,7 @@ async def test_429_retries_once_honouring_retry_after(
 async def test_404_is_terminal_and_invisible_to_the_breaker(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """Kryterium 5.7: 404 nadal podnosi ActNotFoundError, bez ponowień i bez awarii."""
+    """Criterion 5.7: 404 still raises ActNotFoundError, with no retry and no failure."""
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(404))
 
     with pytest.raises(ActNotFoundError):
@@ -303,7 +333,7 @@ async def test_404_is_terminal_and_invisible_to_the_breaker(
 @pytest.mark.asyncio
 @respx.mock
 async def test_client_error_stays_a_generic_api_error(client: SejmApiClient, slept: list[float]) -> None:
-    """O3 + D7: 4xx inne niż 404 nie awansuje do ApiUnavailableError."""
+    """O3 + D7: a 4xx other than 404 is not promoted to ApiUnavailableError."""
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(400, text="złe zapytanie"))
 
     with pytest.raises(SejmApiError) as caught:
@@ -319,7 +349,7 @@ async def test_client_error_stays_a_generic_api_error(client: SejmApiClient, sle
 async def test_open_circuit_rejects_before_sending(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """Otwarty obwód odrzuca żądanie bez ruchu wychodzącego (O1)."""
+    """An open circuit rejects the request with no outbound traffic (O1)."""
     for _ in range(5):
         breaker.release_failure()
     route = respx.get(ACT_URL).mock(return_value=httpx.Response(200, json={"ok": True}))
@@ -332,13 +362,13 @@ async def test_open_circuit_rejects_before_sending(
 
 @pytest.mark.asyncio
 async def test_cancelled_probe_releases_the_half_open_slot(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fix (Critical): anulowanie żądania nie może trwale zablokować bezpiecznika.
+    """Fix (Critical): cancelling a request must not wedge the breaker permanently.
 
-    `asyncio.CancelledError` nie jest wyjątkiem `httpx`, więc omija klasyfikację
-    polityki (`classify_failure` przyjmuje tylko `httpx.HTTPError`). Bez
-    dedykowanej obsługi slot HALF_OPEN nigdy nie wraca do zera, a bezpiecznik
-    nie może już dojść do `release_failure()` (jedynej drogi z powrotem do OPEN)
-    — więc odrzuca wszystko w nieskończoność.
+    `asyncio.CancelledError` is not an `httpx` exception, so it bypasses policy
+    classification (`classify_failure` only accepts `httpx.HTTPError`). Without
+    dedicated handling the HALF_OPEN slot never returns to zero, and the breaker
+    can no longer reach `release_failure()` — the only route back to OPEN — so it
+    rejects everything forever.
     """
     breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=3)
     api = SejmApiClient(
@@ -377,12 +407,12 @@ async def test_cancelled_probe_releases_the_half_open_slot(monkeypatch: pytest.M
 async def test_breaker_counts_failure_seen_before_a_trailing_429(
     client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
 ) -> None:
-    """Fix (Important): awaria 5xx wcześniej w sekwencji nie może zniknąć za 429 na końcu.
+    """Fix (Important): an earlier 5xx must not vanish behind a trailing 429.
 
-    `give_up` patrzył wyłącznie na werdykt ostatniej próby — bez zatrzasku
-    ponad wszystkimi próbami sekwencja 500 → 500 → 429 zwalniałaby wyłącznie
-    sondę mimo dwóch potwierdzonych awarii serwera, więc wyłącznik nigdy by
-    się nie otworzył przeciw API, które degraduje się dokładnie w ten sposób.
+    `give_up` looked only at the verdict of the last attempt — without a latch
+    spanning all attempts, a 500 -> 500 -> 429 sequence would release only the
+    probe despite two confirmed server failures, so the breaker would never open
+    against an API that degrades in exactly this way.
     """
     route = respx.get(ACT_URL).mock(
         side_effect=[
@@ -401,8 +431,50 @@ async def test_breaker_counts_failure_seen_before_a_trailing_429(
     assert breaker.failure_count == 1
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_failure_survives_admission_refusal_mid_sequence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fix (Critical): a failure confirmed before admission is refused must not vanish.
+
+    In HALF_OPEN our probe gets a 500, frees its slot for the wait, and on the next
+    attempt finds the slot taken by concurrent traffic. Without booking the latched
+    failure the breaker stays HALF_OPEN, so an API confirmed broken can be declared
+    recovered by the probes that happened to succeed.
+    """
+    breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=1)
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=45.0,
+    )
+    await api.start()
+
+    for _ in range(5):
+        breaker.release_failure()
+    assert breaker.state is CircuitState.OPEN
+
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(500))
+
+    async def steal_the_only_slot(_seconds: float) -> None:
+        assert breaker.try_acquire() is True
+
+    monkeypatch.setattr(client_module, "_delay", steal_the_only_slot)
+    try:
+        with pytest.raises(ApiUnavailableError):
+            await api.get_json(ACT_PATH)
+    finally:
+        await api.close()
+
+    assert route.call_count == 1
+    assert breaker.state is CircuitState.OPEN
+    assert breaker.failure_count == 6
+
+
 def test_settings_expose_retry_budget_and_attempts() -> None:
-    """Kryterium 4.3: obie nastawy istnieją z wartościami domyślnymi ze spec."""
+    """Criterion 4.3: both settings exist with the default values from the spec."""
     from law_scrapper_mcp.config import Settings
 
     settings = Settings()
@@ -411,7 +483,7 @@ def test_settings_expose_retry_budget_and_attempts() -> None:
 
 
 def test_lifespan_wires_retry_settings_into_the_client() -> None:
-    """Nastawy muszą realnie docierać do klienta, a nie tylko istnieć w configu."""
+    """The settings must actually reach the client, not merely exist in the config."""
     import inspect
 
     from law_scrapper_mcp import server
@@ -422,7 +494,7 @@ def test_lifespan_wires_retry_settings_into_the_client() -> None:
 
 
 def test_tenacity_is_not_a_runtime_dependency() -> None:
-    """D9: jedyny konsument zniknął, zależność też."""
+    """D9: the only consumer is gone, and so is the dependency."""
     import tomllib
     from pathlib import Path
 

--- a/tests/unit/test_client/test_sejm_client_resilience.py
+++ b/tests/unit/test_client/test_sejm_client_resilience.py
@@ -328,3 +328,74 @@ async def test_open_circuit_rejects_before_sending(
         await client.get_json(ACT_PATH)
 
     assert route.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_probe_releases_the_half_open_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fix (Critical): anulowanie żądania nie może trwale zablokować bezpiecznika.
+
+    `asyncio.CancelledError` nie jest wyjątkiem `httpx`, więc omija klasyfikację
+    polityki (`classify_failure` przyjmuje tylko `httpx.HTTPError`). Bez
+    dedykowanej obsługi slot HALF_OPEN nigdy nie wraca do zera, a bezpiecznik
+    nie może już dojść do `release_failure()` (jedynej drogi z powrotem do OPEN)
+    — więc odrzuca wszystko w nieskończoność.
+    """
+    breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=3)
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=45.0,
+    )
+    await api.start()
+
+    for _ in range(5):
+        breaker.release_failure()
+    assert breaker.state is CircuitState.OPEN
+
+    async def cancelled_send(*args: object, **kwargs: object) -> httpx.Response:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(api, "_send", cancelled_send)
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await api.get_json(ACT_PATH)
+    finally:
+        await api.close()
+
+    assert breaker.state is CircuitState.HALF_OPEN
+    assert breaker.try_acquire() is True
+    assert breaker.try_acquire() is True
+    assert breaker.try_acquire() is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_breaker_counts_failure_seen_before_a_trailing_429(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """Fix (Important): awaria 5xx wcześniej w sekwencji nie może zniknąć za 429 na końcu.
+
+    `give_up` patrzył wyłącznie na werdykt ostatniej próby — bez zatrzasku
+    ponad wszystkimi próbami sekwencja 500 → 500 → 429 zwalniałaby wyłącznie
+    sondę mimo dwóch potwierdzonych awarii serwera, więc wyłącznik nigdy by
+    się nie otworzył przeciw API, które degraduje się dokładnie w ten sposób.
+    """
+    route = respx.get(ACT_URL).mock(
+        side_effect=[
+            httpx.Response(500),
+            httpx.Response(500),
+            httpx.Response(429, headers={"Retry-After": "1"}),
+        ]
+    )
+
+    with pytest.raises(SejmApiError) as caught:
+        await client.get_json(ACT_PATH)
+
+    assert not isinstance(caught.value, ApiUnavailableError)
+    assert route.call_count == 3
+    assert slept == [1.0, 2.0]
+    assert breaker.failure_count == 1

--- a/tests/unit/test_client/test_sejm_client_resilience.py
+++ b/tests/unit/test_client/test_sejm_client_resilience.py
@@ -399,3 +399,35 @@ async def test_breaker_counts_failure_seen_before_a_trailing_429(
     assert route.call_count == 3
     assert slept == [1.0, 2.0]
     assert breaker.failure_count == 1
+
+
+def test_settings_expose_retry_budget_and_attempts() -> None:
+    """Kryterium 4.3: obie nastawy istnieją z wartościami domyślnymi ze spec."""
+    from law_scrapper_mcp.config import Settings
+
+    settings = Settings()
+    assert settings.api_max_attempts == 3
+    assert settings.api_retry_budget == pytest.approx(45.0)
+
+
+def test_lifespan_wires_retry_settings_into_the_client() -> None:
+    """Nastawy muszą realnie docierać do klienta, a nie tylko istnieć w configu."""
+    import inspect
+
+    from law_scrapper_mcp import server
+
+    source = inspect.getsource(server.lifespan)
+    assert "max_attempts=settings.api_max_attempts" in source
+    assert "retry_budget=settings.api_retry_budget" in source
+
+
+def test_tenacity_is_not_a_runtime_dependency() -> None:
+    """D9: jedyny konsument zniknął, zależność też."""
+    import tomllib
+    from pathlib import Path
+
+    project_root = Path(__file__).parents[3]
+    with (project_root / "pyproject.toml").open("rb") as pyproject:
+        dependencies = tomllib.load(pyproject)["project"]["dependencies"]
+
+    assert not any(dependency.lower().startswith("tenacity") for dependency in dependencies)

--- a/tests/unit/test_client/test_sejm_client_resilience.py
+++ b/tests/unit/test_client/test_sejm_client_resilience.py
@@ -1,0 +1,330 @@
+"""Testy warstwy odporności klienta Sejm API (F10, F11, F19, F20; kryteria 5.1-5.4, 5.7).
+
+Cały zestaw działa offline na respx, a oczekiwanie jest wstrzykiwane przez
+podmianę `_delay` — żaden test nie odmierza czasu rzeczywistego (O6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+
+from law_scrapper_mcp.client import sejm_client as client_module
+from law_scrapper_mcp.client.cache import TTLCache
+from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker, CircuitState
+from law_scrapper_mcp.client.exceptions import (
+    ActNotFoundError,
+    ApiUnavailableError,
+    SejmApiError,
+)
+from law_scrapper_mcp.client.sejm_client import SejmApiClient
+
+ACT_URL = "https://api.sejm.gov.pl/eli/acts/DU/2024/1"
+ACT_PATH = "acts/DU/2024/1"
+
+
+@pytest.fixture
+def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Przechwyć żądane opóźnienia zamiast ich odczekiwać."""
+    recorded: list[float] = []
+
+    async def fake_delay(seconds: float) -> None:
+        recorded.append(seconds)
+
+    monkeypatch.setattr(client_module, "_delay", fake_delay)
+    return recorded
+
+
+@pytest.fixture
+def breaker() -> CircuitBreaker:
+    return CircuitBreaker(failure_threshold=5, recovery_timeout=60.0, half_open_max_calls=3)
+
+
+@pytest_asyncio.fixture
+async def client(breaker: CircuitBreaker) -> AsyncGenerator[SejmApiClient]:
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=45.0,
+    )
+    await api.start()
+    yield api
+    await api.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_503_is_retried_until_success(client: SejmApiClient, slept: list[float]) -> None:
+    """F10, kryterium 5.1: dwie odpowiedzi 503, potem 200 — trzy żądania, dane wracają."""
+    route = respx.get(ACT_URL).mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(200, json={"ELI": "DU/2024/1"}),
+        ]
+    )
+
+    data = await client.get_json(ACT_PATH)
+
+    assert data == {"ELI": "DU/2024/1"}
+    assert route.call_count == 3
+    assert slept == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_500_exhausts_attempts_then_raises(client: SejmApiClient, slept: list[float]) -> None:
+    """F10 + D7, kryterium 5.1: 500 jest ponawiane i kończy się ApiUnavailableError."""
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(500))
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+    assert route.call_count == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_connect_error_is_retried(client: SejmApiClient, slept: list[float]) -> None:
+    """F11, kryterium 5.2: błąd transportowy przy pierwszej próbie, sukces przy drugiej."""
+    route = respx.get(ACT_URL).mock(
+        side_effect=[
+            httpx.ConnectError("brak połączenia"),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+
+    assert await client.get_json(ACT_PATH) == {"ok": True}
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_read_error_surfaces_as_domain_exception(client: SejmApiClient, slept: list[float]) -> None:
+    """F11, kryterium 5.2: wywołujący nigdy nie widzi surowego wyjątku httpx."""
+    respx.get(ACT_URL).mock(side_effect=httpx.ReadError("błąd odczytu"))
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_repeated_transport_error_counts_one_failure(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """F11 + F20, kryteria 5.2 i 5.4: trzy próby, dokładnie jedna awaria wyłącznika."""
+    respx.get(ACT_URL).mock(side_effect=httpx.ConnectError("brak połączenia"))
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+    assert breaker.failure_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_five_failed_operations_open_the_circuit(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """F19 + F20, kryteria 5.3 i 5.4: próg 5 znaczy pięć operacji, nie dwie."""
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(500))
+
+    for _ in range(4):
+        with pytest.raises(ApiUnavailableError):
+            await client.get_json(ACT_PATH)
+    assert breaker.state is CircuitState.CLOSED
+    assert breaker.failure_count == 4
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+    assert breaker.state is CircuitState.OPEN
+
+    calls_before = route.call_count
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+    assert route.call_count == calls_before
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_budget_cuts_the_retry_sequence(
+    breaker: CircuitBreaker, slept: list[float], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """F20, kryterium 5.4: przekroczony budżet ucina próby, zamiast zasypiać."""
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(503))
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=0.5,
+    )
+    await api.start()
+    try:
+        with pytest.raises(ApiUnavailableError):
+            await api.get_json(ACT_PATH)
+    finally:
+        await api.close()
+
+    assert route.call_count == 1
+    assert slept == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_budget_is_never_exceeded_by_planned_sleeps(client: SejmApiClient, slept: list[float]) -> None:
+    """F20, kryterium 5.4: suma zaplanowanych oczekiwań mieści się w budżecie."""
+    respx.get(ACT_URL).mock(return_value=httpx.Response(503))
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+    assert sum(slept) < 45.0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_circuit_opened_mid_sequence_aborts_retries(
+    client: SejmApiClient, breaker: CircuitBreaker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D2, kryterium 5.4: obwód otwarty przez równoległy ruch przerywa naszą sekwencję.
+
+    Podmieniamy `_delay` na taki, który w trakcie oczekiwania symuluje równoległy
+    ruch dobijający wyłącznik do progu — to najwierniejsze odwzorowanie wyścigu,
+    o którym mówi D2, bez polegania na kolejności zadań.
+    """
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(503))
+
+    async def open_the_circuit(_seconds: float) -> None:
+        for _ in range(5):
+            breaker.release_failure()
+
+    monkeypatch.setattr(client_module, "_delay", open_the_circuit)
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+    assert breaker.state is CircuitState.OPEN
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_half_open_admits_exactly_max_calls(slept: list[float]) -> None:
+    """F21, kryterium 5.5: dziesięć współbieżnych operacji, trzy docierają do API.
+
+    Wyłącznik z zerowym czasem odzysku wchodzi w HALF_OPEN przy pierwszym
+    `try_acquire()`, więc test nie musi manipulować zegarem ani polem prywatnym.
+    """
+    breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=0.0, half_open_max_calls=3)
+    api = SejmApiClient(
+        cache=TTLCache(max_entries=100),
+        timeout=30.0,
+        max_concurrent=10,
+        circuit_breaker=breaker,
+        max_attempts=3,
+        retry_budget=45.0,
+    )
+    await api.start()
+
+    for _ in range(5):
+        breaker.release_failure()
+    assert breaker.state is CircuitState.OPEN
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        # Punkt zawieszenia jest tu konieczny: bez niego respx zwraca
+        # odpowiedź w pełni synchronicznie, więc `asyncio.gather` wykonuje
+        # dziesięć zadań kolejno (każde do końca), zanim zacznie kolejne —
+        # zero realnej współbieżności i próg HALF_OPEN nigdy nie jest napięty.
+        await asyncio.sleep(0)
+        return httpx.Response(200, json={"ok": True})
+
+    route = respx.get(ACT_URL).mock(side_effect=respond)
+    try:
+        results = await asyncio.gather(
+            *(api.get_json(ACT_PATH) for _ in range(10)),
+            return_exceptions=True,
+        )
+    finally:
+        await api.close()
+
+    admitted = [item for item in results if not isinstance(item, BaseException)]
+    rejected = [item for item in results if isinstance(item, ApiUnavailableError)]
+    assert len(admitted) == 3
+    assert len(rejected) == 7
+    assert route.call_count == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_429_retries_once_honouring_retry_after(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """D6, kryterium 5.7: jedno ponowienie po czasie z nagłówka, bez awarii wyłącznika."""
+    route = respx.get(ACT_URL).mock(
+        return_value=httpx.Response(429, headers={"Retry-After": "2"}),
+    )
+
+    with pytest.raises(SejmApiError) as caught:
+        await client.get_json(ACT_PATH)
+
+    assert not isinstance(caught.value, ApiUnavailableError)
+    assert route.call_count == 2
+    assert slept == [2.0]
+    assert breaker.failure_count == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_404_is_terminal_and_invisible_to_the_breaker(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """Kryterium 5.7: 404 nadal podnosi ActNotFoundError, bez ponowień i bez awarii."""
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(404))
+
+    with pytest.raises(ActNotFoundError):
+        await client.get_json(ACT_PATH)
+
+    assert route.call_count == 1
+    assert breaker.failure_count == 0
+    assert slept == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_client_error_stays_a_generic_api_error(client: SejmApiClient, slept: list[float]) -> None:
+    """O3 + D7: 4xx inne niż 404 nie awansuje do ApiUnavailableError."""
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(400, text="złe zapytanie"))
+
+    with pytest.raises(SejmApiError) as caught:
+        await client.get_json(ACT_PATH)
+
+    assert not isinstance(caught.value, ApiUnavailableError)
+    assert caught.value.status_code == 400
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_open_circuit_rejects_before_sending(
+    client: SejmApiClient, breaker: CircuitBreaker, slept: list[float]
+) -> None:
+    """Otwarty obwód odrzuca żądanie bez ruchu wychodzącego (O1)."""
+    for _ in range(5):
+        breaker.release_failure()
+    route = respx.get(ACT_URL).mock(return_value=httpx.Response(200, json={"ok": True}))
+
+    with pytest.raises(ApiUnavailableError):
+        await client.get_json(ACT_PATH)
+
+    assert route.call_count == 0

--- a/tests/unit/test_client/test_user_agent.py
+++ b/tests/unit/test_client/test_user_agent.py
@@ -1,0 +1,62 @@
+"""Tests for the identity the client presents to api.sejm.gov.pl (finding F52)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from law_scrapper_mcp.client.cache import TTLCache
+from law_scrapper_mcp.client.sejm_client import SejmApiClient
+from law_scrapper_mcp.config import USER_AGENT_CONTACT, Settings
+
+CLIENT_PACKAGE = Path(__file__).parents[3] / "src" / "law_scrapper_mcp"
+
+# Matches a hardcoded "law-scrapper-mcp/<version>" literal — the exact shape that
+# drifted two major versions behind the real one before F52 was fixed.
+VERSIONED_LITERAL = re.compile(r"law-scrapper-mcp/\d")
+
+
+def test_user_agent_reports_the_configured_version() -> None:
+    """The advertised version must be the one the server actually reports."""
+    settings = Settings()
+    assert settings.user_agent.startswith(f"{settings.server_name}/{settings.server_version}")
+
+
+def test_user_agent_tracks_a_version_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Derivation, not duplication: overriding the version moves the header too."""
+    monkeypatch.setenv("LAW_MCP_SERVER_VERSION", "9.9.9")
+    assert "law-scrapper-mcp/9.9.9" in Settings().user_agent
+
+
+def test_user_agent_carries_a_contact_channel() -> None:
+    """The API is run by a state institution; its admin needs a route other than a ban."""
+    assert USER_AGENT_CONTACT in Settings().user_agent
+
+
+@pytest.mark.asyncio
+async def test_client_sends_the_user_agent_it_was_given() -> None:
+    """The header must survive the trip from settings into the httpx client."""
+    api = SejmApiClient(cache=TTLCache(max_entries=1), user_agent="law-scrapper-mcp/1.2.3 (+https://example.test)")
+    await api.start()
+    try:
+        assert api._client is not None
+        assert api._client.headers["User-Agent"] == "law-scrapper-mcp/1.2.3 (+https://example.test)"
+    finally:
+        await api.close()
+
+
+def test_no_module_hardcodes_a_versioned_user_agent() -> None:
+    """F52 regression guard: the version must live in exactly one place.
+
+    The original defect was a literal `law-scrapper-mcp/2.0` in the client, which
+    nobody noticed drifting because nothing tied it to `server_version`.
+    """
+    offenders = [
+        f"{path.relative_to(CLIENT_PACKAGE)}:{number}"
+        for path in CLIENT_PACKAGE.rglob("*.py")
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if VERSIONED_LITERAL.search(line)
+    ]
+    assert offenders == []

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,7 +56,15 @@ class TestSettingsDefaults:
         """Test default API concurrency settings."""
         settings = Settings()
         assert settings.api_max_concurrent == 10
-        assert settings.api_max_retries == 3
+
+    def test_dead_retry_knob_is_gone(self):
+        """api_max_retries never reached the client; keeping it advertised a lie.
+
+        The attempt count was hardcoded in the old tenacity decorator, so setting
+        LAW_MCP_API_MAX_RETRIES changed nothing. Unknown prefixed env vars are
+        ignored, so removing the field breaks nobody.
+        """
+        assert not hasattr(Settings(), "api_max_retries")
 
     def test_retry_loop_defaults(self):
         """Test default retry loop settings."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -58,6 +58,31 @@ class TestSettingsDefaults:
         assert settings.api_max_concurrent == 10
         assert settings.api_max_retries == 3
 
+    def test_retry_loop_defaults(self):
+        """Test default retry loop settings."""
+        settings = Settings()
+        assert settings.api_max_attempts == 3
+        assert settings.api_retry_budget == pytest.approx(45.0)
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_api_max_attempts_below_one_is_rejected(self, monkeypatch, value):
+        """A zero attempt budget would silently disable the retry loop.
+
+        With ``range(1, 1)`` the loop body never runs, so the client raises
+        ApiUnavailableError without ever contacting the API and without recording
+        anything on the circuit breaker. Fail loudly at startup instead.
+        """
+        monkeypatch.setenv("LAW_MCP_API_MAX_ATTEMPTS", value)
+        with pytest.raises(ValidationError):
+            Settings()
+
+    @pytest.mark.parametrize("value", ["0", "-0.5"])
+    def test_api_retry_budget_must_be_positive(self, monkeypatch, value):
+        """A non-positive budget makes every planned wait exceed the deadline."""
+        monkeypatch.setenv("LAW_MCP_API_RETRY_BUDGET", value)
+        with pytest.raises(ValidationError):
+            Settings()
+
     def test_cache_ttl_defaults(self):
         """Test default cache TTL values."""
         settings = Settings()

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
-    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -501,7 +500,6 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
-    { name = "tenacity", specifier = ">=9.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1220,15 +1218,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload_time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload_time = "2026-06-12T09:23:10.017Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload_time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload_time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Repair the resilience layer of `SejmApiClient` to actually implement the retry, circuit breaker, and error translation mechanisms that were declared but broken.

**Audit findings addressed:** F10, F11, F14, F19, F20, F21 (from `docs/mcp-audit-2026-08-06.md`)

## Changes

### Core Architecture
- Split `_request()` into three resilience layers with clear responsibilities:
  - `_send` — raw HTTP transport
  - `_execute_with_resilience` — retry loop, circuit breaker accounting
  - `_request` — exception type translation
- Add pure `failure_policy.py` module with `classify_failure()` — testable offline
- Redesigned circuit breaker contract: `try_acquire() / release_success() / release_failure() / release_probe()`
- Remove `tenacity` dependency (not used elsewhere; replaced with explicit retry loop)

### Key Fixes
- **F10**: Retry now works for HTTP 5xx (was: intercepted before retry policy could see them)
- **F11**: Transport errors (`ConnectError`, `ReadError`, `ProtocolError`) now handled uniformly
- **F19**: All 5xx errors now count as circuit breaker failures (was: 5xx silently excluded)
- **F20**: One failed operation = one breaker failure (was: three retries = three failures)
  - Hard budget on retry time (configurable, default 45s)
- **F21**: No race condition in HALF_OPEN — probes counted on admission, not completion
- **F14**: Full test suite for circuit breaker state transitions and failure classification

### New Configuration
- `LAW_MCP_API_RETRY_BUDGET` (default: 45.0s) — total retry window per operation
- `LAW_MCP_API_MAX_ATTEMPTS` (default: 3) — retry attempts

### Files Changed
- **New**: `client/failure_policy.py` — pure classification logic
- **New**: `tests/unit/test_client/test_failure_policy.py`
- **New**: `tests/unit/test_client/test_circuit_breaker.py`
- **New**: `tests/unit/test_client/test_sejm_client_resilience.py`
- **Modified**: `client/circuit_breaker.py`, `client/sejm_client.py`, `client/exceptions.py`, `config.py`, `server.py`, `pyproject.toml`

## Testing
- ✅ 1008 unit tests passing
- ✅ `ruff check` — no issues
- ✅ `ruff format --check` — already formatted
- ✅ `mypy` — no errors
- ✅ All 6 audit findings covered by test suite (red on main, green on this branch)

## Notes for Reviewer
- D8 compliance: all tests written first and verified failing on main
- O1 compliance: retry increase balanced by time budget and `Retry-After` respect
- O3 compliance: `ApiUnavailableError extends SejmApiError` — no existing handlers broken
- D10 compliance: circuit breaker contract is synchronous (no `asyncio.Lock` needed; atomic by construction)

Closes #klaster-4