### PR TITLE
build(deps): bump CI action chain to Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      python-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   pin-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Reject unpinned actions
         run: |
           set -euo pipefail
@@ -36,7 +36,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -52,10 +52,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
         if: needs.changes.outputs.code == 'true'
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
@@ -94,10 +94,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
         if: needs.changes.outputs.code == 'true'
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
       - name: Set up Python
@@ -175,7 +175,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Require changelog when package version changes
@@ -200,10 +200,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
         if: needs.changes.outputs.code == 'true'
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Parse version from tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
       - name: Require per-version changelog
@@ -37,10 +37,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -51,7 +51,7 @@ jobs:
         run: uv build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -63,13 +63,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Parse version from tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Download artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
@@ -80,7 +80,7 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: docs/changelogs/v${{ env.VERSION }}.md
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LAW_MCP_API_MAX_ATTEMPTS` (default 3) and `LAW_MCP_API_RETRY_BUDGET` (default 45.0 s) — settings for the API client retry loop (cluster 4)
 
 ### Changed
+- CI and release workflows bump their pinned GitHub Actions to the current Node 24 runtime: `actions/checkout` 4.2.2→7.0.1, `astral-sh/setup-uv` 5.3.1→10.0.1, `actions/upload-artifact` 4.4.3→7.0.1, `actions/download-artifact` 4.1.9→8.0.1, `softprops/action-gh-release` 2.2.1→3.0.2 (consolidates Dependabot #22-#26)
 - `SejmApiClient` splits a request into three layers (`_send` / `_execute_with_resilience` / `_request`); exception translation happens outside the retry loop (cluster 4, F10)
 - The circuit breaker gains a `try_acquire` / `release_success` / `release_failure` / `release_probe` contract; the probe counter grows on admission, not on request completion (cluster 4, F21)
 - HTTP 500 and 504 raise `ApiUnavailableError` instead of a generic `SejmApiError`, so the exception type matches the breaker's classification. `ApiUnavailableError` inherits from `SejmApiError`, so existing `except` blocks catch exactly as before (cluster 4, F19/D7)


### PR DESCRIPTION
## Summary

Consolidates five separate Dependabot PRs (#22, #23, #24, #25, #26) into one change. All five bumps touch `.github/workflows/` only — no changes to `pyproject.toml`, `uv.lock`, or `src/`. The application cannot be affected by this PR; the surface at risk is CI/release tooling.

| Action | Old → New | Breaking changes in between | Impact here |
|---|---|---|---|
| `actions/checkout` | 4.2.2 → 7.0.1 | Node 24 runtime; creds moved to a separate file; forked-PR checkout blocked for `pull_request_target`/`workflow_run` | None — we don't read the extraheader or use those triggers |
| `astral-sh/setup-uv` | 5.3.1 → 10.0.1 | Removed `pyproject-file`/`uv-file`/`server-url` inputs; venv no longer auto-activated; `prune-cache` now defaults `false`; `enable-cache: auto` disables cache for sensitive events | None functional — we only pass `enable-cache: true` and call `uv run` explicitly |
| `actions/upload-artifact` | 4.4.3 → 7.0.1 | Node 24; new `archive` input (defaults `true` = old behavior) | None — `name`/`path` usage unchanged |
| `actions/download-artifact` | 4.1.9 → 8.0.1 | v5 breaking only for `artifact-ids` downloads; v8 is ESM and now defaults `digest-mismatch: error` | We download by `name`, so v5 doesn't apply. v8's stricter digest check is new and desirable — verified live (see below) |
| `softprops/action-gh-release` | 2.2.1 → 3.0.2 | v3.0.0 is Node 24 only | None — confirmed `body_path`/`files` inputs still exist in `action.yml` at the pinned SHA; 3.0.2 also fixes small-checksum-asset upload reliability |

`upload-artifact` v7 and `download-artifact` v8 shipped the same day as a joint ESM migration, so they're bumped together to avoid a window where `release.yml` mixes artifact generations.

Every SHA was verified to resolve to its claimed tag via `gh api repos/<repo>/git/ref/tags/<tag>` before pinning — protects against a tj-actions-style tag-repoint attack.

Also adds `groups:` to `.github/dependabot.yml` (github-actions fully grouped; pip only for minor/patch) so future bumps land as one PR instead of several.

## Testing

**Local baseline (unchanged by this PR, confirms no regression):**
- `ruff check src tests` — pass
- `ruff format --check src tests` — pass
- `mypy src/law_scrapper_mcp/` — no issues
- `pytest tests/unit/` — 1024 passed
- `pytest tests/integration/ -m integration` — 97 passed

**Static validation of the new pins:**
- Both `pin-check` job greps (unpinned tags, mutable refs) reproduced locally — zero matches
- All workflow + dependabot YAML files parse cleanly

**Release-path dry run** (`release.yml` only runs on tag push, so normal CI never exercises `upload-artifact`/`download-artifact`/`action-gh-release` — exercised end-to-end on a throwaway branch + workflow, since deleted, run: https://github.com/numikel/law-scrapper-mcp/actions/runs/32513753400):
- `uv build` → `upload-artifact@v7` → `download-artifact@v8` → asserted no `.zip` present (v8 decompressed correctly, new default `digest-mismatch: error` did not trip)
- SHA-256 of the built wheel/sdist identical before upload and after download (byte-identical round trip)
- `action-gh-release@v3.0.2` created a draft release and uploaded `checksums.txt` + both dist files successfully
- Draft release deleted, throwaway branch deleted, no tag was left behind (drafts don't create a git tag)

Supersedes #22, #23, #24, #25, #26 — please close those (or let Dependabot auto-close on merge) once this lands.