### PR TITLE
feat: logging hygiene — correlation, UTF-8, privacy, timezone (F13, F40, F49, F50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Log output contract** — Every log record now carries a `request_id` field: `lifespan` for records emitted outside a tool call, an eight-character hexadecimal id for records emitted inside one. JSON logs keep Polish diacritics literal instead of escaping them to `\uXXXX`, and the JSON `timestamp` field now ends in an explicit `+00:00` instead of being a naive UTC value. Log aggregation pipelines parsing this output absorb one field-shape change, not three.
+
+### Fixed
+
+- **Query text no longer reaches INFO through the result store or the tool error path** — `ResultStore.store()` logs the result set id and counts at INFO and moves the query summary to DEBUG; the tool error decorator logs validation failures at ERROR without the caller-supplied message, which moves to DEBUG. In the legal domain a query can be sensitive even when every act it matches is public. Tool responses are unchanged.
+
 ## [3.1.1] - 2026-08-24
 
 See [docs/changelogs/v3.1.1.md](docs/changelogs/v3.1.1.md) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Log output contract** — Every log record now carries a `request_id` field: `lifespan` for records emitted outside a tool call, an eight-character hexadecimal id for records emitted inside one. JSON logs keep Polish diacritics literal instead of escaping them to `\uXXXX`, and the JSON `timestamp` field now ends in an explicit `+00:00` instead of being a naive UTC value. Log aggregation pipelines parsing this output absorb one field-shape change, not three.
+- **Log output contract** — Log aggregation pipelines parsing this output absorb one field-shape change rather than three:
+  - Every record carries a `request_id` field: `lifespan` outside a tool call, an eight-character hexadecimal id inside one.
+  - JSON logs keep Polish diacritics literal instead of escaping them to `\uXXXX`.
+  - The JSON `timestamp` field ends in an explicit `+00:00` instead of being a naive UTC value.
 
 ### Fixed
 
-- **Query text no longer reaches INFO through the result store or the tool error path** — `ResultStore.store()` logs the result set id and counts at INFO and moves the query summary to DEBUG; the tool error decorator logs validation failures at ERROR without the caller-supplied message, which moves to DEBUG. In the legal domain a query can be sensitive even when every act it matches is public. Tool responses are unchanged.
+- **Query text no longer reaches INFO through the result store or the tool error path** — `ResultStore.store()` logs the result set id and counts at INFO and moves the query summary to DEBUG. The tool error decorator logs `validation` and `upstream` failures at ERROR without the exception text — caller-supplied for the former, an upstream response body that a 4xx can fill with the rejected request's parameters for the latter — keeping both recoverable at DEBUG; an upstream HTTP status still appears on ERROR. In the legal domain a query can be sensitive even when every act it matches is public. Tool responses are unchanged.
 
 ## [3.1.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_LOG_LEVEL` | `INFO` | Log level: DEBUG, INFO, WARNING, ERROR |
 | `LAW_MCP_LOG_FORMAT` | `text` | Log format: `text` or `json` |
 
+Logs go to stderr (stdout carries the MCP protocol on the STDIO transport). Every record carries a `request_id` correlating it with a single tool call — `lifespan` for records emitted outside one:
+
+```text
+2026-08-24 12:00:00,123 - law_scrapper_mcp.tools.search - [a1b2c3d4] - INFO - Stored result set rs_1: 20 results (total 137)
+```
+
+```json
+{"timestamp": "2026-08-24T10:00:00.123456+00:00", "level": "INFO", "logger": "law_scrapper_mcp.tools.search", "request_id": "a1b2c3d4", "message": "Stored result set rs_1: 20 results (total 137)"}
+```
+
+Set `LAW_MCP_LOG_LEVEL=DEBUG` to recover the detail deliberately kept off INFO: search query text and the exception messages behind `validation` and `upstream` failures.
+
 Example environment configuration:
 
 ```bash

--- a/src/law_scrapper_mcp/logging_config.py
+++ b/src/law_scrapper_mcp/logging_config.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import contextlib
 import contextvars
 import logging
 import sys
 from typing import Literal
 
-request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="lifespan")
+DEFAULT_REQUEST_ID = "lifespan"
+"""Correlation id carried by records emitted outside a tool call.
+
+Shared by the ContextVar default and both formatter fallbacks so the two output
+formats cannot drift apart.
+"""
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default=DEFAULT_REQUEST_ID)
 """Correlation id of the tool call in flight.
 
 The default is a value, not a sentinel: records emitted from `lifespan`,
@@ -20,8 +28,9 @@ class RequestIdFilter(logging.Filter):
     """Stamp every record with the current correlation id.
 
     Attached to the handler rather than to the `law_scrapper_mcp` logger on
-    purpose: records from uvicorn and httpx know nothing about this mechanism,
-    and the text format references `%(request_id)s` on every record it renders.
+    purpose: uvicorn and httpx know nothing about this mechanism, yet a record
+    they emit during a tool call belongs to that call. Attaching here is what
+    gives such records the live id instead of the formatter fallback.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
@@ -44,14 +53,10 @@ def _force_utf8_stderr() -> None:
     reconfigure = getattr(sys.stderr, "reconfigure", None)
     if reconfigure is None:
         return
-    try:
+    # A detached, closed or otherwise incompatible stream costs the encoding
+    # guarantee, never startup.
+    with contextlib.suppress(Exception):
         reconfigure(encoding="utf-8", errors="backslashreplace")
-    except Exception:
-        # Any exception (TypeError from incompatible stream, ValueError from
-        # detached/closed stream, etc.): logging still works, only the encoding
-        # guarantee is lost. The absolute invariant "logging must never break
-        # startup" takes precedence over encoding safety.
-        return
 
 
 def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text") -> None:
@@ -77,7 +82,7 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
                     "timestamp": datetime.now(UTC).isoformat(),
                     "level": record.levelname,
                     "logger": record.name,
-                    "request_id": getattr(record, "request_id", "lifespan"),
+                    "request_id": getattr(record, "request_id", DEFAULT_REQUEST_ID),
                     "message": record.getMessage(),
                 }
                 if record.exc_info:
@@ -86,8 +91,14 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
 
         formatter: logging.Formatter = JsonFormatter()
     else:
-        # Text format for development
-        formatter = logging.Formatter("%(asctime)s - %(name)s - [%(request_id)s] - %(levelname)s - %(message)s")
+        # Text format for development. `defaults` mirrors the JSON fallback:
+        # without it a record reaching this formatter unfiltered raises
+        # `KeyError` inside `format()`, which `Handler.handleError()` swallows
+        # into a crash dump instead of a log line.
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - [%(request_id)s] - %(levelname)s - %(message)s",
+            defaults={"request_id": DEFAULT_REQUEST_ID},
+        )
 
     # Configure root logger
     root_logger = logging.getLogger()

--- a/src/law_scrapper_mcp/logging_config.py
+++ b/src/law_scrapper_mcp/logging_config.py
@@ -69,12 +69,12 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
     if format == "json":
         # JSON format for production
         import json
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         class JsonFormatter(logging.Formatter):
             def format(self, record: logging.LogRecord) -> str:
                 log_data = {
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(UTC).isoformat(),
                     "level": record.levelname,
                     "logger": record.name,
                     "request_id": getattr(record, "request_id", "lifespan"),

--- a/src/law_scrapper_mcp/logging_config.py
+++ b/src/law_scrapper_mcp/logging_config.py
@@ -7,6 +7,31 @@ import sys
 from typing import Literal
 
 
+def _force_utf8_stderr() -> None:
+    """Make stderr accept non-ASCII records regardless of platform default.
+
+    Windows consoles default to cp1252, which mangles Polish diacritics. The
+    call is guarded twice: `reconfigure` is absent on replaced streams (tests,
+    embedded runtimes), and `errors="backslashreplace"` keeps a stubborn
+    stream from turning a log line into a `UnicodeEncodeError`. Logging must
+    never be the reason the server fails to start.
+
+    Only stderr is touched: the STDIO transport carries the MCP protocol over
+    stdout, which must keep its own configuration.
+    """
+    reconfigure = getattr(sys.stderr, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="backslashreplace")
+    except Exception:
+        # Any exception (TypeError from incompatible stream, ValueError from
+        # detached/closed stream, etc.): logging still works, only the encoding
+        # guarantee is lost. The absolute invariant "logging must never break
+        # startup" takes precedence over encoding safety.
+        return
+
+
 def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text") -> None:
     """Setup structured logging for the application.
 
@@ -14,6 +39,8 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         format: Output format ("text" or "json")
     """
+    _force_utf8_stderr()
+
     # Convert level string to logging constant
     log_level = getattr(logging, level.upper(), logging.INFO)
 

--- a/src/law_scrapper_mcp/logging_config.py
+++ b/src/law_scrapper_mcp/logging_config.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import sys
 from typing import Literal
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="lifespan")
+"""Correlation id of the tool call in flight.
+
+The default is a value, not a sentinel: records emitted from `lifespan`,
+background eviction, or process startup carry `"lifespan"` without any code
+setting it, which keeps the JSON key set stable for log aggregation.
+"""
+
+
+class RequestIdFilter(logging.Filter):
+    """Stamp every record with the current correlation id.
+
+    Attached to the handler rather than to the `law_scrapper_mcp` logger on
+    purpose: records from uvicorn and httpx know nothing about this mechanism,
+    and the text format references `%(request_id)s` on every record it renders.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        return True
 
 
 def _force_utf8_stderr() -> None:
@@ -55,16 +77,17 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
                     "timestamp": datetime.utcnow().isoformat(),
                     "level": record.levelname,
                     "logger": record.name,
+                    "request_id": getattr(record, "request_id", "lifespan"),
                     "message": record.getMessage(),
                 }
                 if record.exc_info:
                     log_data["exception"] = self.formatException(record.exc_info)
-                return json.dumps(log_data)
+                return json.dumps(log_data, ensure_ascii=False)
 
         formatter: logging.Formatter = JsonFormatter()
     else:
         # Text format for development
-        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        formatter = logging.Formatter("%(asctime)s - %(name)s - [%(request_id)s] - %(levelname)s - %(message)s")
 
     # Configure root logger
     root_logger = logging.getLogger()
@@ -77,6 +100,7 @@ def setup_logging(level: str = "INFO", format: Literal["text", "json"] = "text")
     # Add stderr handler
     handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(log_level)
+    handler.addFilter(RequestIdFilter())
     handler.setFormatter(formatter)
     root_logger.addHandler(handler)
 

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -80,7 +80,10 @@ class ResultStore:
                 query_summary=query_summary,
                 total_count=total_count,
             )
-            logger.info(f"Stored result set {result_set_id}: {len(results)} results (query: {query_summary})")
+            logger.info("Stored result set %s: %d results (total %d)", result_set_id, len(results), total_count)
+            # The query text can be sensitive on its own; keep it recoverable
+            # but off the default production level.
+            logger.debug("Result set %s query: %s", result_set_id, query_summary)
             return result_set_id
 
     async def get(self, result_set_id: str) -> StoredResultSet | None:

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -80,13 +80,27 @@ def handle_tool_errors(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable
             return await func(*args, **kwargs)
         except Exception as exc:
             category = _classify_error(exc)
-            logger.error(
-                "Tool %s failed [%s]: %s",
-                func.__name__,
-                category,
-                exc,
-                exc_info=category == "internal",
-            )
+            if category == "validation":
+                # Most validation-category exceptions carry caller-supplied
+                # text (a regex pattern, an act title) that can be sensitive
+                # on its own. `TypeError` is also bucketed into "validation"
+                # by `_classify_error` even though it is typically an
+                # internal bug rather than caller input — narrowing that
+                # classification is out of this task's scope, so its detail
+                # is redacted from ERROR the same as the rest of the
+                # category and stays recoverable at DEBUG. Other categories
+                # draw on constants defined in this project, so they keep
+                # their detail on ERROR.
+                logger.error("Tool %s failed [%s]", func.__name__, category)
+                logger.debug("Tool %s validation detail: %s", func.__name__, exc)
+            else:
+                logger.error(
+                    "Tool %s failed [%s]: %s",
+                    func.__name__,
+                    category,
+                    exc,
+                    exc_info=category == "internal",
+                )
             raise ToolExecutionError(_public_message(exc, category)) from exc
 
     return wrapper

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -47,6 +47,16 @@ _ERROR_CATEGORIES: dict[type[Exception], str] = {
 # fall through to `str(exc)`.
 _UPSTREAM_MESSAGE = "Serwis api.sejm.gov.pl nie odpowiedział poprawnie. Spróbuj ponownie za chwilę."
 
+# Categories whose exception text this project did not author, and which can
+# therefore echo back what the caller submitted. `validation` messages quote
+# caller input directly (a regex pattern, an act title); `upstream` messages
+# carry the Sejm API response body, which a 4xx can fill with the parameters of
+# the rejected request. Both are redacted from ERROR and stay recoverable at
+# DEBUG. `TypeError` also lands in `validation` even though it usually signals
+# an internal bug rather than caller input — narrowing that classification is
+# out of scope here, and redacting it costs only log detail.
+_REDACTED_DETAIL_CATEGORIES = frozenset({"validation", "upstream"})
+
 
 class ToolExecutionError(Exception):
     """Public, sanitized tool execution failure."""
@@ -57,6 +67,16 @@ def _classify_error(exc: Exception) -> str:
         if isinstance(exc, exc_type):
             return category
     return "internal"
+
+
+def _status_suffix(exc: Exception) -> str:
+    """Render the HTTP status of an upstream failure, if it carries one.
+
+    The status is the one part of an upstream failure that cannot echo back
+    submitted parameters, so it stays on ERROR while the body drops to DEBUG.
+    """
+    status = getattr(exc, "status_code", None)
+    return "" if status is None else f" (HTTP {status})"
 
 
 def _public_message(exc: Exception, category: str) -> str:
@@ -80,19 +100,9 @@ def handle_tool_errors(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable
             return await func(*args, **kwargs)
         except Exception as exc:
             category = _classify_error(exc)
-            if category == "validation":
-                # Most validation-category exceptions carry caller-supplied
-                # text (a regex pattern, an act title) that can be sensitive
-                # on its own. `TypeError` is also bucketed into "validation"
-                # by `_classify_error` even though it is typically an
-                # internal bug rather than caller input — narrowing that
-                # classification is out of this task's scope, so its detail
-                # is redacted from ERROR the same as the rest of the
-                # category and stays recoverable at DEBUG. Other categories
-                # draw on constants defined in this project, so they keep
-                # their detail on ERROR.
-                logger.error("Tool %s failed [%s]", func.__name__, category)
-                logger.debug("Tool %s validation detail: %s", func.__name__, exc)
+            if category in _REDACTED_DETAIL_CATEGORIES:
+                logger.error("Tool %s failed [%s]%s", func.__name__, category, _status_suffix(exc))
+                logger.debug("Tool %s failure detail [%s]: %s", func.__name__, category, exc)
             else:
                 logger.error(
                     "Tool %s failed [%s]: %s",

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -6,6 +6,7 @@ import functools
 import logging
 from collections.abc import Awaitable, Callable
 from typing import ParamSpec, TypeVar
+from uuid import uuid4
 
 import httpx
 
@@ -18,6 +19,7 @@ from law_scrapper_mcp.client.exceptions import (
     InvalidEliError,
     SejmApiError,
 )
+from law_scrapper_mcp.logging_config import request_id_var
 from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
 
 logger = logging.getLogger(__name__)
@@ -70,6 +72,10 @@ def handle_tool_errors(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable
 
     @functools.wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        # One id per tool call. The decorator wraps all 13 tools and behaves
+        # identically on STDIO and Streamable HTTP, so this is the single
+        # place both transports need.
+        request_id_var.set(uuid4().hex[:8])
         try:
             return await func(*args, **kwargs)
         except Exception as exc:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -69,6 +69,28 @@ class TestHandleToolErrorsPublicSurface:
         assert caplog.records
         assert not caplog.records[-1].exc_info
 
+    async def test_validation_failure_keeps_detail_off_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A validation message is written by the caller and can carry a regex
+        pattern or an act title. The public exception still returns it — F13
+        is about the durable stderr record, not about the tool response."""
+        detail = "wzorzec 'zdrowie|przymusowe' jest nieprawidłowy"
+
+        @handle_tool_errors
+        async def failing_tool() -> str:
+            raise ValueError(detail)
+
+        with caplog.at_level(logging.DEBUG, logger="law_scrapper_mcp.tools.error_handling"):
+            with pytest.raises(ToolExecutionError, match="nieprawidłowy"):
+                await failing_tool()
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+
+        assert error_records
+        assert all(detail not in r.getMessage() for r in error_records)
+        assert any("failing_tool" in r.getMessage() for r in error_records)
+        assert any(detail in r.getMessage() for r in debug_records)
+
 
 @pytest.mark.asyncio
 async def test_content_too_large_message_survives_sanitization() -> None:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -39,21 +39,49 @@ class TestHandleToolErrorsPublicSurface:
     """Exercise the public `handle_tool_errors` surface, not `_classify_error`."""
 
     async def test_upstream_failure_hides_the_response_body(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The upstream body must stay out of both the response and the log.
+
+        A 4xx body can echo back the parameters of the rejected request, so
+        keeping it off the tool response while still writing it to stderr
+        would leave the same exposure open on the durable side. The status
+        survives on ERROR — it cannot carry caller input.
+        """
         secret_body = "<html>internal upstream trace</html>"
 
         @handle_tool_errors
         async def failing_tool() -> str:
             raise SejmApiError(f"HTTP 500: {secret_body}", status_code=500, url="https://api.sejm.gov.pl/eli/acts")
 
-        with caplog.at_level(logging.ERROR, logger="law_scrapper_mcp.tools.error_handling"):
+        with caplog.at_level(logging.DEBUG, logger="law_scrapper_mcp.tools.error_handling"):
             with pytest.raises(ToolExecutionError) as exc_info:
                 await failing_tool()
 
         message = str(exc_info.value)
         assert "api.sejm.gov.pl nie odpowiedział poprawnie" in message
         assert secret_body not in message
+
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+
+        assert error_records
+        assert all(secret_body not in r.getMessage() for r in error_records)
+        assert any("HTTP 500" in r.getMessage() for r in error_records)
+        assert not any(r.exc_info for r in error_records)
+        assert any(secret_body in r.getMessage() for r in debug_records)
+
+    async def test_upstream_timeout_without_status_logs_no_http_suffix(self, caplog: pytest.LogCaptureFixture) -> None:
+        """`httpx.TimeoutException` is `upstream` but carries no status code."""
+
+        @handle_tool_errors
+        async def failing_tool() -> str:
+            raise httpx.TimeoutException("read timed out")
+
+        with caplog.at_level(logging.ERROR, logger="law_scrapper_mcp.tools.error_handling"):
+            with pytest.raises(ToolExecutionError):
+                await failing_tool()
+
         assert caplog.records
-        assert not caplog.records[-1].exc_info
+        assert caplog.records[-1].getMessage() == "Tool failing_tool failed [upstream]"
 
     async def test_result_set_too_large_is_precondition_without_traceback(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,79 @@
+"""Tests for the log output contract: encoding, correlation id, timestamp zone.
+
+`JsonFormatter` is a function-local class inside `setup_logging`, so it cannot
+be imported. Every assertion here goes through a replaced `sys.stderr`, which
+`logging.StreamHandler` captures at `setup_logging()` call time.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from law_scrapper_mcp.logging_config import setup_logging
+
+
+class RecordingStream(io.StringIO):
+    """A stderr stand-in that records how `setup_logging` reconfigured it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reconfigured: dict[str, str] | None = None
+
+    def reconfigure(self, *, encoding: str, errors: str) -> None:
+        self.reconfigured = {"encoding": encoding, "errors": errors}
+
+
+@pytest.fixture(autouse=True)
+def restore_logging_state() -> Iterator[None]:
+    """Undo the global mutation `setup_logging` performs.
+
+    It strips every root handler, including the one pytest's `caplog` relies
+    on, so without this fixture the tests below would break unrelated tests
+    that run later in the same session.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_root_level = root.level
+    app_logger = logging.getLogger("law_scrapper_mcp")
+    saved_app_level = app_logger.level
+
+    yield
+
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_root_level)
+    app_logger.setLevel(saved_app_level)
+
+
+def test_setup_logging_forces_utf8_on_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    stream = RecordingStream()
+    monkeypatch.setattr(sys, "stderr", stream)
+
+    setup_logging(level="INFO", format="text")
+
+    assert stream.reconfigured == {"encoding": "utf-8", "errors": "backslashreplace"}
+
+
+def test_setup_logging_survives_a_stream_without_reconfigure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An embedded runtime or a replaced stream must not break server startup."""
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+
+    setup_logging(level="INFO", format="text")
+
+    logging.getLogger("law_scrapper_mcp.test").info("startup")
+
+
+def test_setup_logging_never_touches_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that stdout is never reconfigured (STDIO transport framing must be untouched)."""
+    stderr_stream = RecordingStream()
+    stdout_stream = RecordingStream()
+    monkeypatch.setattr(sys, "stderr", stderr_stream)
+    monkeypatch.setattr(sys, "stdout", stdout_stream)
+
+    setup_logging(level="INFO", format="text")
+
+    assert stdout_stream.reconfigured is None

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -17,7 +17,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from law_scrapper_mcp.logging_config import request_id_var, setup_logging
+from law_scrapper_mcp.logging_config import DEFAULT_REQUEST_ID, request_id_var, setup_logging
 from law_scrapper_mcp.tools.error_handling import handle_tool_errors
 
 
@@ -121,6 +121,22 @@ async def test_concurrent_tool_calls_log_distinct_request_ids(monkeypatch: pytes
     assert request_id_var.get() == "lifespan"
 
 
+def test_text_format_survives_a_record_without_the_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The filter supplies `request_id`; `defaults` covers whatever escapes it.
+
+    A record formatted by a handler this project did not configure would
+    otherwise raise `KeyError` and be swallowed into a crash dump.
+    """
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    setup_logging(level="INFO", format="text")
+    formatter = logging.getLogger().handlers[0].formatter
+    assert formatter is not None
+
+    record = logging.LogRecord("uvicorn.error", logging.INFO, __file__, 1, "started", None, None)
+
+    assert f"[{DEFAULT_REQUEST_ID}]" in formatter.format(record)
+
+
 def test_polish_diacritics_are_not_escaped(monkeypatch: pytest.MonkeyPatch) -> None:
     """Escaped diacritics would make `grep` useless on Polish error messages."""
     message = "Nie znaleziono aktu — żółć, ląd, ważne"
@@ -138,11 +154,11 @@ def test_polish_diacritics_are_not_escaped(monkeypatch: pytest.MonkeyPatch) -> N
     setup_logging(level="INFO", format="text")
     logging.getLogger("law_scrapper_mcp.test").info(message)
     rendered_text = text_stream.getvalue()
-    # A missing `request_id` filter/formatter mismatch raises `KeyError` inside
-    # `Formatter.format()`; `logging.Handler.handleError()` swallows it and
-    # echoes the record's message back into this same stream as part of its
-    # own crash dump, which would make a bare `message in rendered_text`
-    # assertion pass even though text-format rendering is broken end to end.
+    # Any formatter failure — a `request_id` the record lacks, a broken format
+    # string — is swallowed by `logging.Handler.handleError()`, which echoes
+    # the record's message back into this same stream as part of its crash
+    # dump. A bare `message in rendered_text` assertion would pass on output
+    # that is broken end to end, so rule the crash dump out first.
     assert "--- Logging error ---" not in rendered_text
     assert "law_scrapper_mcp.test - [lifespan] - INFO" in rendered_text
     assert message in rendered_text

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -7,14 +7,18 @@ be imported. Every assertion here goes through a replaced `sys.stderr`, which
 
 from __future__ import annotations
 
+import asyncio
 import io
+import json
 import logging
+import re
 import sys
 from collections.abc import Iterator
 
 import pytest
 
-from law_scrapper_mcp.logging_config import setup_logging
+from law_scrapper_mcp.logging_config import request_id_var, setup_logging
+from law_scrapper_mcp.tools.error_handling import handle_tool_errors
 
 
 class RecordingStream(io.StringIO):
@@ -77,3 +81,68 @@ def test_setup_logging_never_touches_stdout(monkeypatch: pytest.MonkeyPatch) -> 
     setup_logging(level="INFO", format="text")
 
     assert stdout_stream.reconfigured is None
+
+
+def test_json_record_carries_request_id_outside_a_tool_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stream)
+    setup_logging(level="INFO", format="json")
+
+    logging.getLogger("law_scrapper_mcp.test").info("lifespan started")
+
+    payload = json.loads(stream.getvalue().strip())
+    assert payload["request_id"] == "lifespan"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_calls_log_distinct_request_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two asyncio tasks must not see each other's correlation id.
+
+    Each task runs in a copy of the context, so `.set()` inside one is
+    invisible to the other and to the caller.
+    """
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stream)
+    setup_logging(level="INFO", format="json")
+    log = logging.getLogger("law_scrapper_mcp.test")
+
+    @handle_tool_errors
+    async def fake_tool(name: str) -> str:
+        await asyncio.sleep(0)  # force interleaving
+        log.info("inside %s", name)
+        return name
+
+    await asyncio.gather(fake_tool("a"), fake_tool("b"))
+
+    ids = [json.loads(line)["request_id"] for line in stream.getvalue().splitlines() if line.strip()]
+    assert len(ids) == 2
+    assert ids[0] != ids[1]
+    assert all(re.fullmatch(r"[0-9a-f]{8}", value) for value in ids)
+    assert request_id_var.get() == "lifespan"
+
+
+def test_polish_diacritics_are_not_escaped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Escaped diacritics would make `grep` useless on Polish error messages."""
+    message = "Nie znaleziono aktu — żółć, ląd, ważne"
+
+    json_stream = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", json_stream)
+    setup_logging(level="INFO", format="json")
+    logging.getLogger("law_scrapper_mcp.test").info(message)
+    rendered = json_stream.getvalue()
+    assert message in rendered
+    assert "\\u017c" not in rendered
+
+    text_stream = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", text_stream)
+    setup_logging(level="INFO", format="text")
+    logging.getLogger("law_scrapper_mcp.test").info(message)
+    rendered_text = text_stream.getvalue()
+    # A missing `request_id` filter/formatter mismatch raises `KeyError` inside
+    # `Formatter.format()`; `logging.Handler.handleError()` swallows it and
+    # echoes the record's message back into this same stream as part of its
+    # own crash dump, which would make a bare `message in rendered_text`
+    # assertion pass even though text-format rendering is broken end to end.
+    assert "--- Logging error ---" not in rendered_text
+    assert "law_scrapper_mcp.test - [lifespan] - INFO" in rendered_text
+    assert message in rendered_text

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -146,3 +146,30 @@ def test_polish_diacritics_are_not_escaped(monkeypatch: pytest.MonkeyPatch) -> N
     assert "--- Logging error ---" not in rendered_text
     assert "law_scrapper_mcp.test - [lifespan] - INFO" in rendered_text
     assert message in rendered_text
+
+
+def test_json_timestamp_is_explicit_utc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The timestamp field must be timezone-aware and explicitly marked as UTC.
+
+    A naive timestamp (without +00:00 or Z) is ambiguous: log aggregators
+    default to local time, which in Europe/Warsaw would show events two hours
+    earlier than correlated upstream events. The suffix +00:00 is the ISO 8601
+    way to explicitly mark UTC.
+    """
+    from datetime import datetime
+
+    stream = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stream)
+    setup_logging(level="INFO", format="json")
+
+    logging.getLogger("law_scrapper_mcp.test").info("test message")
+
+    payload = json.loads(stream.getvalue().strip())
+    timestamp_str = payload["timestamp"]
+
+    # Must end with +00:00 (ISO 8601 explicit UTC marker)
+    assert timestamp_str.endswith("+00:00"), f"Expected timestamp to end with +00:00, got {timestamp_str}"
+
+    # Must parse as timezone-aware datetime
+    parsed = datetime.fromisoformat(timestamp_str)
+    assert parsed.tzinfo is not None, f"Timestamp must be timezone-aware, got {parsed}"

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 import uvicorn
 
 from law_scrapper_mcp import server as server_module
+
+
+@pytest.fixture(autouse=True)
+def isolate_logging_setup(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep `main()` from reconfiguring the process on the way past.
+
+    `main()` calls `setup_logging()`, which strips every root handler (the one
+    `caplog` needs included) and reconfigures `sys.stderr` — under pytest that
+    is the capture stream, and nothing here restores it. Neither effect is what
+    these tests are about, so the call is stubbed rather than undone.
+    """
+    monkeypatch.setattr(server_module, "setup_logging", lambda *args, **kwargs: None)
+    yield
 
 
 def test_uvicorn_config_carries_the_graceful_shutdown_window() -> None:

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -481,14 +481,11 @@ async def test_store_keeps_query_text_off_info(caplog: pytest.LogCaptureFixture)
     store = ResultStore(max_sets=5, ttl=60)
     query = "keywords=zdrowie psychiczne, przymusowe leczenie"
 
-    # `test_server_bootstrap.py` exercises `server.main()`, which calls
-    # `setup_logging()` and pins the `law_scrapper_mcp` logger's level at
-    # INFO for the rest of the process (no restore fixture there, unlike
-    # `test_logging_config.py`). Passing `logger="law_scrapper_mcp"` here —
-    # the ancestor `setup_logging()` actually mutates, not a path to this
-    # specific module — makes `caplog.at_level` save and restore that
-    # logger's level too, so this test does not depend on which other test
-    # modules ran first.
+    # Scoped to `law_scrapper_mcp` rather than to this module's own path: that
+    # ancestor is the logger `setup_logging()` pins to INFO, so naming it here
+    # makes `caplog.at_level` save and restore that level too. Without it, any
+    # test that runs `setup_logging()` earlier in the session would leave the
+    # DEBUG record below filtered out before `caplog` ever sees it.
     with caplog.at_level(logging.DEBUG, logger="law_scrapper_mcp"):
         result_set_id = await store.store(results=[], query_summary=query, total_count=7)
 

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from unittest.mock import patch
 
@@ -470,3 +471,31 @@ class TestResultStoreFilterAndStore:
         assert output.filtered_count == 0
         assert output.result_set_id is None
         assert output.filters_applied["pattern"] == "nonexistent-pattern-xyz"
+
+
+@pytest.mark.asyncio
+async def test_store_keeps_query_text_off_info(caplog: pytest.LogCaptureFixture) -> None:
+    """In the legal domain the query itself can be sensitive, even when every
+    act it matches is public. INFO keeps identifiers and counts; the text
+    stays recoverable at DEBUG."""
+    store = ResultStore(max_sets=5, ttl=60)
+    query = "keywords=zdrowie psychiczne, przymusowe leczenie"
+
+    # `test_server_bootstrap.py` exercises `server.main()`, which calls
+    # `setup_logging()` and pins the `law_scrapper_mcp` logger's level at
+    # INFO for the rest of the process (no restore fixture there, unlike
+    # `test_logging_config.py`). Passing `logger="law_scrapper_mcp"` here —
+    # the ancestor `setup_logging()` actually mutates, not a path to this
+    # specific module — makes `caplog.at_level` save and restore that
+    # logger's level too, so this test does not depend on which other test
+    # modules ran first.
+    with caplog.at_level(logging.DEBUG, logger="law_scrapper_mcp"):
+        result_set_id = await store.store(results=[], query_summary=query, total_count=7)
+
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+
+    assert info_records, "store() must still report the result set on INFO"
+    assert all(query not in r.getMessage() for r in info_records)
+    assert any(result_set_id in r.getMessage() for r in info_records)
+    assert any(query in r.getMessage() for r in debug_records)


### PR DESCRIPTION
## Summary

This PR implements **four interconnected logging improvements** across the MCP server to achieve production-grade observability while protecting sensitive legal query text:

- **F40**: Request correlation IDs (`request_id` field) allow tracing a single tool call across concurrent requests
- **F13**: User query text no longer leaks to INFO-level logs in result stores or tool error paths
- **F49**: Polish diacritics pass through stderr and JSON unescaped and unmangled
- **F50**: Log timestamps carry explicit UTC designation (`+00:00`) instead of naive values

All four changes are bundled in one PR because they touch the same `logging_config.py` fileâ€”splitting them would create rebasing friction without the granularity that four separate commits already provide within this PR.

## Structure

Five commits (the fifth records the change in CHANGELOG):

1. `fix(logging): force UTF-8 on stderr` â€” Prerequisite for ensuring diacritics survive
2. `feat(logging): add request correlation id` â€” Unique per-tool-call ID, context-local
3. `fix(logging): keep user query text off INFO` â€” Split query into DEBUG-only log records
4. `fix(logging): stamp log timestamps as explicit UTC` â€” Add `+00:00` suffix to JSON timestamps
5. `docs(changelog): record the log output contract change` â€” Update CHANGELOG for observability

## Verification

- âś… 1056 unit tests pass
- âś… ruff check + mypy validation pass
- âś… Backward-compatible: only log output format changes, no API or tool behavior changes
- âś… F13 security: query text never reaches INFO-level persistent storage on stderr
- âś… F40 observability: correlated requests visible in `request_id` field
- âś… F49 & F50: UTF-8 and timezone contracts explicit

## Ready for code review

This PR awaits your review on GitHub before merge.
