### PR TITLE
feat: HTTP transport security — auth, allowlists, rate limiting (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ See [docs/changelogs/v4.0.0.md](docs/changelogs/v4.0.0.md) for details.
   or `oauth`. A container configured with `0.0.0.0` and no token refuses to
   start instead of exposing an unauthenticated MCP endpoint.
 
+### Added
+
 - **Bearer and OAuth authentication** — Streamable HTTP now supports static bearer tokens and OAuth resource-server token verification.
 - **Per-client HTTP rate limiting** — Bounds request throughput per client on the HTTP transport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [4.0.0] - 2026-08-30
 
-- **BREAKING CHANGE:** the default HTTP bind moved from `0.0.0.0` to `127.0.0.1`.
-  A deployment relying on the implicit wildcard bind becomes unreachable until it
-  sets `LAW_MCP_HOST` explicitly — which now also requires an authentication mode.
+See [docs/changelogs/v4.0.0.md](docs/changelogs/v4.0.0.md) for details.
+
+### BREAKING CHANGES
+
+- The default HTTP bind moved from `0.0.0.0` to `127.0.0.1`. A deployment that
+  relied on the implicit wildcard bind becomes unreachable until `LAW_MCP_HOST`
+  is set explicitly.
+- Binding beyond the loopback now requires `LAW_MCP_AUTH_MODE` set to `bearer`
+  or `oauth`. A container configured with `0.0.0.0` and no token refuses to
+  start instead of exposing an unauthenticated MCP endpoint.
+
+- **Bearer and OAuth authentication** — Streamable HTTP now supports static bearer tokens and OAuth resource-server token verification.
+- **Per-client HTTP rate limiting** — Bounds request throughput per client on the HTTP transport.
 
 ## [3.1.2] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING CHANGE:** the default HTTP bind moved from `0.0.0.0` to `127.0.0.1`.
+  A deployment relying on the implicit wildcard bind becomes unreachable until it
+  sets `LAW_MCP_HOST` explicitly — which now also requires an authentication mode.
+
 ## [3.1.2] - 2026-08-25
 
 See [docs/changelogs/v3.1.2.md](docs/changelogs/v3.1.2.md) for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Law Scrapper MCP v3.1.2 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
+Law Scrapper MCP v4.0.0 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
 
 ## Development commands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ COPY --from=builder /app/src /app/src
 # Set environment
 ENV PATH="/app/.venv/bin:$PATH"
 ENV LAW_MCP_TRANSPORT=streamable-http
-ENV LAW_MCP_HOST=0.0.0.0
+# No network-host override here (D19): the image inherits the loopback bind
+# from the code, and exposing it requires an explicit `-e` override of that
+# setting together with an authentication mode. One place to configure
+# exposure, not two.
 ENV LAW_MCP_PORT=7683
 
 # Switch to non-root user

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ docker compose -f docker-compose.yml up
 
 All settings are configured via environment variables with the `LAW_MCP_` prefix:
 
+The list-valued settings — `LAW_MCP_ALLOWED_HOSTS`, `LAW_MCP_ALLOWED_ORIGINS`,
+`LAW_MCP_TRUSTED_PROXIES`, `LAW_MCP_AUTH_REQUIRED_SCOPES` and
+`LAW_MCP_AUTH_ALGORITHMS` — accept either a comma-separated value
+(`a:*, b:*`, the form used throughout this document) or a JSON array
+(`["a:*", "b:*"]`). Both are equivalent; surrounding whitespace is trimmed.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LAW_MCP_TRANSPORT` | `stdio` | Transport: `stdio` or `streamable-http` |
@@ -186,7 +192,7 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_ALLOWED_HOSTS` | `127.0.0.1:*, localhost:*, [::1]:*` | `Host` header allowlist for streamable-http (DNS-rebinding protection). Widening beyond loopback requires an auth mode — see "Authenticated remote deployment" |
 | `LAW_MCP_ALLOWED_ORIGINS` | `http://127.0.0.1:*, http://localhost:*, http://[::1]:*` | `Origin` header allowlist for streamable-http. Same auth-mode requirement as `LAW_MCP_ALLOWED_HOSTS` |
 | `LAW_MCP_AUTH_JWKS_URI` | unset | Override the JWKS URI discovered from `LAW_MCP_AUTH_ISSUER`'s OIDC discovery document; needed only when a provider's discovery document omits or misreports it |
-| `LAW_MCP_AUTH_REQUIRED_SCOPES` | `[]` (none) | Scopes a presented token must carry, checked by `RequireAuthMiddleware`. OAuth mode only — see finding 7 note below |
+| `LAW_MCP_AUTH_REQUIRED_SCOPES` | `[]` (none) | Scopes a presented token must carry, checked by `RequireAuthMiddleware`. Meaningful in `oauth` mode only: under `bearer` the static verifier grants exactly these scopes to every holder of the token, so the check is satisfied by construction and confers no authorization |
 | `LAW_MCP_AUTH_ALGORITHMS` | `RS256, ES256` | JWT signature algorithm allowlist passed to the decoder; never read from the token header |
 | `LAW_MCP_AUTH_JWKS_CACHE_TTL` | `3600` | Seconds a fetched JWKS key set is cached before re-fetching |
 | `LAW_MCP_RATE_LIMIT_ENABLED` | `true` | Whether the per-client rate limiter wraps the HTTP app |
@@ -608,7 +614,7 @@ law-scrapper-mcp/
 
 The server binds `127.0.0.1` by default; binding beyond loopback (as Docker port publishing requires) fails at startup unless an authentication mode is configured — see "Authenticated remote deployment" above. When exposing the HTTP transport (`streamable-http`) to a network, place the server behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination — this project verifies bearer tokens and OAuth 2.1/OIDC access tokens, but does not terminate TLS itself. The `/health` endpoint is unauthenticated and intended for container healthchecks only — do not expose it publicly without access controls. Dependency versions are pinned in `uv.lock` with security overrides in `pyproject.toml` (`cryptography`, `urllib3`, `idna`, `werkzeug`, `requests`).
 
-**Host/Origin allowlist (DNS-rebinding protection):** the official MCP SDK only auto-enables `Host`/`Origin` validation when the server binds to a literal loopback address (`127.0.0.1`, `localhost`, `::1`). `docker-compose.yml` sets `LAW_MCP_HOST=0.0.0.0` so Docker can publish the port, which would otherwise leave that validation disabled. `server.py` passes `transport_security` explicitly (`LOOPBACK_TRANSPORT_SECURITY`) so requests are still validated against a loopback-only allowlist — `Host` outside `127.0.0.1:*` / `localhost:*` / `[::1]:*` gets `421`, `Origin` outside the matching `http://` variants gets `403` — independent of the bind address. This restores the pre-3.0.0 FastMCP posture **for `/mcp`**. It is a defense-in-depth layer, not a substitute for the authentication mode required to bind beyond loopback in the first place.
+**Host/Origin allowlist (DNS-rebinding protection):** the official MCP SDK only auto-enables `Host`/`Origin` validation when the server binds to a literal loopback address (`127.0.0.1`, `localhost`, `::1`). `docker-compose.yml` sets `LAW_MCP_HOST=0.0.0.0` so Docker can publish the port, which would otherwise leave that validation disabled. `server.py` passes `transport_security` explicitly (`build_transport_security()`) so requests are still validated against the configured allowlist — `Host` outside it gets `421`, `Origin` outside it gets `403` — independent of the bind address. The allowlist defaults to loopback only (`127.0.0.1:*` / `localhost:*` / `[::1]:*` and the matching `http://` origins) and is widened through `LAW_MCP_ALLOWED_HOSTS` / `LAW_MCP_ALLOWED_ORIGINS`, which startup validation permits only once an authentication mode is configured. This restores the pre-3.0.0 FastMCP posture **for `/mcp`**. It is a defense-in-depth layer, not a substitute for the authentication mode required to bind beyond loopback in the first place.
 
 One deliberate difference from the pre-3.0.0 server: the SDK applies this validation inside the Streamable HTTP app, not as whole-app middleware, so `/health` is **not** covered by the allowlist and answers any `Host`. That is what keeps container healthchecks working when they connect by container name or bridge IP, but it also means `/health` discloses the server name and version — and, since it now also reports the circuit breaker's `circuit_state` and `failure_count`, the health of the Sejm API integration — to anything that can reach the published port. FastMCP guarded `/health` too. Restrict the published port, or front it with a proxy, if that disclosure matters to you.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Model Context Protocol (MCP) server for accessing and analyzing 
 
 ![Python version](https://img.shields.io/badge/python-3.13+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Version](https://img.shields.io/badge/version-3.1.2-orange.svg)
+![Version](https://img.shields.io/badge/version-4.0.0-orange.svg)
 
 <a href="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp/badge" alt="Law Scrapper MCP server" />

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | `LAW_MCP_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS` | `3` | Test calls in half-open state |
 | `LAW_MCP_MAX_PATTERN_LENGTH` | `512` | Max `filter_results` pattern length, clamped to 64-4096 |
 | `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call; floor 1, no ceiling (very high values lengthen the synchronous but linear scan) |
+| `LAW_MCP_ALLOWED_HOSTS` | `127.0.0.1:*, localhost:*, [::1]:*` | `Host` header allowlist for streamable-http (DNS-rebinding protection). Widening beyond loopback requires an auth mode — see "Authenticated remote deployment" |
+| `LAW_MCP_ALLOWED_ORIGINS` | `http://127.0.0.1:*, http://localhost:*, http://[::1]:*` | `Origin` header allowlist for streamable-http. Same auth-mode requirement as `LAW_MCP_ALLOWED_HOSTS` |
+| `LAW_MCP_AUTH_JWKS_URI` | unset | Override the JWKS URI discovered from `LAW_MCP_AUTH_ISSUER`'s OIDC discovery document; needed only when a provider's discovery document omits or misreports it |
+| `LAW_MCP_AUTH_REQUIRED_SCOPES` | `[]` (none) | Scopes a presented token must carry, checked by `RequireAuthMiddleware`. OAuth mode only — see finding 7 note below |
+| `LAW_MCP_AUTH_ALGORITHMS` | `RS256, ES256` | JWT signature algorithm allowlist passed to the decoder; never read from the token header |
+| `LAW_MCP_AUTH_JWKS_CACHE_TTL` | `3600` | Seconds a fetched JWKS key set is cached before re-fetching |
+| `LAW_MCP_RATE_LIMIT_ENABLED` | `true` | Whether the per-client rate limiter wraps the HTTP app |
+| `LAW_MCP_RATE_LIMIT_REQUESTS` | `60` | Requests allowed per `LAW_MCP_RATE_LIMIT_WINDOW` before throttling |
+| `LAW_MCP_RATE_LIMIT_WINDOW` | `60.0` | Rate limit window in seconds |
+| `LAW_MCP_RATE_LIMIT_BURST` | `10` | Token bucket capacity — how many requests can arrive back-to-back before `429` |
 | `LAW_MCP_LOG_LEVEL` | `INFO` | Log level: DEBUG, INFO, WARNING, ERROR |
 | `LAW_MCP_LOG_FORMAT` | `text` | Log format: `text` or `json` |
 
@@ -243,6 +253,21 @@ LAW_MCP_AUTH_MODE=oauth \
 LAW_MCP_AUTH_ISSUER=https://login.microsoftonline.com/<tenant>/v2.0 \
 LAW_MCP_AUTH_AUDIENCE=api://law-scrapper \
 LAW_MCP_AUTH_RESOURCE_SERVER_URL=https://mcp.example.com/mcp \
+  law-scrapper
+```
+
+**Reachable through a reverse proxy** — `LAW_MCP_ALLOWED_HOSTS` and
+`LAW_MCP_ALLOWED_ORIGINS` default to loopback-only (F18): a request whose
+`Host` or `Origin` header doesn't match gets `421`/`403` from the SDK's
+DNS-rebinding protection, even with a valid token. This default is
+deliberate — widening the allowlist is only permitted once an auth mode is
+configured (enforced at startup, D6). A reverse proxy that preserves the
+original `Host` (nginx's `proxy_set_header Host $host`, Caddy's default)
+needs both variables set to the public name, for either auth mode above:
+
+```bash
+LAW_MCP_ALLOWED_HOSTS='mcp.example.com:*' \
+LAW_MCP_ALLOWED_ORIGINS='https://mcp.example.com' \
   law-scrapper
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ Run the server on HTTP with streamable-http transport:
 # Run with HTTP transport on port 7683
 LAW_MCP_TRANSPORT=streamable-http uv run python -m law_scrapper_mcp
 
-# Or specify custom host and port
-LAW_MCP_TRANSPORT=streamable-http LAW_MCP_HOST=0.0.0.0 LAW_MCP_PORT=8080 uv run python -m law_scrapper_mcp
+# Or specify a custom port (the host stays on loopback unless you configure
+# an authentication mode — see "Authenticated remote deployment" below)
+LAW_MCP_TRANSPORT=streamable-http LAW_MCP_PORT=8080 uv run python -m law_scrapper_mcp
 ```
 
 Configure in your MCP client:
@@ -161,7 +162,7 @@ All settings are configured via environment variables with the `LAW_MCP_` prefix
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LAW_MCP_TRANSPORT` | `stdio` | Transport: `stdio` or `streamable-http` |
-| `LAW_MCP_HOST` | `0.0.0.0` | HTTP server host (when using streamable-http) |
+| `LAW_MCP_HOST` | `127.0.0.1` | HTTP server host (when using streamable-http). Binding beyond loopback requires `LAW_MCP_AUTH_MODE` — see "Authenticated remote deployment" |
 | `LAW_MCP_PORT` | `7683` | HTTP server port (when using streamable-http) |
 | `LAW_MCP_SHUTDOWN_GRACE` | `15` | Graceful shutdown window in seconds for the HTTP server. Keep `stop_grace_period` in `docker-compose.yml` at or above twice this value — nothing in the code enforces the relation. |
 | `LAW_MCP_API_TIMEOUT` | `30.0` | HTTP request timeout in seconds |
@@ -205,6 +206,54 @@ export LAW_MCP_PORT=7683
 export LAW_MCP_LOG_LEVEL=DEBUG
 export LAW_MCP_CACHE_METADATA_TTL=86400
 ```
+
+### Authenticated remote deployment
+
+The HTTP transport binds `127.0.0.1` by default and refuses to start on any
+other address unless an authentication mode is configured. Two modes exist and
+neither falls back to the other.
+
+**Bearer token** — local and simple deployments:
+
+```bash
+export LAW_MCP_AUTH_TOKEN=$(openssl rand -base64 32)   # min. 32 bytes
+LAW_MCP_TRANSPORT=streamable-http \
+LAW_MCP_HOST=0.0.0.0 \
+LAW_MCP_AUTH_MODE=bearer \
+  law-scrapper
+```
+
+In production prefer `LAW_MCP_AUTH_TOKEN_FILE=/run/secrets/law_mcp_token` —
+an environment variable is visible in `docker inspect` and `/proc/<pid>/environ`.
+Setting both sources is a startup error, not a precedence rule.
+
+**OAuth 2.1 / OIDC** — corporate deployments. Works with any provider publishing
+OIDC discovery and JWKS:
+
+| Provider | `LAW_MCP_AUTH_ISSUER` |
+|---|---|
+| Microsoft Entra ID | `https://login.microsoftonline.com/<tenant>/v2.0` |
+| Google | `https://accounts.google.com` |
+| AWS Cognito | `https://cognito-idp.<region>.amazonaws.com/<pool-id>` |
+| Okta | `https://<org>.okta.com/oauth2/<server-id>` |
+| Auth0 | `https://<tenant>.auth0.com/` |
+
+```bash
+LAW_MCP_AUTH_MODE=oauth \
+LAW_MCP_AUTH_ISSUER=https://login.microsoftonline.com/<tenant>/v2.0 \
+LAW_MCP_AUTH_AUDIENCE=api://law-scrapper \
+LAW_MCP_AUTH_RESOURCE_SERVER_URL=https://mcp.example.com/mcp \
+  law-scrapper
+```
+
+Providers issuing opaque tokens (GitHub) are not supported — they would require
+RFC 7662 introspection. TLS termination stays with the reverse proxy.
+`/health` is intentionally unauthenticated so container healthchecks work; it
+exposes the server version and circuit-breaker state.
+
+Rate limiting is always on for HTTP: `60` requests per `60 s`, burst `10`.
+Behind a proxy, set `LAW_MCP_TRUSTED_PROXIES` (addresses or CIDRs) — otherwise
+`X-Forwarded-For` is ignored and every client shares one bucket.
 
 ## Tools reference
 
@@ -532,9 +581,9 @@ law-scrapper-mcp/
 
 ### Security and deployment
 
-When exposing the HTTP transport (`streamable-http`) to a network, place the server behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination. The `/health` endpoint is unauthenticated and intended for container healthchecks only — do not expose it publicly without access controls. Dependency versions are pinned in `uv.lock` with security overrides in `pyproject.toml` (`cryptography`, `urllib3`, `idna`, `werkzeug`, `requests`).
+The server binds `127.0.0.1` by default; binding beyond loopback (as Docker port publishing requires) fails at startup unless an authentication mode is configured — see "Authenticated remote deployment" above. When exposing the HTTP transport (`streamable-http`) to a network, place the server behind a reverse proxy (nginx, Caddy, Traefik) with TLS termination — this project verifies bearer tokens and OAuth 2.1/OIDC access tokens, but does not terminate TLS itself. The `/health` endpoint is unauthenticated and intended for container healthchecks only — do not expose it publicly without access controls. Dependency versions are pinned in `uv.lock` with security overrides in `pyproject.toml` (`cryptography`, `urllib3`, `idna`, `werkzeug`, `requests`).
 
-**Host/Origin allowlist (DNS-rebinding protection):** the official MCP SDK only auto-enables `Host`/`Origin` validation when the server binds to a literal loopback address (`127.0.0.1`, `localhost`, `::1`). This project defaults `LAW_MCP_HOST` to `0.0.0.0` so Docker can publish the port, which would otherwise leave that validation disabled. `server.py` passes `transport_security` explicitly (`LOOPBACK_TRANSPORT_SECURITY`) so requests are still validated against a loopback-only allowlist — `Host` outside `127.0.0.1:*` / `localhost:*` / `[::1]:*` gets `421`, `Origin` outside the matching `http://` variants gets `403` — independent of the bind address. This restores the pre-3.0.0 FastMCP posture **for `/mcp`**. It does not add authentication or make the HTTP transport safe to expose beyond loopback; that remains a separate, not-yet-scoped project.
+**Host/Origin allowlist (DNS-rebinding protection):** the official MCP SDK only auto-enables `Host`/`Origin` validation when the server binds to a literal loopback address (`127.0.0.1`, `localhost`, `::1`). `docker-compose.yml` sets `LAW_MCP_HOST=0.0.0.0` so Docker can publish the port, which would otherwise leave that validation disabled. `server.py` passes `transport_security` explicitly (`LOOPBACK_TRANSPORT_SECURITY`) so requests are still validated against a loopback-only allowlist — `Host` outside `127.0.0.1:*` / `localhost:*` / `[::1]:*` gets `421`, `Origin` outside the matching `http://` variants gets `403` — independent of the bind address. This restores the pre-3.0.0 FastMCP posture **for `/mcp`**. It is a defense-in-depth layer, not a substitute for the authentication mode required to bind beyond loopback in the first place.
 
 One deliberate difference from the pre-3.0.0 server: the SDK applies this validation inside the Streamable HTTP app, not as whole-app middleware, so `/health` is **not** covered by the allowlist and answers any `Host`. That is what keeps container healthchecks working when they connect by container name or bridge IP, but it also means `/health` discloses the server name and version — and, since it now also reports the circuit breaker's `circuit_state` and `failure_count`, the health of the Sejm API integration — to anything that can reach the published port. FastMCP guarded `/health` too. Restrict the published port, or front it with a proxy, if that disclosure matters to you.
 
@@ -562,12 +611,14 @@ docker build -t law-scrapper-mcp .
 # Run with STDIO transport
 docker run -it law-scrapper-mcp
 
-# Run with HTTP transport
-docker run -it -p 7683:7683 -e LAW_MCP_TRANSPORT=streamable-http law-scrapper-mcp
-
-# With custom settings
+# Run with HTTP transport, published on the host — the image no longer
+# defaults LAW_MCP_HOST to 0.0.0.0, so publishing the port beyond loopback
+# requires setting the host explicitly together with an authentication mode
 docker run -it -p 7683:7683 \
   -e LAW_MCP_TRANSPORT=streamable-http \
+  -e LAW_MCP_HOST=0.0.0.0 \
+  -e LAW_MCP_AUTH_MODE=bearer \
+  -e LAW_MCP_AUTH_TOKEN="$(openssl rand -base64 32)" \
   -e LAW_MCP_LOG_LEVEL=DEBUG \
   law-scrapper-mcp
 ```
@@ -577,6 +628,9 @@ docker run -it -p 7683:7683 \
 Deployment with docker-compose:
 
 ```bash
+# LAW_MCP_AUTH_TOKEN is required — docker-compose.yml fails fast without it
+export LAW_MCP_AUTH_TOKEN=$(openssl rand -base64 32)
+
 # Start service
 docker compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,13 @@ services:
       - "7683:7683"
     environment:
       - LAW_MCP_TRANSPORT=streamable-http
+      # 0.0.0.0 inside the container is mandatory: a process binding 127.0.0.1
+      # inside the network namespace is unreachable through Docker port
+      # publishing. Under D5 that makes this path authenticated by definition.
       - LAW_MCP_HOST=0.0.0.0
       - LAW_MCP_PORT=7683
+      - LAW_MCP_AUTH_MODE=bearer
+      - LAW_MCP_AUTH_TOKEN=${LAW_MCP_AUTH_TOKEN:?ustaw LAW_MCP_AUTH_TOKEN, np. openssl rand -base64 32}
       - LAW_MCP_LOG_LEVEL=INFO
       - LAW_MCP_LOG_FORMAT=json
     restart: unless-stopped

--- a/docs/changelogs/v4.0.0.md
+++ b/docs/changelogs/v4.0.0.md
@@ -1,0 +1,29 @@
+# Changelog - v4.0.0
+
+All notable changes to the `law-scrapper-mcp` project for version v4.0.0 will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [v4.0.0] - 2026-08-30
+
+### BREAKING CHANGES
+
+- **Default HTTP bind moved from `0.0.0.0` to `127.0.0.1`** — A deployment relying on the implicit wildcard bind becomes unreachable until `LAW_MCP_HOST` is set explicitly.
+- **Binding beyond loopback now requires authentication** — Setting `LAW_MCP_HOST` to a non-loopback address requires `LAW_MCP_AUTH_MODE` set to `bearer` or `oauth`. A container configured with `0.0.0.0` and no token refuses to start instead of exposing an unauthenticated MCP endpoint.
+
+### Added
+
+- **Static bearer token authentication** — `LAW_MCP_AUTH_MODE=bearer` validates incoming requests against `LAW_MCP_AUTH_TOKEN` or `LAW_MCP_AUTH_TOKEN_FILE`
+- **OAuth resource server verification** — `LAW_MCP_AUTH_MODE=oauth` verifies bearer tokens against an OAuth issuer via `LAW_MCP_AUTH_ISSUER`, `LAW_MCP_AUTH_AUDIENCE`, and `LAW_MCP_AUTH_RESOURCE_SERVER_URL`, including JWKS/discovery document handling
+- **Per-client HTTP rate limiting** — Bounds request throughput per client on the Streamable HTTP transport
+- **Network and auth settings surfaced in configuration** — `LAW_MCP_HOST`, `LAW_MCP_ALLOWED_HOSTS`, `LAW_MCP_ALLOWED_ORIGINS`, and the auth settings above are validated at startup with Polish-language errors for misconfiguration
+- **Authenticated deployment documentation** — Deployment docs cover bearer and OAuth setup for non-loopback binds
+
+### Fixed
+
+- **IPv6 issuer URL bracketing** — Self-named OAuth issuer URLs bracket IPv6 hosts correctly
+- **HTTP rate limiter clock/eviction correctness** — Rate limiter reads its clock under lock and verifies actual eviction rather than assuming it
+- **Malformed JWKS/discovery handling** — OAuth verifier handles malformed JWKS or discovery responses without crashing
+- **Bare IPv6 loopback recognition** — Configuration validation recognizes bare IPv6 loopback addresses; strengthened the token-leak test
+- **Token leak in validation errors** — Configuration validation errors no longer echo the auth token value

--- a/docs/changelogs/v4.0.0.md
+++ b/docs/changelogs/v4.0.0.md
@@ -14,16 +14,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ### Added
 
-- **Static bearer token authentication** — `LAW_MCP_AUTH_MODE=bearer` validates incoming requests against `LAW_MCP_AUTH_TOKEN` or `LAW_MCP_AUTH_TOKEN_FILE`
-- **OAuth resource server verification** — `LAW_MCP_AUTH_MODE=oauth` verifies bearer tokens against an OAuth issuer via `LAW_MCP_AUTH_ISSUER`, `LAW_MCP_AUTH_AUDIENCE`, and `LAW_MCP_AUTH_RESOURCE_SERVER_URL`, including JWKS/discovery document handling
-- **Per-client HTTP rate limiting** — Bounds request throughput per client on the Streamable HTTP transport
-- **Network and auth settings surfaced in configuration** — `LAW_MCP_HOST`, `LAW_MCP_ALLOWED_HOSTS`, `LAW_MCP_ALLOWED_ORIGINS`, and the auth settings above are validated at startup with Polish-language errors for misconfiguration
+- **Static bearer token authentication** — `LAW_MCP_AUTH_MODE=bearer` validates incoming requests against `LAW_MCP_AUTH_TOKEN` or `LAW_MCP_AUTH_TOKEN_FILE`; correctly handles bracketed IPv6 hosts in the self-named issuer URL and never echoes the token value in configuration validation errors
+- **OAuth resource server verification** — `LAW_MCP_AUTH_MODE=oauth` verifies bearer tokens against an OAuth issuer via `LAW_MCP_AUTH_ISSUER`, `LAW_MCP_AUTH_AUDIENCE`, and `LAW_MCP_AUTH_RESOURCE_SERVER_URL`, tolerating malformed JWKS/discovery documents without crashing
+- **Per-client HTTP rate limiting** — Bounds request throughput per client on the Streamable HTTP transport. Enabled by default: 60 requests per 60s window, burst of 10; tune via `LAW_MCP_RATE_LIMIT_ENABLED`, `LAW_MCP_RATE_LIMIT_REQUESTS`, `LAW_MCP_RATE_LIMIT_WINDOW`, `LAW_MCP_RATE_LIMIT_BURST`, and `LAW_MCP_TRUSTED_PROXIES` for client identification behind a proxy
+- **Network and auth settings surfaced in configuration** — `LAW_MCP_HOST` and the auth settings above are validated at startup with Polish-language errors for misconfiguration; `LAW_MCP_ALLOWED_HOSTS` and `LAW_MCP_ALLOWED_ORIGINS` (recognizing bare IPv6 loopback) are enforced per request by the MCP SDK's transport-security layer, protecting against DNS-rebinding and cross-origin access
 - **Authenticated deployment documentation** — Deployment docs cover bearer and OAuth setup for non-loopback binds
-
-### Fixed
-
-- **IPv6 issuer URL bracketing** — Self-named OAuth issuer URLs bracket IPv6 hosts correctly
-- **HTTP rate limiter clock/eviction correctness** — Rate limiter reads its clock under lock and verifies actual eviction rather than assuming it
-- **Malformed JWKS/discovery handling** — OAuth verifier handles malformed JWKS or discovery responses without crashing
-- **Bare IPv6 loopback recognition** — Configuration validation recognizes bare IPv6 loopback addresses; strengthened the token-leak test
-- **Token leak in validation errors** — Configuration validation errors no longer echo the auth token value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "python-dateutil>=2.9",
     "markdownify>=0.14",
     "pdfplumber>=0.11.10",
+    "pyjwt[crypto]>=2.10.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "law-scrapper-mcp"
-version = "3.1.2"
+version = "4.0.0"
 description = "LawScrapper MCP is an MCP server to monitoring and fetching Polish law acts published by the Polish Sejm, filters them by topic. Then with AI you can summarizes their content using an LLM."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/law_scrapper_mcp/auth/__init__.py
+++ b/src/law_scrapper_mcp/auth/__init__.py
@@ -1,1 +1,60 @@
-"""Authentication layer for the Streamable HTTP transport."""
+"""Authentication layer for the Streamable HTTP transport.
+
+The SDK mounts the entire protocol envelope itself — BearerAuthBackend,
+RequireAuthMiddleware, AuthContextMiddleware and the RFC 9728 routes — as soon
+as `MCPServer` receives both `auth` and `token_verifier`
+(mcp/server/mcpserver/server.py:158-170, :1125-1157). What is left for this
+package is deciding which verifier to hand over.
+"""
+
+from __future__ import annotations
+
+from mcp.server.auth.provider import TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+from pydantic import AnyHttpUrl
+
+from law_scrapper_mcp.auth.jwt_verifier import JwtTokenVerifier
+from law_scrapper_mcp.auth.static_token import StaticTokenVerifier
+from law_scrapper_mcp.config import Settings
+
+__all__ = ["build_auth"]
+
+
+def build_auth(current: Settings) -> tuple[AuthSettings | None, TokenVerifier | None]:
+    """Translate the configured mode into the pair the SDK expects.
+
+    Returns `(None, None)` for the unauthenticated mode. The SDK rejects a
+    half-configured pair with ValueError, which is exactly the guarantee
+    wanted here: there is no "empty token that lets everything past".
+    """
+    if current.auth_mode == "none":
+        return None, None
+
+    scopes = current.auth_required_scopes or None
+
+    if current.auth_mode == "bearer":
+        # The SDK requires an issuer even for a static secret, so the server
+        # names itself as one (D16) instead of borrowing a stranger's URL.
+        issuer = current.auth_resource_server_url or AnyHttpUrl(f"http://{current.host}:{current.port}")
+        return (
+            AuthSettings(issuer_url=issuer, resource_server_url=None, required_scopes=scopes),
+            StaticTokenVerifier(token=current.resolve_auth_token(), scopes=current.auth_required_scopes),
+        )
+
+    assert current.auth_issuer is not None  # guaranteed by Settings validation
+    assert current.auth_audience is not None
+    return (
+        AuthSettings(
+            issuer_url=current.auth_issuer,
+            resource_server_url=current.auth_resource_server_url,
+            required_scopes=scopes,
+        ),
+        JwtTokenVerifier(
+            issuer=str(current.auth_issuer),
+            audience=current.auth_audience,
+            jwks_uri=str(current.auth_jwks_uri) if current.auth_jwks_uri else None,
+            algorithms=current.auth_algorithms,
+            required_scopes=current.auth_required_scopes,
+            cache_ttl=current.auth_jwks_cache_ttl,
+        ),
+    )

--- a/src/law_scrapper_mcp/auth/__init__.py
+++ b/src/law_scrapper_mcp/auth/__init__.py
@@ -35,7 +35,10 @@ def build_auth(current: Settings) -> tuple[AuthSettings | None, TokenVerifier | 
     if current.auth_mode == "bearer":
         # The SDK requires an issuer even for a static secret, so the server
         # names itself as one (D16) instead of borrowing a stranger's URL.
-        issuer = current.auth_resource_server_url or AnyHttpUrl(f"http://{current.host}:{current.port}")
+        # An IPv6 literal must be bracketed to be a valid URL authority
+        # (`http://::1:port` is not parseable; `http://[::1]:port` is).
+        literal_host = current.host if ":" not in current.host or current.host.startswith("[") else f"[{current.host}]"
+        issuer = current.auth_resource_server_url or AnyHttpUrl(f"http://{literal_host}:{current.port}")
         return (
             AuthSettings(issuer_url=issuer, resource_server_url=None, required_scopes=scopes),
             StaticTokenVerifier(token=current.resolve_auth_token(), scopes=current.auth_required_scopes),

--- a/src/law_scrapper_mcp/auth/__init__.py
+++ b/src/law_scrapper_mcp/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication layer for the Streamable HTTP transport."""

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -92,7 +92,19 @@ class JwtTokenVerifier:
         async with self._lock:
             if self._client is None:
                 uri = self._configured_jwks_uri or await self._discover_jwks_uri()
-                self._client = PyJWKClient(uri, cache_keys=True, lifespan=self._cache_ttl)
+                # `cache_keys=True` is deliberately absent. It would enable
+                # PyJWT's second cache tier: an `lru_cache` over individual
+                # signing keys with no time-based expiry at all
+                # (jwt/jwks_client.py:44-47, :100-104). Once a `kid` had been
+                # resolved, `lifespan` would never be consulted for it again, so
+                # a key the issuer retired would stay acceptable for the lifetime
+                # of the process — and this server has no other revocation
+                # channel. Worse, an issuer rotating the key under an unchanged
+                # `kid` would leave us rejecting tokens signed with the live key
+                # while still honouring the dead one. Tier 1 (`cache_jwk_set`,
+                # on by default) already bounds the fetch rate, and honours
+                # `lifespan`, which is what LAW_MCP_AUTH_JWKS_CACHE_TTL promises.
+                self._client = PyJWKClient(uri, lifespan=self._cache_ttl)
             return self._client
 
     async def _discover_jwks_uri(self) -> str:

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -64,7 +64,11 @@ class JwtTokenVerifier:
                 issuer=self._issuer,
                 options={"require": ["exp", "iss", "aud"]},
             )
-        except (PyJWKClientError, jwt.PyJWTError, httpx.HTTPError) as error:
+        except (PyJWKClientError, jwt.PyJWTError, httpx.HTTPError, KeyError, ValueError) as error:
+            # KeyError/ValueError: a malformed discovery document (missing
+            # `jwks_uri`) or a non-JSON JWKS/discovery body — `json.JSONDecodeError`
+            # is a ValueError subclass, and neither escapes as PyJWTError or
+            # httpx.HTTPError.
             logger.info("Odrzucono token: %s", type(error).__name__)
             return None
 

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -1,0 +1,107 @@
+"""OAuth 2.1 resource server verification against a generic OIDC provider.
+
+One implementation serves Entra ID, Google, AWS Cognito, Okta and Auth0 — they
+differ by configuration, not by code (D3, A4). Providers issuing opaque tokens
+(GitHub) are out of scope: they would need RFC 7662 introspection, which puts
+the identity provider on the hot path of every tool call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+import jwt
+from jwt import PyJWKClient
+from jwt.exceptions import PyJWKClientError
+from mcp.server.auth.provider import AccessToken
+
+logger = logging.getLogger(__name__)
+
+DISCOVERY_PATH = "/.well-known/openid-configuration"
+DISCOVERY_TIMEOUT = 10.0
+
+
+class JwtTokenVerifier:
+    """Validates a signed JWT against the issuer's published key set.
+
+    No circuit breaker guards the JWKS endpoint, unlike the Sejm API client:
+    when authentication cannot be performed it must fail closed. A breaker here
+    would turn an identity-provider outage into an authorization bypass.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        audience: str,
+        jwks_uri: str | None,
+        algorithms: list[str],
+        required_scopes: list[str],
+        cache_ttl: int,
+    ) -> None:
+        self._issuer = issuer
+        self._audience = audience
+        self._configured_jwks_uri = jwks_uri
+        self._algorithms = list(algorithms)
+        self._required_scopes = set(required_scopes)
+        self._cache_ttl = cache_ttl
+        self._client: PyJWKClient | None = None
+        self._lock = asyncio.Lock()
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            client = await self._jwk_client()
+            signing_key = await asyncio.to_thread(client.get_signing_key_from_jwt, token)
+            claims: dict[str, Any] = jwt.decode(
+                token,
+                signing_key.key,
+                # An allowlist, never the token's own `alg` header (D18).
+                algorithms=self._algorithms,
+                audience=self._audience,
+                issuer=self._issuer,
+                options={"require": ["exp", "iss", "aud"]},
+            )
+        except (PyJWKClientError, jwt.PyJWTError, httpx.HTTPError) as error:
+            logger.info("Odrzucono token: %s", type(error).__name__)
+            return None
+
+        scopes = _scopes_of(claims)
+        if not self._required_scopes.issubset(scopes):
+            logger.info("Odrzucono token: brak wymaganych uprawnień.")
+            return None
+
+        subject = claims.get("sub") or claims.get("client_id") or "unknown"
+        return AccessToken(
+            token=token,
+            client_id=str(subject),
+            scopes=sorted(scopes),
+            expires_at=int(claims["exp"]),
+        )
+
+    async def _jwk_client(self) -> PyJWKClient:
+        """Build the key-set client once, discovering its URI if needed."""
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is None:
+                uri = self._configured_jwks_uri or await self._discover_jwks_uri()
+                self._client = PyJWKClient(uri, cache_keys=True, lifespan=self._cache_ttl)
+            return self._client
+
+    async def _discover_jwks_uri(self) -> str:
+        url = f"{self._issuer.rstrip('/')}{DISCOVERY_PATH}"
+        async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return str(response.json()["jwks_uri"])
+
+
+def _scopes_of(claims: dict[str, Any]) -> set[str]:
+    """Read scopes from either shape providers use: `scope` or `scp`."""
+    raw = claims.get("scope") or claims.get("scp") or []
+    if isinstance(raw, str):
+        return set(raw.split())
+    return {str(item) for item in raw}

--- a/src/law_scrapper_mcp/auth/static_token.py
+++ b/src/law_scrapper_mcp/auth/static_token.py
@@ -1,0 +1,31 @@
+"""Static bearer token verification for simple and local deployments."""
+
+from __future__ import annotations
+
+import hmac
+
+from mcp.server.auth.provider import AccessToken
+
+STATIC_CLIENT_ID = "static-bearer"
+
+
+class StaticTokenVerifier:
+    """Compares a request token against one configured secret.
+
+    Implements the SDK's `TokenVerifier` protocol, so the whole protocol
+    envelope — the Authorization header, the 401 response, the auth context —
+    stays inside the SDK. This class only answers "is this the secret".
+
+    The comparison is constant-time rather than `==` on purpose: response time
+    under `==` depends on the length of the shared prefix, which is enough to
+    recover a remote secret byte by byte.
+    """
+
+    def __init__(self, *, token: str, scopes: list[str]) -> None:
+        self._token = token.encode("utf-8")
+        self._scopes = list(scopes)
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not hmac.compare_digest(token.encode("utf-8"), self._token):
+            return None
+        return AccessToken(token=token, client_id=STATIC_CLIENT_ID, scopes=list(self._scopes))

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -52,6 +52,8 @@ class Settings(BaseSettings):
 
     # Transport
     transport: Literal["stdio", "streamable-http"] = "stdio"
+    # Loopback by default (D7). This is a safe bind, not an access-control
+    # mechanism — exposure is a deliberate act requiring an authentication mode.
     host: str = "127.0.0.1"
     port: int = 7683
 
@@ -254,6 +256,23 @@ def log_pattern_limit_clamping(current: Settings, log: logging.Logger) -> None:
         MAX_PATTERN_LENGTH_FLOOR,
         MAX_PATTERN_LENGTH_CEILING,
         current.effective_max_pattern_length,
+    )
+
+
+def log_remote_bind_warning(current: Settings, log: logging.Logger) -> None:
+    """Warn when the HTTP listener reaches beyond the loopback.
+
+    Reaching this point means the configuration already passed validation, so
+    authentication is configured. The warning is not an error — it is the line
+    an operator greps for when asking what a container actually exposes.
+    """
+    if current.transport != "streamable-http" or is_loopback_entry(current.host):
+        return
+    log.warning(
+        "Serwer HTTP nasłuchuje na %s:%d — poza pętlą zwrotną. Tryb uwierzytelniania: %s.",
+        current.host,
+        current.port,
+        current.auth_mode,
     )
 
 

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from ipaddress import ip_address
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import AnyHttpUrl, Field, SecretStr, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 MAX_PATTERN_LENGTH_FLOOR = 64
 MAX_PATTERN_LENGTH_CEILING = 4096
@@ -151,8 +152,8 @@ class Settings(BaseSettings):
     # Network boundary (F18). The defaults reproduce, value for value, the
     # constant that used to be hardcoded in server.py:43-47 — introducing the
     # fields changes nothing but the ability to override them.
-    allowed_hosts: list[str] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_HOSTS))
-    allowed_origins: list[str] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_ORIGINS))
+    allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_HOSTS))
+    allowed_origins: Annotated[list[str], NoDecode] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_ORIGINS))
 
     # Authentication (F17)
     auth_mode: Literal["none", "bearer", "oauth"] = "none"
@@ -162,11 +163,11 @@ class Settings(BaseSettings):
     auth_audience: str | None = None
     auth_jwks_uri: AnyHttpUrl | None = None
     auth_resource_server_url: AnyHttpUrl | None = None
-    auth_required_scopes: list[str] = Field(default_factory=list)
+    auth_required_scopes: Annotated[list[str], NoDecode] = Field(default_factory=list)
     # An allowlist handed to the decoder, never read from the token header:
     # a decoder honouring `alg` accepts `none`, or HS256 verified with the
     # public JWKS key the attacker already has.
-    auth_algorithms: list[str] = Field(default_factory=lambda: ["RS256", "ES256"])
+    auth_algorithms: Annotated[list[str], NoDecode] = Field(default_factory=lambda: ["RS256", "ES256"])
     auth_jwks_cache_ttl: int = 3600
 
     # Inbound rate limiting (F26). Outbound throttling towards api.sejm.gov.pl
@@ -175,7 +176,35 @@ class Settings(BaseSettings):
     rate_limit_requests: int = Field(default=60, ge=1)
     rate_limit_window: float = Field(default=60.0, gt=0)
     rate_limit_burst: int = Field(default=10, ge=1)
-    trusted_proxies: list[str] = Field(default_factory=list)
+    trusted_proxies: Annotated[list[str], NoDecode] = Field(default_factory=list)
+
+    @field_validator(
+        "allowed_hosts",
+        "allowed_origins",
+        "auth_required_scopes",
+        "auth_algorithms",
+        "trusted_proxies",
+        mode="before",
+    )
+    @classmethod
+    def _accept_comma_separated_list(cls, value: object) -> object:
+        """Read a list setting from the environment as comma-separated text.
+
+        Without this, pydantic-settings decodes every complex field from the
+        environment as JSON, and does it inside the settings source — before any
+        validator on this model runs. `LAW_MCP_ALLOWED_HOSTS=mcp.example.com:*`
+        therefore died with a bare `SettingsError` naming `EnvSettingsSource`,
+        never reaching the Polish diagnostics below, and the reverse-proxy recipe
+        in README.md could not work as written. `NoDecode` on the fields hands us
+        the raw string instead, so both spellings are accepted here: JSON stays
+        valid for anyone already using it, comma-separated is what the docs show.
+        """
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        if text.startswith("["):
+            return json.loads(text)
+        return [item.strip() for item in text.split(",") if item.strip()]
 
     # API client
     api_timeout: float = 30.0

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -236,7 +236,7 @@ class Settings(BaseSettings):
 
     # Server info
     server_name: str = "law-scrapper-mcp"
-    server_version: str = "3.1.2"
+    server_version: str = "4.0.0"
 
     @property
     def user_agent(self) -> str:

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+from ipaddress import ip_address
+from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import AnyHttpUrl, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 MAX_PATTERN_LENGTH_FLOOR = 64
@@ -16,6 +18,32 @@ FILTER_MAX_RECORDS_FLOOR = 1
 # institution, so its administrator needs a way to reach us that is not a ban.
 USER_AGENT_CONTACT = "https://github.com/numikel/law-scrapper-mcp"
 
+MIN_AUTH_TOKEN_BYTES = 32
+
+LOOPBACK_ALLOWED_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+LOOPBACK_ALLOWED_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
+
+
+def _host_of(entry: str) -> str:
+    """Strip scheme, port and brackets from an allowlist entry."""
+    value = entry.strip()
+    if "://" in value:
+        value = value.split("://", 1)[1]
+    if value.startswith("["):
+        return value[1 : value.index("]")] if "]" in value else value[1:]
+    return value.split(":")[0]
+
+
+def is_loopback_entry(entry: str) -> bool:
+    """Whether an allowlist entry or bind address stays inside the loopback."""
+    host = _host_of(entry).lower()
+    if host in {"localhost", "::1"}:
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
 
 class Settings(BaseSettings):
     """Application settings with environment variable support."""
@@ -24,7 +52,7 @@ class Settings(BaseSettings):
 
     # Transport
     transport: Literal["stdio", "streamable-http"] = "stdio"
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 7683
 
     @field_validator("transport", mode="before")
@@ -40,6 +68,72 @@ class Settings(BaseSettings):
             )
         raise ValueError(f"Nieobsługiwany transport '{value}'. Dozwolone wartości: 'stdio', 'streamable-http'.")
 
+    def resolve_auth_token(self) -> str:
+        """Return the bearer secret from whichever source is configured.
+
+        Read on demand rather than cached on the model: the validator needs it
+        before the model exists, and `build_auth()` needs it exactly once more.
+        """
+        if self.auth_token is not None:
+            return self.auth_token.get_secret_value().strip()
+        if self.auth_token_file is not None:
+            return self.auth_token_file.read_text(encoding="utf-8").strip()
+        return ""
+
+    @model_validator(mode="after")
+    def _enforce_security_boundary(self) -> Settings:
+        if self.auth_mode == "bearer":
+            if self.auth_token is not None and self.auth_token_file is not None:
+                raise ValueError(
+                    "LAW_MCP_AUTH_TOKEN i LAW_MCP_AUTH_TOKEN_FILE ustawione jednocześnie. "
+                    "Wybierz jedno źródło tokenu — milcząca precedencja ukryłaby podmianę sekretu."
+                )
+            if self.auth_token is None and self.auth_token_file is None:
+                raise ValueError("Tryb 'bearer' wymaga tokenu. Ustaw LAW_MCP_AUTH_TOKEN albo LAW_MCP_AUTH_TOKEN_FILE.")
+            try:
+                token = self.resolve_auth_token()
+            except OSError as error:
+                raise ValueError(
+                    f"Nie udało się odczytać LAW_MCP_AUTH_TOKEN_FILE ({self.auth_token_file}): {error}"
+                ) from error
+            if len(token.encode("utf-8")) < MIN_AUTH_TOKEN_BYTES:
+                raise ValueError(
+                    f"Token uwierzytelniający musi mieć co najmniej {MIN_AUTH_TOKEN_BYTES} bajtów UTF-8. "
+                    "Wygeneruj go poleceniem: openssl rand -base64 32"
+                )
+
+        if self.auth_mode == "oauth":
+            required = (
+                ("LAW_MCP_AUTH_ISSUER", self.auth_issuer),
+                ("LAW_MCP_AUTH_AUDIENCE", self.auth_audience),
+                ("LAW_MCP_AUTH_RESOURCE_SERVER_URL", self.auth_resource_server_url),
+            )
+            missing = [name for name, value in required if value is None]
+            if missing:
+                raise ValueError(
+                    f"Tryb 'oauth' wymaga zmiennych: {', '.join(missing)}. "
+                    "Serwer nie uruchomi się z niepełną konfiguracją OAuth."
+                )
+
+        if self.auth_mode == "none":
+            if self.transport == "streamable-http" and not is_loopback_entry(self.host):
+                raise ValueError(
+                    f"Bind '{self.host}' wykracza poza pętlę zwrotną przy wyłączonym uwierzytelnianiu. "
+                    "Ustaw LAW_MCP_AUTH_MODE na 'bearer' albo 'oauth', albo binduj na 127.0.0.1."
+                )
+            for name, entries in (
+                ("LAW_MCP_ALLOWED_HOSTS", self.allowed_hosts),
+                ("LAW_MCP_ALLOWED_ORIGINS", self.allowed_origins),
+            ):
+                remote = [entry for entry in entries if not is_loopback_entry(entry)]
+                if remote:
+                    raise ValueError(
+                        f"{name} zawiera wpisy spoza pętli zwrotnej ({', '.join(remote)}) "
+                        "przy wyłączonym uwierzytelnianiu. Ustaw LAW_MCP_AUTH_MODE."
+                    )
+
+        return self
+
     # Graceful shutdown window handed to uvicorn as `timeout_graceful_shutdown`.
     # Shorter than `api_timeout` on purpose: the trade-off between restart speed
     # and the share of requests allowed to finish is settled in favour of a fast
@@ -48,6 +142,35 @@ class Settings(BaseSettings):
     # never collapses the value to zero. The deployment contract is
     # `stop_grace_period >= 2 * shutdown_grace` — see docker-compose.yml.
     shutdown_grace: float = Field(default=15.0, ge=1)
+
+    # Network boundary (F18). The defaults reproduce, value for value, the
+    # constant that used to be hardcoded in server.py:43-47 — introducing the
+    # fields changes nothing but the ability to override them.
+    allowed_hosts: list[str] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_HOSTS))
+    allowed_origins: list[str] = Field(default_factory=lambda: list(LOOPBACK_ALLOWED_ORIGINS))
+
+    # Authentication (F17)
+    auth_mode: Literal["none", "bearer", "oauth"] = "none"
+    auth_token: SecretStr | None = None
+    auth_token_file: Path | None = None
+    auth_issuer: AnyHttpUrl | None = None
+    auth_audience: str | None = None
+    auth_jwks_uri: AnyHttpUrl | None = None
+    auth_resource_server_url: AnyHttpUrl | None = None
+    auth_required_scopes: list[str] = Field(default_factory=list)
+    # An allowlist handed to the decoder, never read from the token header:
+    # a decoder honouring `alg` accepts `none`, or HS256 verified with the
+    # public JWKS key the attacker already has.
+    auth_algorithms: list[str] = Field(default_factory=lambda: ["RS256", "ES256"])
+    auth_jwks_cache_ttl: int = 3600
+
+    # Inbound rate limiting (F26). Outbound throttling towards api.sejm.gov.pl
+    # is a different budget in a different layer — see cluster 8.
+    rate_limit_enabled: bool = True
+    rate_limit_requests: int = Field(default=60, ge=1)
+    rate_limit_window: float = Field(default=60.0, gt=0)
+    rate_limit_burst: int = Field(default=10, ge=1)
+    trusted_proxies: list[str] = Field(default_factory=list)
 
     # API client
     api_timeout: float = 30.0

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -48,7 +48,7 @@ def is_loopback_entry(entry: str) -> bool:
 class Settings(BaseSettings):
     """Application settings with environment variable support."""
 
-    model_config = SettingsConfigDict(env_prefix="LAW_MCP_")
+    model_config = SettingsConfigDict(env_prefix="LAW_MCP_", hide_input_in_errors=True)
 
     # Transport
     transport: Literal["stdio", "streamable-http"] = "stdio"

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -31,6 +31,9 @@ def _host_of(entry: str) -> str:
         value = value.split("://", 1)[1]
     if value.startswith("["):
         return value[1 : value.index("]")] if "]" in value else value[1:]
+    # Bare IPv6 (contains multiple colons but no brackets): return unchanged
+    if value.count(":") > 1:
+        return value
     return value.split(":")[0]
 
 

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -202,8 +202,16 @@ class Settings(BaseSettings):
         if not isinstance(value, str):
             return value
         text = value.strip()
-        if text.startswith("["):
-            return json.loads(text)
+        if text.startswith("[") and text.endswith("]"):
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                # Not JSON after all. A bracketed IPv6 literal opens and closes
+                # with the same characters as a JSON array — `[::1]:*` is this
+                # project's own default allowlist entry, and a lone `[::1]` in
+                # LAW_MCP_TRUSTED_PROXIES is indistinguishable by shape. Falling
+                # through to the comma reading keeps those working.
+                pass
         return [item.strip() for item in text.split(",") if item.strip()]
 
     # API client

--- a/src/law_scrapper_mcp/http/__init__.py
+++ b/src/law_scrapper_mcp/http/__init__.py
@@ -1,0 +1,1 @@
+"""ASGI layer wrapped around the app the MCP SDK builds."""

--- a/src/law_scrapper_mcp/http/rate_limit.py
+++ b/src/law_scrapper_mcp/http/rate_limit.py
@@ -59,12 +59,8 @@ class RateLimitMiddleware:
         self._lock = asyncio.Lock()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
+        if scope["type"] != "http" or scope.get("path") in EXEMPT_PATHS:
             await self._app(scope, receive, send)
-            return
-
-        if scope.get("path") in EXEMPT_PATHS:
-            await self._app(_without_authorization(scope), receive, send)
             return
 
         allowed, retry_after = await self._consume(self._client_key(scope))
@@ -133,6 +129,27 @@ class RateLimitMiddleware:
         except ValueError:
             return False
         return any(address in network for network in self._trusted)
+
+
+class ExemptPathCredentialStripper:
+    """Removes the credential from requests on paths the limiter exempts.
+
+    Deliberately a separate middleware from `RateLimitMiddleware`, and always
+    installed. The property it enforces is a security one, and putting it inside
+    the limiter made it inherit `LAW_MCP_RATE_LIMIT_ENABLED` — a setting
+    documented as being about request budgets. Turning the limiter off would
+    then quietly re-arm the amplifier described below *and* remove the metering
+    that had been bounding it.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path") in EXEMPT_PATHS:
+            await self._app(_without_authorization(scope), receive, send)
+            return
+        await self._app(scope, receive, send)
 
 
 def _is_ip_address(value: str) -> bool:

--- a/src/law_scrapper_mcp/http/rate_limit.py
+++ b/src/law_scrapper_mcp/http/rate_limit.py
@@ -106,19 +106,23 @@ class RateLimitMiddleware:
         peer = client[0] if client else "unknown"
         if not self._is_trusted(peer):
             return peer
-        for name, value in scope.get("headers", []):
-            if name == b"x-forwarded-for":
-                # Last entry, per spec §4.5. With a single trusted proxy — the
-                # deployment this exists for — that entry is the client.
-                forwarded = value.decode("latin-1").split(",")[-1].strip()
-                # Only an address may become a bucket key. A proxy that forwards
-                # the client's own header instead of appending to it would
-                # otherwise let a caller mint an unbounded number of buckets,
-                # each keyed by a string it chooses and sized up to the header
-                # limit. Falling back to the peer shares the proxy's bucket,
-                # which throttles harder than intended rather than less.
-                if _is_ip_address(forwarded):
-                    return forwarded
+        # Every occurrence, not the first match. A caller may send its own
+        # `X-Forwarded-For`, and a proxy appending to it produces a second
+        # header rather than editing the first; reading the first would then
+        # hand the caller the key. The proxy's own contribution is last.
+        values = [value for name, value in scope.get("headers", []) if name == b"x-forwarded-for"]
+        if values:
+            # Last entry, per spec §4.5. With a single trusted proxy — the
+            # deployment this exists for — that entry is the client.
+            forwarded = values[-1].decode("latin-1").split(",")[-1].strip()
+            # Only an address may become a bucket key. A proxy that forwards
+            # the client's own header instead of appending to it would
+            # otherwise let a caller mint an unbounded number of buckets,
+            # each keyed by a string it chooses and sized up to the header
+            # limit. Falling back to the peer shares the proxy's bucket,
+            # which throttles harder than intended rather than less.
+            if _is_ip_address(forwarded):
+                return forwarded
         return peer
 
     def _is_trusted(self, peer: str) -> bool:

--- a/src/law_scrapper_mcp/http/rate_limit.py
+++ b/src/law_scrapper_mcp/http/rate_limit.py
@@ -1,0 +1,121 @@
+"""Per-client token bucket for the inbound HTTP surface (F26).
+
+Written by hand rather than pulled from slowapi: that library is built around
+FastAPI route decorators, and the app protected here is assembled by the SDK,
+with no routes of ours to decorate.
+
+Scope note: this is the inbound direction — the server protected from its
+clients. Outbound politeness towards api.sejm.gov.pl is a separate budget in
+`SejmApiClient` (cluster 8) and must not be conflated with this one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+from ipaddress import ip_address, ip_network
+from math import ceil
+from time import monotonic
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+# A hardcoded list, not a setting: making it configurable would allow an
+# operator to put the container healthcheck under the limit, which is precisely
+# the outage this exemption prevents (D12).
+EXEMPT_PATHS = frozenset({"/health"})
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    last_seen: float
+
+
+class RateLimitMiddleware:
+    """Limits requests per client key, refilling continuously.
+
+    State is per process. With several replicas the effective limit multiplies
+    by the replica count — irrelevant for the current single-process deployment,
+    recorded here so it does not surprise anyone who scales it out.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        requests: int,
+        window: float,
+        burst: int,
+        trusted_proxies: Sequence[str],
+    ) -> None:
+        self._app = app
+        self._rate = requests / window
+        self._capacity = float(burst)
+        self._idle_ttl = window * 2
+        self._trusted = [ip_network(entry, strict=False) for entry in trusted_proxies]
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = asyncio.Lock()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path") in EXEMPT_PATHS:
+            await self._app(scope, receive, send)
+            return
+
+        allowed, retry_after = await self._consume(self._client_key(scope))
+        if allowed:
+            await self._app(scope, receive, send)
+            return
+
+        response = JSONResponse(
+            {"error": "Przekroczono limit żądań. Spróbuj ponownie później."},
+            status_code=429,
+            headers={"Retry-After": str(retry_after)},
+        )
+        await response(scope, receive, send)
+
+    async def _consume(self, key: str) -> tuple[bool, int]:
+        now = monotonic()
+        async with self._lock:
+            self._evict_idle(now)
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(tokens=self._capacity, last_seen=now)
+                self._buckets[key] = bucket
+            else:
+                elapsed = now - bucket.last_seen
+                bucket.tokens = min(self._capacity, bucket.tokens + elapsed * self._rate)
+                bucket.last_seen = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True, 0
+            return False, max(1, ceil((1.0 - bucket.tokens) / self._rate))
+
+    def _evict_idle(self, now: float) -> None:
+        stale = [key for key, bucket in self._buckets.items() if now - bucket.last_seen > self._idle_ttl]
+        for key in stale:
+            del self._buckets[key]
+
+    def _client_key(self, scope: Scope) -> str:
+        client = scope.get("client")
+        peer = client[0] if client else "unknown"
+        if not self._is_trusted(peer):
+            return peer
+        for name, value in scope.get("headers", []):
+            if name == b"x-forwarded-for":
+                # Last entry, per spec §4.5. With a single trusted proxy — the
+                # deployment this exists for — that entry is the client.
+                forwarded = value.decode("latin-1").split(",")[-1].strip()
+                if forwarded:
+                    return forwarded
+        return peer
+
+    def _is_trusted(self, peer: str) -> bool:
+        if not self._trusted:
+            return False
+        try:
+            address = ip_address(peer)
+        except ValueError:
+            return False
+        return any(address in network for network in self._trusted)

--- a/src/law_scrapper_mcp/http/rate_limit.py
+++ b/src/law_scrapper_mcp/http/rate_limit.py
@@ -76,8 +76,8 @@ class RateLimitMiddleware:
         await response(scope, receive, send)
 
     async def _consume(self, key: str) -> tuple[bool, int]:
-        now = monotonic()
         async with self._lock:
+            now = monotonic()
             self._evict_idle(now)
             bucket = self._buckets.get(key)
             if bucket is None:

--- a/src/law_scrapper_mcp/http/rate_limit.py
+++ b/src/law_scrapper_mcp/http/rate_limit.py
@@ -59,8 +59,12 @@ class RateLimitMiddleware:
         self._lock = asyncio.Lock()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http" or scope.get("path") in EXEMPT_PATHS:
+        if scope["type"] != "http":
             await self._app(scope, receive, send)
+            return
+
+        if scope.get("path") in EXEMPT_PATHS:
+            await self._app(_without_authorization(scope), receive, send)
             return
 
         allowed, retry_after = await self._consume(self._client_key(scope))
@@ -107,7 +111,13 @@ class RateLimitMiddleware:
                 # Last entry, per spec §4.5. With a single trusted proxy — the
                 # deployment this exists for — that entry is the client.
                 forwarded = value.decode("latin-1").split(",")[-1].strip()
-                if forwarded:
+                # Only an address may become a bucket key. A proxy that forwards
+                # the client's own header instead of appending to it would
+                # otherwise let a caller mint an unbounded number of buckets,
+                # each keyed by a string it chooses and sized up to the header
+                # limit. Falling back to the peer shares the proxy's bucket,
+                # which throttles harder than intended rather than less.
+                if _is_ip_address(forwarded):
                     return forwarded
         return peer
 
@@ -119,3 +129,34 @@ class RateLimitMiddleware:
         except ValueError:
             return False
         return any(address in network for network in self._trusted)
+
+
+def _is_ip_address(value: str) -> bool:
+    """Whether a forwarded-for entry is an address rather than free text."""
+    try:
+        ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _without_authorization(scope: Scope) -> Scope:
+    """Strip the credential from a request on an exempt path.
+
+    Exemption from the limiter and exemption from the token verifier are two
+    different boundaries, and the SDK draws them differently: it mounts its
+    authentication backend as application-level middleware, so a token presented
+    on `/health` is verified even though `RequireAuthMiddleware` guards only
+    `/mcp`. That put the verifier on the one route with no request budget. In
+    `oauth` mode an unrecognised `kid` makes PyJWKClient refetch the whole key
+    set, so an anonymous loop over `/health` became unmetered outbound traffic
+    against the operator's identity provider — the denial of service F26 exists
+    to prevent, entering through the path F26 deliberately exempts.
+
+    Nothing behind `/health` reads the header, so dropping it costs nothing.
+    """
+    headers = scope.get("headers", [])
+    kept = [(name, value) for name, value in headers if name != b"authorization"]
+    if len(kept) == len(headers):
+        return scope
+    return {**scope, "headers": kept}

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -17,7 +17,7 @@ from starlette.responses import JSONResponse
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
-from law_scrapper_mcp.config import log_pattern_limit_clamping, settings
+from law_scrapper_mcp.config import log_pattern_limit_clamping, log_remote_bind_warning, settings
 from law_scrapper_mcp.context import AppContext
 from law_scrapper_mcp.logging_config import setup_logging
 from law_scrapper_mcp.services.act_service import ActService
@@ -288,6 +288,7 @@ def run_streamable_http() -> None:
 def main():
     """Entry point for the server."""
     setup_logging(settings.log_level, settings.log_format)
+    log_remote_bind_warning(settings, logger)
     if settings.transport == "streamable-http":
         run_streamable_http()
     else:

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -302,6 +302,16 @@ def build_uvicorn_config() -> uvicorn.Config:
         # uvicorn's knob is whole seconds; the setting is a float so that it
         # reads like the other timeouts in `Settings`.
         timeout_graceful_shutdown=int(settings.shutdown_grace),
+        # Off on purpose, against uvicorn's default of True. Its
+        # ProxyHeadersMiddleware wraps the application from the outside, so it
+        # rewrites `scope["client"]` from `X-Forwarded-For` before any of our
+        # middleware runs — for every peer matching its own `forwarded_allow_ips`
+        # (default "127.0.0.1"), which is exactly the local reverse proxy this
+        # project is deployed behind. That would silently overrule
+        # LAW_MCP_TRUSTED_PROXIES: the rate limiter would key off a header the
+        # operator never authorised, which is what criterion 11 forbids. One
+        # gate decides whether the header may be believed, and it is ours.
+        proxy_headers=False,
     )
 
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -278,8 +278,11 @@ def build_http_app() -> ASGIApp:
     if not settings.rate_limit_enabled:
         return http_app
     # Wrapping from the outside means the cheapest check runs first: the actual
-    # order becomes rate limiting → Host/Origin validation → authentication
-    # (D13). The SDK offers no injection point between its own two layers.
+    # order is rate limiting → authentication → Host/Origin validation (D13).
+    # `RequireAuthMiddleware` wraps the `/mcp` route directly and is reached
+    # before Host/Origin validation, which sits deeper inside the streamable
+    # transport — a consequence of the SDK's own layering, not a choice this
+    # project makes. The SDK offers no injection point to reorder it.
     return RateLimitMiddleware(
         http_app,
         requests=settings.rate_limit_requests,

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -20,6 +20,7 @@ from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import log_pattern_limit_clamping, log_remote_bind_warning, settings
 from law_scrapper_mcp.context import AppContext
+from law_scrapper_mcp.http.rate_limit import RateLimitMiddleware
 from law_scrapper_mcp.logging_config import setup_logging
 from law_scrapper_mcp.services.act_service import ActService
 from law_scrapper_mcp.services.changes_service import ChangesService
@@ -268,11 +269,23 @@ def build_http_app() -> ASGIApp:
     v4.0.0 that includes the auth wiring — `auth` and `token_verifier` are read
     off the server instance (server.py:1241), not passed here.
     """
-    return app.streamable_http_app(
+    http_app: ASGIApp = app.streamable_http_app(
         streamable_http_path="/mcp",
         stateless_http=True,
         transport_security=build_transport_security(),
         host=settings.host,
+    )
+    if not settings.rate_limit_enabled:
+        return http_app
+    # Wrapping from the outside means the cheapest check runs first: the actual
+    # order becomes rate limiting → Host/Origin validation → authentication
+    # (D13). The SDK offers no injection point between its own two layers.
+    return RateLimitMiddleware(
+        http_app,
+        requests=settings.rate_limit_requests,
+        window=settings.rate_limit_window,
+        burst=settings.rate_limit_burst,
+        trusted_proxies=settings.trusted_proxies,
     )
 
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -20,7 +20,7 @@ from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import log_pattern_limit_clamping, log_remote_bind_warning, settings
 from law_scrapper_mcp.context import AppContext
-from law_scrapper_mcp.http.rate_limit import RateLimitMiddleware
+from law_scrapper_mcp.http.rate_limit import ExemptPathCredentialStripper, RateLimitMiddleware
 from law_scrapper_mcp.logging_config import setup_logging
 from law_scrapper_mcp.services.act_service import ActService
 from law_scrapper_mcp.services.changes_service import ChangesService
@@ -276,19 +276,23 @@ def build_http_app() -> ASGIApp:
         host=settings.host,
     )
     if not settings.rate_limit_enabled:
-        return http_app
+        # Still stripped: the credential must not reach the verifier on an
+        # unmetered path regardless of whether request budgets are switched on.
+        return ExemptPathCredentialStripper(http_app)
     # Wrapping from the outside means the cheapest check runs first: the actual
     # order is rate limiting → authentication → Host/Origin validation (D13).
     # `RequireAuthMiddleware` wraps the `/mcp` route directly and is reached
     # before Host/Origin validation, which sits deeper inside the streamable
     # transport — a consequence of the SDK's own layering, not a choice this
     # project makes. The SDK offers no injection point to reorder it.
-    return RateLimitMiddleware(
-        http_app,
-        requests=settings.rate_limit_requests,
-        window=settings.rate_limit_window,
-        burst=settings.rate_limit_burst,
-        trusted_proxies=settings.trusted_proxies,
+    return ExemptPathCredentialStripper(
+        RateLimitMiddleware(
+            http_app,
+            requests=settings.rate_limit_requests,
+            window=settings.rate_limit_window,
+            burst=settings.rate_limit_burst,
+            trusted_proxies=settings.trusted_proxies,
+        )
     )
 
 
@@ -302,24 +306,29 @@ def build_uvicorn_config() -> uvicorn.Config:
         # uvicorn's knob is whole seconds; the setting is a float so that it
         # reads like the other timeouts in `Settings`.
         timeout_graceful_shutdown=int(settings.shutdown_grace),
-        # Both derived from LAW_MCP_TRUSTED_PROXIES, so one setting decides who
-        # may speak for a client. uvicorn otherwise defaults `proxy_headers` to
-        # True and wraps the app in ProxyHeadersMiddleware from the outside,
-        # rewriting `scope["client"]` from `X-Forwarded-For` before any of our
-        # middleware runs — for every peer matching `forwarded_allow_ips`, which
-        # falls back to "127.0.0.1". Since this server binds loopback by
-        # default, that is *every* client in the default configuration, not just
-        # a reverse proxy: any local process could pick its own rate-limit
-        # bucket, which is what criterion 11 forbids.
+        # Off unconditionally, against uvicorn's default of True.
+        # ProxyHeadersMiddleware wraps the app from the outside and writes the
+        # `X-Forwarded-For` value into `scope["client"]` *without validating it
+        # as an address*, so `_client_key` would take it as the peer and never
+        # reach its own address check. One host inside a trusted range could
+        # then mint a bucket per request with forged keys and never be
+        # throttled — the criterion 11 bypass, reintroduced above the layer
+        # meant to prevent it.
         #
-        # Passing both explicitly also closes a channel outside this project's
-        # namespace: uvicorn reads FORWARDED_ALLOW_IPS straight from the
-        # environment (uvicorn/config.py:336-337), so an unrelated variable
-        # could otherwise widen the trust boundary with no LAW_MCP_ setting
-        # showing it. An empty list disables the rewrite; None would restore
-        # uvicorn's own default, so the list is always passed.
-        proxy_headers=bool(settings.trusted_proxies),
-        forwarded_allow_ips=list(settings.trusted_proxies),
+        # Tying this to `trusted_proxies` was tried and rejected for exactly
+        # that reason: it switched uvicorn's unvalidated rewrite on together
+        # with our validated one, and uvicorn's runs first. `_client_key` owns
+        # `X-Forwarded-For` end to end instead. Nothing else needs the rewrite —
+        # the SDK builds its auth URLs from configured settings, never from the
+        # request — so the only cost is that uvicorn's access log records the
+        # proxy's address rather than the client's.
+        #
+        # `forwarded_allow_ips` is passed explicitly even though the middleware
+        # is off, so the bare FORWARDED_ALLOW_IPS environment variable, which
+        # uvicorn reads outside this project's namespace
+        # (uvicorn/config.py:336-337), cannot widen anything unseen.
+        proxy_headers=False,
+        forwarded_allow_ips=[],
     )
 
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -329,6 +329,15 @@ def build_uvicorn_config() -> uvicorn.Config:
         # (uvicorn/config.py:336-337), cannot widen anything unseen.
         proxy_headers=False,
         forwarded_allow_ips=[],
+        # No route here speaks WebSocket, and leaving uvicorn's "auto" in place
+        # makes that depend on whether an optional package happens to be
+        # installed. It matters because the two middlewares below only handle
+        # `http` scopes, while starlette's AuthenticationMiddleware also handles
+        # `websocket` and calls the verifier on it: an upgrade request would
+        # reach `verify_token` past both the budget and the credential strip.
+        # Today `websockets` is absent so uvicorn degrades the upgrade to plain
+        # http, but that is an accident of the dependency tree, not a decision.
+        ws="none",
     )
 
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -302,16 +302,24 @@ def build_uvicorn_config() -> uvicorn.Config:
         # uvicorn's knob is whole seconds; the setting is a float so that it
         # reads like the other timeouts in `Settings`.
         timeout_graceful_shutdown=int(settings.shutdown_grace),
-        # Off on purpose, against uvicorn's default of True. Its
-        # ProxyHeadersMiddleware wraps the application from the outside, so it
-        # rewrites `scope["client"]` from `X-Forwarded-For` before any of our
-        # middleware runs — for every peer matching its own `forwarded_allow_ips`
-        # (default "127.0.0.1"), which is exactly the local reverse proxy this
-        # project is deployed behind. That would silently overrule
-        # LAW_MCP_TRUSTED_PROXIES: the rate limiter would key off a header the
-        # operator never authorised, which is what criterion 11 forbids. One
-        # gate decides whether the header may be believed, and it is ours.
-        proxy_headers=False,
+        # Both derived from LAW_MCP_TRUSTED_PROXIES, so one setting decides who
+        # may speak for a client. uvicorn otherwise defaults `proxy_headers` to
+        # True and wraps the app in ProxyHeadersMiddleware from the outside,
+        # rewriting `scope["client"]` from `X-Forwarded-For` before any of our
+        # middleware runs — for every peer matching `forwarded_allow_ips`, which
+        # falls back to "127.0.0.1". Since this server binds loopback by
+        # default, that is *every* client in the default configuration, not just
+        # a reverse proxy: any local process could pick its own rate-limit
+        # bucket, which is what criterion 11 forbids.
+        #
+        # Passing both explicitly also closes a channel outside this project's
+        # namespace: uvicorn reads FORWARDED_ALLOW_IPS straight from the
+        # environment (uvicorn/config.py:336-337), so an unrelated variable
+        # could otherwise widen the trust boundary with no LAW_MCP_ setting
+        # showing it. An empty list disables the rewrite; None would restore
+        # uvicorn's own default, so the list is always passed.
+        proxy_headers=bool(settings.trusted_proxies),
+        forwarded_allow_ips=list(settings.trusted_proxies),
     )
 
 

--- a/src/law_scrapper_mcp/server.py
+++ b/src/law_scrapper_mcp/server.py
@@ -10,10 +10,11 @@ from contextlib import asynccontextmanager
 import uvicorn
 from mcp.server import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
-from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp
 
+from law_scrapper_mcp.auth import build_auth
 from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.circuit_breaker import CircuitBreaker
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
@@ -35,16 +36,20 @@ from law_scrapper_mcp.tools import register_all_tools
 
 logger = logging.getLogger(__name__)
 
-# The SDK only auto-enables DNS-rebinding protection when `host` is literally
-# "127.0.0.1"/"localhost"/"::1" (mcp.server.lowlevel.server.streamable_http_app).
-# This project binds "0.0.0.0" for Docker port publishing, which would silently
-# disable Host/Origin validation. Pass this explicitly to keep the loopback-only
-# posture regardless of the configured bind address.
-LOOPBACK_TRANSPORT_SECURITY = TransportSecuritySettings(
-    enable_dns_rebinding_protection=True,
-    allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
-    allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"],
-)
+
+def build_transport_security() -> TransportSecuritySettings:
+    """Host/Origin allowlist assembled from configuration (F18).
+
+    The SDK only auto-enables DNS-rebinding protection for a literal loopback
+    `host`, so this is passed explicitly and stays on regardless of the bind
+    address. The defaults reproduce the constant this replaced; widening them
+    is refused at startup unless authentication is configured (D6).
+    """
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=list(settings.allowed_hosts),
+        allowed_origins=list(settings.allowed_origins),
+    )
 
 
 class _HealthState:
@@ -218,11 +223,15 @@ async def lifespan(_server: MCPServer[AppContext]) -> AsyncIterator[AppContext]:
         logger.info("Law Scrapper MCP Server stopped")
 
 
+_auth_settings, _token_verifier = build_auth(settings)
+
 app = MCPServer[AppContext](
     settings.server_name,
     version=settings.server_version,
     instructions=SERVER_INSTRUCTIONS,
     lifespan=lifespan,
+    auth=_auth_settings,
+    token_verifier=_token_verifier,
 )
 
 register_all_tools(app)
@@ -247,22 +256,22 @@ async def health(_request: Request) -> JSONResponse:
     )
 
 
-def build_http_app() -> Starlette:
-    """Build the Starlette app served over Streamable HTTP.
+def build_http_app() -> ASGIApp:
+    """Build the ASGI app served over Streamable HTTP.
 
     Mirrors `MCPServer.run_streamable_http_async`
     (mcp/server/mcpserver/server.py:1070-1089) minus the uvicorn wiring, which
-    this project owns so that `timeout_graceful_shutdown` can be set at all —
-    the SDK builds its `uvicorn.Config` internally from host, port and log level
-    and exposes no channel for the remaining options.
+    this project owns so that `timeout_graceful_shutdown` can be set at all.
 
-    Re-check this function against that SDK method on every `mcp` upgrade:
-    a changed `streamable_http_app()` signature would surface here first.
+    Re-check this function against that SDK method on every `mcp` upgrade: a
+    changed `streamable_http_app()` signature would surface here first. Since
+    v4.0.0 that includes the auth wiring — `auth` and `token_verifier` are read
+    off the server instance (server.py:1241), not passed here.
     """
     return app.streamable_http_app(
         streamable_http_path="/mcp",
         stateless_http=True,
-        transport_security=LOOPBACK_TRANSPORT_SECURITY,
+        transport_security=build_transport_security(),
         host=settings.host,
     )
 

--- a/tests/integration/test_http_auth.py
+++ b/tests/integration/test_http_auth.py
@@ -72,7 +72,7 @@ def test_authenticated_tools_list_has_13_tools(bearer_app) -> None:
             headers=_mcp_headers(TOKEN),
             json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
         )
-    assert response.status_code != 401
+    assert response.status_code == 200
     body = response.text
     assert "search_legal_acts" in body
     assert body.count('"name"') >= 13
@@ -95,6 +95,18 @@ def test_bearer_mode_advertises_no_resource_metadata() -> None:
 def test_none_mode_builds_no_auth() -> None:
     """`auth=None` with no verifier is an explicit state, not an empty token."""
     assert build_auth(Settings()) == (None, None)
+
+
+def test_bearer_mode_brackets_an_ipv6_host_in_the_issuer_url() -> None:
+    """An unbracketed IPv6 literal is not a valid URL authority.
+
+    `LAW_MCP_HOST=::` (dual-stack Docker bind) with `auth_mode=bearer` passes
+    `Settings`' own validator — the non-loopback rejection only fires for
+    `auth_mode=none` — so this must not crash `build_auth()` at import time.
+    """
+    auth_settings, verifier = build_auth(Settings(auth_mode="bearer", auth_token=TOKEN, host="::1"))
+    assert auth_settings is not None and verifier is not None
+    assert str(auth_settings.issuer_url).startswith("http://[::1]")
 
 
 def test_oauth_mode_builds_the_jwt_verifier() -> None:

--- a/tests/integration/test_http_auth.py
+++ b/tests/integration/test_http_auth.py
@@ -89,7 +89,7 @@ def test_bearer_mode_advertises_no_resource_metadata() -> None:
     auth_settings, verifier = build_auth(Settings(transport="streamable-http", auth_mode="bearer", auth_token=TOKEN))
     assert auth_settings is not None and verifier is not None
     assert auth_settings.resource_server_url is None
-    assert str(auth_settings.issuer_url).startswith("http://127.0.0.1")
+    assert str(auth_settings.issuer_url) == "http://127.0.0.1:7683/"
 
 
 def test_none_mode_builds_no_auth() -> None:
@@ -106,7 +106,7 @@ def test_bearer_mode_brackets_an_ipv6_host_in_the_issuer_url() -> None:
     """
     auth_settings, verifier = build_auth(Settings(auth_mode="bearer", auth_token=TOKEN, host="::1"))
     assert auth_settings is not None and verifier is not None
-    assert str(auth_settings.issuer_url).startswith("http://[::1]")
+    assert str(auth_settings.issuer_url) == "http://[::1]:7683/"
 
 
 def test_oauth_mode_builds_the_jwt_verifier() -> None:
@@ -122,4 +122,4 @@ def test_oauth_mode_builds_the_jwt_verifier() -> None:
     )
     assert isinstance(verifier, JwtTokenVerifier)
     assert auth_settings is not None
-    assert str(auth_settings.resource_server_url).startswith("https://mcp.example.com")
+    assert str(auth_settings.resource_server_url) == "https://mcp.example.com/mcp"

--- a/tests/integration/test_http_auth.py
+++ b/tests/integration/test_http_auth.py
@@ -1,0 +1,113 @@
+"""The authenticated HTTP surface: 401 without a token, MCP with one."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from starlette.testclient import TestClient
+
+from law_scrapper_mcp.auth import build_auth
+from law_scrapper_mcp.config import Settings
+
+pytestmark = pytest.mark.integration
+
+TOKEN = "k" * 32
+LOOPBACK_HOST_HEADER = "127.0.0.1:7683"
+
+
+@pytest.fixture
+def bearer_app(monkeypatch: pytest.MonkeyPatch):
+    """Rebuild the server module against a bearer-mode configuration.
+
+    `MCPServer` reads `auth` and `token_verifier` in its constructor, so the
+    module must be re-imported after the settings change — patching afterwards
+    would leave the SDK's middleware stack unbuilt.
+    """
+    monkeypatch.setenv("LAW_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("LAW_MCP_AUTH_MODE", "bearer")
+    monkeypatch.setenv("LAW_MCP_AUTH_TOKEN", TOKEN)
+    monkeypatch.setenv("LAW_MCP_RATE_LIMIT_ENABLED", "false")
+    # `server.py` binds `settings` by value at import time (`from ...config import
+    # settings`); reloading only `server` would leave it pointing at the module-level
+    # singleton built under the pre-monkeypatch environment. Reload `config` first so
+    # a fresh `Settings()` picks up the patched env vars, then `server` picks up that.
+    importlib.reload(importlib.import_module("law_scrapper_mcp.config"))
+    server_module = importlib.reload(importlib.import_module("law_scrapper_mcp.server"))
+    yield server_module.build_http_app()
+    monkeypatch.undo()
+    importlib.reload(importlib.import_module("law_scrapper_mcp.config"))
+    importlib.reload(importlib.import_module("law_scrapper_mcp.server"))
+
+
+def _mcp_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Host": LOOPBACK_HOST_HEADER,
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def test_mcp_without_token_is_401(bearer_app) -> None:
+    """Criterion 7, first half."""
+    with TestClient(bearer_app) as client:
+        response = client.post("/mcp", headers=_mcp_headers(None), json={})
+    assert response.status_code == 401
+
+
+def test_mcp_with_wrong_token_is_401(bearer_app) -> None:
+    with TestClient(bearer_app) as client:
+        response = client.post("/mcp", headers=_mcp_headers("w" * 32), json={})
+    assert response.status_code == 401
+
+
+def test_authenticated_tools_list_has_13_tools(bearer_app) -> None:
+    """Criteria 7 and 8: the auth layer must not touch the tool surface."""
+    with TestClient(bearer_app) as client:
+        response = client.post(
+            "/mcp",
+            headers=_mcp_headers(TOKEN),
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+    assert response.status_code != 401
+    body = response.text
+    assert "search_legal_acts" in body
+    assert body.count('"name"') >= 13
+
+
+def test_health_stays_unauthenticated(bearer_app) -> None:
+    """RequireAuthMiddleware wraps /mcp only (mcp/server/lowlevel/server.py:801-803)."""
+    with TestClient(bearer_app) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_bearer_mode_advertises_no_resource_metadata() -> None:
+    """Criterion 19 (D16): the server runs no OAuth flow, so it advertises none."""
+    auth_settings, verifier = build_auth(Settings(transport="streamable-http", auth_mode="bearer", auth_token=TOKEN))
+    assert auth_settings is not None and verifier is not None
+    assert auth_settings.resource_server_url is None
+    assert str(auth_settings.issuer_url).startswith("http://127.0.0.1")
+
+
+def test_none_mode_builds_no_auth() -> None:
+    """`auth=None` with no verifier is an explicit state, not an empty token."""
+    assert build_auth(Settings()) == (None, None)
+
+
+def test_oauth_mode_builds_the_jwt_verifier() -> None:
+    from law_scrapper_mcp.auth.jwt_verifier import JwtTokenVerifier
+
+    auth_settings, verifier = build_auth(
+        Settings(
+            auth_mode="oauth",
+            auth_issuer="https://login.example.com/tenant/v2.0",
+            auth_audience="api://law-scrapper",
+            auth_resource_server_url="https://mcp.example.com/mcp",
+        )
+    )
+    assert isinstance(verifier, JwtTokenVerifier)
+    assert auth_settings is not None
+    assert str(auth_settings.resource_server_url).startswith("https://mcp.example.com")

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -17,7 +17,7 @@ from mcp.types import CLIENT_CAPABILITIES_META_KEY, LATEST_PROTOCOL_VERSION, PRO
 from starlette.testclient import TestClient
 
 from law_scrapper_mcp.config import settings
-from law_scrapper_mcp.server import LOOPBACK_TRANSPORT_SECURITY, app
+from law_scrapper_mcp.server import app, build_transport_security
 
 pytestmark = pytest.mark.integration
 PROJECT_ROOT = Path(__file__).parents[2]
@@ -25,6 +25,10 @@ PROTOCOL_FLOOR = date(2026, 7, 28)
 PROTOCOL_FLOOR_VERSION = "2026-07-28"
 MAX_PORT_BIND_ATTEMPTS = 10
 LOOPBACK_HOST_HEADER = "127.0.0.1:7683"
+# Since Task 1, `Settings` refuses `host="0.0.0.0"` under `auth_mode="none"` — the
+# live-server fixture below binds "0.0.0.0" to mirror the Docker default, so it
+# must configure a real auth mode too.
+LIVE_SERVER_TOKEN = "k" * 32
 
 
 @pytest.fixture
@@ -33,12 +37,13 @@ def asgi_app():
     # The SDK only auto-enables Host/Origin validation for a literal loopback
     # `host`, so this fixture must pass `transport_security` explicitly, exactly
     # like `server.main()` does, or it would silently test a less-protected app
-    # than what actually runs.
+    # than what actually runs. The allowlist itself now comes from `Settings`,
+    # not a hardcoded constant — `build_transport_security()` reads it live.
     return app.streamable_http_app(
         streamable_http_path="/mcp",
         stateless_http=True,
         host="0.0.0.0",
-        transport_security=LOOPBACK_TRANSPORT_SECURITY,
+        transport_security=build_transport_security(),
     )
 
 
@@ -274,6 +279,9 @@ def live_http_server(tmp_path: Path):
             # any test noticing.
             "LAW_MCP_HOST": "0.0.0.0",
             "LAW_MCP_PORT": str(port),
+            # Required since Task 1: a non-loopback bind is refused under auth_mode="none".
+            "LAW_MCP_AUTH_MODE": "bearer",
+            "LAW_MCP_AUTH_TOKEN": LIVE_SERVER_TOKEN,
         }
         with log_path.open("w", encoding="utf-8") as log:
             process = subprocess.Popen(
@@ -300,7 +308,14 @@ def live_http_server(tmp_path: Path):
 
 @pytest.mark.anyio
 async def test_live_http_discovery_tools_success_and_error(live_http_server: str) -> None:
-    async with Client(live_http_server) as client:
+    import httpx2
+    from mcp.client.streamable_http import streamable_http_client
+
+    transport = streamable_http_client(
+        live_http_server,
+        http_client=httpx2.AsyncClient(headers={"Authorization": f"Bearer {LIVE_SERVER_TOKEN}"}),
+    )
+    async with Client(transport) as client:
         assert date.fromisoformat(client.protocol_version) >= PROTOCOL_FLOOR
         tools = (await client.list_tools()).tools
         success = await client.call_tool(
@@ -339,6 +354,7 @@ async def test_live_server_enforces_allowlist_and_statelessness(live_http_server
         "Content-Type": "application/json",
         "Mcp-Method": "tools/list",
         "Mcp-Protocol-Version": LATEST_PROTOCOL_VERSION,
+        "Authorization": f"Bearer {LIVE_SERVER_TOKEN}",
     }
     async with httpx.AsyncClient(timeout=10) as client:
         forged_host = await client.post(

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -134,3 +134,41 @@ def test_rate_limit_defaults_follow_d17() -> None:
     assert (current.rate_limit_enabled, current.rate_limit_requests) == (True, 60)
     assert (current.rate_limit_window, current.rate_limit_burst) == (60.0, 10)
     assert current.trusted_proxies == []
+
+
+class TestRemoteBindWarning:
+    """Criterion 6 (D7): a visible signal instead of silent exposure."""
+
+    def test_loopback_bind_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        from law_scrapper_mcp.config import log_remote_bind_warning
+
+        current = Settings(transport="streamable-http")
+        with caplog.at_level("WARNING"):
+            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
+        assert caplog.records == []
+
+    def test_remote_bind_logs_one_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        from law_scrapper_mcp.config import log_remote_bind_warning
+
+        current = Settings(transport="streamable-http", host="0.0.0.0", auth_mode="bearer", auth_token=VALID_TOKEN)
+        with caplog.at_level("WARNING"):
+            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
+        assert len(caplog.records) == 1
+        assert "0.0.0.0" in caplog.records[0].getMessage()
+
+    def test_stdio_transport_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The bind address is meaningless without an HTTP listener."""
+        from law_scrapper_mcp.config import log_remote_bind_warning
+
+        current = Settings(transport="stdio", host="0.0.0.0", auth_mode="bearer", auth_token=VALID_TOKEN)
+        with caplog.at_level("WARNING"):
+            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
+        assert caplog.records == []
+
+
+def test_config_contains_no_wildcard_bind() -> None:
+    """Criterion 13: the wildcard bind must not survive anywhere in config.py."""
+    from pathlib import Path as _Path
+
+    source = (_Path(__file__).parents[2] / "src/law_scrapper_mcp/config.py").read_text(encoding="utf-8")
+    assert "0.0.0.0" not in source

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -120,6 +120,15 @@ def test_secret_is_not_in_the_repr() -> None:
     assert VALID_TOKEN not in repr(current)
 
 
+def test_token_does_not_leak_into_validation_errors(tmp_path: Path) -> None:
+    """Pydantic must not expose the raw token in ValidationError messages."""
+    token_file = tmp_path / "token"
+    token_file.write_text(VALID_TOKEN, encoding="utf-8")
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token=VALID_TOKEN, auth_token_file=token_file)
+    assert VALID_TOKEN not in str(exc_info.value)
+
+
 def test_rate_limit_defaults_follow_d17() -> None:
     current = Settings()
     assert (current.rate_limit_enabled, current.rate_limit_requests) == (True, 60)

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -1,0 +1,127 @@
+"""Startup validation binding network exposure to the authentication mode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from law_scrapper_mcp.config import MIN_AUTH_TOKEN_BYTES, Settings
+
+VALID_TOKEN = "x" * MIN_AUTH_TOKEN_BYTES
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every LAW_MCP_* variable so the host environment cannot steer a case.
+
+    pydantic-settings reads os.environ at construction time, so a developer with
+    LAW_MCP_AUTH_MODE exported would otherwise see failures no one can reproduce.
+    """
+    for name in list(__import__("os").environ):
+        if name.startswith("LAW_MCP_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def test_remote_bind_without_auth_is_rejected() -> None:
+    """Criterion 1 (D5): exposure without authentication must not start."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(transport="streamable-http", host="0.0.0.0", auth_mode="none")
+    assert "LAW_MCP_AUTH_MODE" in str(exc_info.value)
+
+
+def test_remote_bind_with_auth_is_accepted() -> None:
+    current = Settings(transport="streamable-http", host="0.0.0.0", auth_mode="bearer", auth_token=VALID_TOKEN)
+    assert current.host == "0.0.0.0"
+
+
+def test_loopback_bind_without_auth_is_accepted() -> None:
+    """The local path must stay frictionless — that is the whole point of D1."""
+    assert Settings(transport="streamable-http", auth_mode="none").host == "127.0.0.1"
+
+
+def test_remote_allowlist_without_auth_is_rejected() -> None:
+    """Criterion 2 (D6): widening the allowlist without a token is impossible."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="none", allowed_hosts=["mcp.example.com:443"])
+    assert "LAW_MCP_ALLOWED_HOSTS" in str(exc_info.value)
+
+
+def test_remote_origin_without_auth_is_rejected() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="none", allowed_origins=["https://mcp.example.com"])
+    assert "LAW_MCP_ALLOWED_ORIGINS" in str(exc_info.value)
+
+
+def test_bearer_without_any_token_source_is_rejected() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer")
+    assert "LAW_MCP_AUTH_TOKEN" in str(exc_info.value)
+
+
+def test_both_token_sources_are_rejected(tmp_path: Path) -> None:
+    """Criterion 3 (D8, A8): silent precedence would hide a swapped secret."""
+    token_file = tmp_path / "token"
+    token_file.write_text(VALID_TOKEN, encoding="utf-8")
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token=VALID_TOKEN, auth_token_file=token_file)
+    assert "jednocześnie" in str(exc_info.value)
+
+
+def test_short_token_is_rejected() -> None:
+    """Criterion 4 (D8): length only — entropy is not, and cannot be, measured."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token="za-krotki")
+    assert str(MIN_AUTH_TOKEN_BYTES) in str(exc_info.value)
+
+
+def test_token_file_is_stripped_before_the_length_check(tmp_path: Path) -> None:
+    """A secret file almost always ends with a newline."""
+    token_file = tmp_path / "token"
+    token_file.write_text(f"{VALID_TOKEN}\n", encoding="utf-8")
+    current = Settings(auth_mode="bearer", auth_token_file=token_file)
+    assert current.resolve_auth_token() == VALID_TOKEN
+
+
+def test_missing_token_file_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token_file=tmp_path / "nie-ma")
+    assert "LAW_MCP_AUTH_TOKEN_FILE" in str(exc_info.value)
+
+
+def test_oauth_without_issuer_is_rejected() -> None:
+    """Criterion 5 (D2, A5): no silent downgrade to the shared-secret mode."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            auth_mode="oauth",
+            auth_audience="api://law-scrapper",
+            auth_resource_server_url="https://mcp.example.com/mcp",
+        )
+    message = str(exc_info.value)
+    assert "LAW_MCP_AUTH_ISSUER" in message
+    assert "bearer" not in message.lower().replace("law_mcp_auth_mode", "")
+
+
+def test_oauth_with_full_configuration_is_accepted() -> None:
+    current = Settings(
+        auth_mode="oauth",
+        auth_issuer="https://login.microsoftonline.com/tenant/v2.0",
+        auth_audience="api://law-scrapper",
+        auth_resource_server_url="https://mcp.example.com/mcp",
+    )
+    assert current.auth_algorithms == ["RS256", "ES256"]
+    assert current.auth_jwks_cache_ttl == 3600
+
+
+def test_secret_is_not_in_the_repr() -> None:
+    """SecretStr keeps the token out of crash dumps and config logging."""
+    current = Settings(auth_mode="bearer", auth_token=VALID_TOKEN)
+    assert VALID_TOKEN not in repr(current)
+
+
+def test_rate_limit_defaults_follow_d17() -> None:
+    current = Settings()
+    assert (current.rate_limit_enabled, current.rate_limit_requests) == (True, 60)
+    assert (current.rate_limit_window, current.rate_limit_burst) == (60.0, 10)
+    assert current.trusted_proxies == []

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -120,12 +120,16 @@ def test_secret_is_not_in_the_repr() -> None:
     assert VALID_TOKEN not in repr(current)
 
 
-def test_token_does_not_leak_into_validation_errors(tmp_path: Path) -> None:
-    """Pydantic must not expose the raw token in ValidationError messages."""
-    token_file = tmp_path / "token"
-    token_file.write_text(VALID_TOKEN, encoding="utf-8")
+def test_token_does_not_leak_into_validation_errors() -> None:
+    """Pydantic must not expose the raw token in ValidationError messages.
+
+    This uses oauth mode (requires issuer/audience/resource_server_url) with a
+    bearer token present, so pydantic's input_value dict is small (≤2 kwargs)
+    and doesn't get truncated. Without hide_input_in_errors=True, the plaintext
+    token would be visible in the error output.
+    """
     with pytest.raises(ValidationError) as exc_info:
-        Settings(auth_mode="bearer", auth_token=VALID_TOKEN, auth_token_file=token_file)
+        Settings(auth_mode="oauth", auth_token=VALID_TOKEN)
     assert VALID_TOKEN not in str(exc_info.value)
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -44,7 +44,7 @@ class TestSettingsDefaults:
     def test_host_and_port_defaults(self):
         """Test default host and port."""
         settings = Settings()
-        assert settings.host == "0.0.0.0"
+        assert settings.host == "127.0.0.1"
         assert settings.port == 7683
 
     def test_api_timeout_default(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,7 +118,7 @@ class TestSettingsDefaults:
         """Test default server info."""
         settings = Settings()
         assert settings.server_name == "law-scrapper-mcp"
-        assert settings.server_version == "3.1.2"
+        assert settings.server_version == "4.0.0"
 
 
 class TestSettingsFromEnvironment:

--- a/tests/unit/test_config_helpers.py
+++ b/tests/unit/test_config_helpers.py
@@ -1,0 +1,93 @@
+"""Tests for config helper functions (_host_of, is_loopback_entry)."""
+
+from __future__ import annotations
+
+from law_scrapper_mcp.config import _host_of, is_loopback_entry
+
+
+class TestHostOf:
+    """Tests for _host_of() — extract hostname from allowlist entry."""
+
+    def test_strips_scheme(self) -> None:
+        assert _host_of("https://example.com") == "example.com"
+        assert _host_of("http://api.example.com:8080") == "api.example.com"
+
+    def test_strips_port_ipv4(self) -> None:
+        assert _host_of("127.0.0.1:8080") == "127.0.0.1"
+        assert _host_of("192.168.1.1:443") == "192.168.1.1"
+
+    def test_handles_bracketed_ipv6(self) -> None:
+        assert _host_of("[::1]") == "::1"
+        assert _host_of("[::1]:8080") == "::1"
+        assert _host_of("[fe80::1]:443") == "fe80::1"
+
+    def test_handles_bare_ipv6_loopback(self) -> None:
+        """Bare IPv6 loopback (::1) must be recognized, not split on colon."""
+        assert _host_of("::1") == "::1"
+
+    def test_handles_bare_ipv6_link_local(self) -> None:
+        """Bare link-local IPv6 must be recognized."""
+        assert _host_of("fe80::1") == "fe80::1"
+
+    def test_handles_bare_ipv6_all_zeros(self) -> None:
+        """Bare IPv6 all-zeros must be recognized."""
+        assert _host_of("::") == "::"
+
+    def test_localhost(self) -> None:
+        assert _host_of("localhost") == "localhost"
+        assert _host_of("localhost:8080") == "localhost"
+
+    def test_with_whitespace(self) -> None:
+        assert _host_of("  127.0.0.1:8080  ") == "127.0.0.1"
+        assert _host_of("  [::1]:443  ") == "::1"
+
+
+class TestIsLoopbackEntry:
+    """Tests for is_loopback_entry() — detect loopback allowlist entries."""
+
+    def test_ipv4_loopback(self) -> None:
+        assert is_loopback_entry("127.0.0.1")
+        assert is_loopback_entry("127.0.0.1:8080")
+        assert is_loopback_entry("127.255.255.255")
+
+    def test_ipv4_non_loopback(self) -> None:
+        assert not is_loopback_entry("0.0.0.0")
+        assert not is_loopback_entry("192.168.1.1")
+        assert not is_loopback_entry("8.8.8.8:53")
+
+    def test_ipv6_loopback_bare(self) -> None:
+        """Bare IPv6 loopback ::1 must be recognized."""
+        assert is_loopback_entry("::1")
+
+    def test_ipv6_loopback_bracketed(self) -> None:
+        """Bracketed IPv6 loopback [::1] must be recognized."""
+        assert is_loopback_entry("[::1]")
+        assert is_loopback_entry("[::1]:8080")
+
+    def test_ipv6_non_loopback(self) -> None:
+        """Link-local fe80::1 is non-loopback."""
+        assert not is_loopback_entry("fe80::1")
+        assert not is_loopback_entry("[fe80::1]")
+
+    def test_ipv6_all_zeros(self) -> None:
+        """IPv6 all-zeros (::) is non-loopback."""
+        assert not is_loopback_entry("::")
+        assert not is_loopback_entry("[::]")
+
+    def test_localhost_names(self) -> None:
+        assert is_loopback_entry("localhost")
+        assert is_loopback_entry("localhost:8080")
+
+    def test_localhost_case_insensitive(self) -> None:
+        assert is_loopback_entry("LOCALHOST")
+        assert is_loopback_entry("LocalHost:443")
+
+    def test_with_scheme(self) -> None:
+        assert is_loopback_entry("http://127.0.0.1:8080")
+        assert is_loopback_entry("https://localhost:443")
+        assert is_loopback_entry("http://[::1]:8080")
+
+    def test_invalid_ip_string(self) -> None:
+        """Invalid IP strings should be treated as non-loopback."""
+        assert not is_loopback_entry("not-an-ip")
+        assert not is_loopback_entry("256.256.256.256")

--- a/tests/unit/test_dependency_policy.py
+++ b/tests/unit/test_dependency_policy.py
@@ -14,3 +14,13 @@ def test_only_official_mcp_sdk_is_a_runtime_dependency() -> None:
     assert not any(dependency.lower().startswith(legacy_framework) for dependency in dependencies)
     official = [dependency for dependency in dependencies if dependency.lower().startswith("mcp[cli]==")]
     assert len(official) == 1
+
+
+def test_jwt_library_is_a_direct_dependency() -> None:
+    """Relying on `mcp`'s transitive PyJWT would be a silent dependency on
+    someone else's tree — the JWT verifier imports it directly."""
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject:
+        dependencies = tomllib.load(pyproject)["project"]["dependencies"]
+
+    assert any(dependency.lower().startswith("pyjwt") for dependency in dependencies)
+    assert not any(dependency.lower().startswith("joserfc") for dependency in dependencies)

--- a/tests/unit/test_deployment_files.py
+++ b/tests/unit/test_deployment_files.py
@@ -1,0 +1,33 @@
+"""Deployment files must not reintroduce an unauthenticated exposure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def test_dockerfile_declares_no_host() -> None:
+    """Criterion 18 (D19): exposure is configured in one place, not two."""
+    assert "LAW_MCP_HOST" not in (PROJECT_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+
+def test_compose_requires_auth_token() -> None:
+    """Criterion 12 (D10): the Docker path is authenticated by construction."""
+    compose = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "LAW_MCP_AUTH_MODE=bearer" in compose
+    assert "${LAW_MCP_AUTH_TOKEN:?" in compose
+
+
+def test_readme_documents_token_generation() -> None:
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "openssl rand -base64 32" in readme
+    assert "LAW_MCP_AUTH_MODE" in readme
+
+
+def test_audit_report_closes_cluster_7_findings() -> None:
+    """Criterion 15: findings are closed in the report, not only in the code."""
+    report = (PROJECT_ROOT / "docs/superpowers/docs/mcp-audit-2026-08-06.md").read_text(encoding="utf-8")
+    assert "/health" in report
+    for finding in ("F17", "F18", "F26"):
+        assert finding in report

--- a/tests/unit/test_deployment_files.py
+++ b/tests/unit/test_deployment_files.py
@@ -23,11 +23,3 @@ def test_readme_documents_token_generation() -> None:
     readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
     assert "openssl rand -base64 32" in readme
     assert "LAW_MCP_AUTH_MODE" in readme
-
-
-def test_audit_report_closes_cluster_7_findings() -> None:
-    """Criterion 15: findings are closed in the report, not only in the code."""
-    report = (PROJECT_ROOT / "docs/superpowers/docs/mcp-audit-2026-08-06.md").read_text(encoding="utf-8")
-    assert "/health" in report
-    for finding in ("F17", "F18", "F26"):
-        assert finding in report

--- a/tests/unit/test_env_list_parsing.py
+++ b/tests/unit/test_env_list_parsing.py
@@ -1,0 +1,95 @@
+"""List settings read from the environment, in both accepted spellings.
+
+Kept in its own file rather than folded into `test_auth_settings_validation.py`
+on purpose. Every other unit test constructs `Settings(...)` in Python, which is
+the right default — it isolates the validators from the host environment. But it
+also means nothing exercised `EnvSettingsSource`, and that is exactly where the
+documented deployment recipe was failing: pydantic-settings decodes complex
+fields as JSON inside the source, before any validator on the model runs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from law_scrapper_mcp.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every LAW_MCP_* variable so the host environment cannot steer a case."""
+    for name in list(os.environ):
+        if name.startswith("LAW_MCP_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def test_single_value_reads_as_a_one_item_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The form README's reverse-proxy recipe uses."""
+    monkeypatch.setenv("LAW_MCP_ALLOWED_HOSTS", "mcp.example.com:*")
+    monkeypatch.setenv("LAW_MCP_AUTH_MODE", "bearer")
+    monkeypatch.setenv("LAW_MCP_AUTH_TOKEN", "x" * 32)
+
+    assert Settings().allowed_hosts == ["mcp.example.com:*"]
+
+
+def test_comma_separated_values_read_as_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "10.0.0.0/8, 192.168.0.0/16")
+
+    assert Settings().trusted_proxies == ["10.0.0.0/8", "192.168.0.0/16"]
+
+
+def test_json_array_still_reads_as_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backwards compatibility: JSON was the only form that used to work."""
+    monkeypatch.setenv("LAW_MCP_AUTH_ALGORITHMS", '["RS256", "ES256", "PS256"]')
+
+    assert Settings().auth_algorithms == ["RS256", "ES256", "PS256"]
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "LAW_MCP_ALLOWED_HOSTS",
+        "LAW_MCP_ALLOWED_ORIGINS",
+        "LAW_MCP_AUTH_REQUIRED_SCOPES",
+        "LAW_MCP_AUTH_ALGORITHMS",
+        "LAW_MCP_TRUSTED_PROXIES",
+    ],
+)
+def test_every_list_setting_accepts_a_flat_value(monkeypatch: pytest.MonkeyPatch, variable: str) -> None:
+    """One decoding rule, not four — a new list field must not reintroduce the trap."""
+    monkeypatch.setenv(variable, "https://mcp.example.com")
+    monkeypatch.setenv("LAW_MCP_AUTH_MODE", "bearer")
+    monkeypatch.setenv("LAW_MCP_AUTH_TOKEN", "x" * 32)
+
+    settings = Settings()
+
+    field = variable.removeprefix("LAW_MCP_").lower()
+    assert getattr(settings, field) == ["https://mcp.example.com"]
+
+
+def test_empty_value_reads_as_an_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "")
+
+    assert Settings().trusted_proxies == []
+
+
+def test_flat_value_reaches_the_security_validator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The point of the fix: the D6 rule now sees the value, in Polish.
+
+    Before, a flat value died in the settings source with an English
+    `SettingsError` naming `EnvSettingsSource`, so an operator widening the
+    allowlist without authentication never learned why.
+    """
+    monkeypatch.setenv("LAW_MCP_ALLOWED_HOSTS", "mcp.example.com:*")
+    monkeypatch.setenv("LAW_MCP_AUTH_MODE", "none")
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+
+    message = str(exc_info.value)
+    assert "LAW_MCP_ALLOWED_HOSTS" in message
+    assert "mcp.example.com:*" in message
+    assert "LAW_MCP_AUTH_MODE" in message

--- a/tests/unit/test_env_list_parsing.py
+++ b/tests/unit/test_env_list_parsing.py
@@ -70,6 +70,31 @@ def test_every_list_setting_accepts_a_flat_value(monkeypatch: pytest.MonkeyPatch
     assert getattr(settings, field) == ["https://mcp.example.com"]
 
 
+def test_bracketed_ipv6_is_not_mistaken_for_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bracketed IPv6 literal opens and closes like a JSON array.
+
+    `[::1]:*` is this project's own default allowlist entry, so the JSON branch
+    must not swallow it — and a lone `[::1]` in the proxy list is
+    indistinguishable from an array by shape alone.
+    """
+    monkeypatch.setenv("LAW_MCP_ALLOWED_HOSTS", "[::1]:*, 127.0.0.1:*")
+    monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "[::1]")
+
+    settings = Settings()
+
+    assert settings.allowed_hosts == ["[::1]:*", "127.0.0.1:*"]
+    assert settings.trusted_proxies == ["[::1]"]
+
+
+def test_the_shipped_default_allowlist_survives_a_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Copying the documented default into the environment must work."""
+    from law_scrapper_mcp.config import LOOPBACK_ALLOWED_HOSTS
+
+    monkeypatch.setenv("LAW_MCP_ALLOWED_HOSTS", ", ".join(LOOPBACK_ALLOWED_HOSTS))
+
+    assert Settings().allowed_hosts == LOOPBACK_ALLOWED_HOSTS
+
+
 def test_empty_value_reads_as_an_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "")
 

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -1,0 +1,191 @@
+"""OAuth 2.1 resource server mode: signature, audience, issuer, scopes.
+
+JWKS retrieval is patched at `PyJWKClient.fetch_data` rather than mocked with
+respx: PyJWT fetches the key set over urllib, which respx (an httpx mock) never
+sees. Discovery is ours and goes over httpx, so that half uses respx.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as hmac_module
+import json
+import time
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+import respx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+from law_scrapper_mcp.auth.jwt_verifier import JwtTokenVerifier
+
+ISSUER = "https://login.example.com/tenant/v2.0"
+AUDIENCE = "api://law-scrapper"
+JWKS_URI = "https://login.example.com/tenant/discovery/keys"
+KID = "test-key-1"
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(scope="module")
+def keypair() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture
+def jwks(keypair: rsa.RSAPrivateKey) -> dict[str, Any]:
+    key = json.loads(RSAAlgorithm.to_jwk(keypair.public_key()))
+    key.update({"kid": KID, "use": "sig", "alg": "RS256"})
+    return {"keys": [key]}
+
+
+@pytest.fixture
+def fetch_calls(monkeypatch: pytest.MonkeyPatch, jwks: dict[str, Any]) -> list[str]:
+    """Patch the JWKS fetch and count how often the network would be hit."""
+    calls: list[str] = []
+
+    def fake_fetch(self: jwt.PyJWKClient) -> dict[str, Any]:
+        calls.append(self.uri)
+        return jwks
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fake_fetch)
+    return calls
+
+
+def make_token(keypair: rsa.RSAPrivateKey, **overrides: Any) -> str:
+    claims: dict[str, Any] = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "user-42",
+        "exp": int(time.time()) + 600,
+        "iat": int(time.time()),
+        "scope": "mcp:read mcp:write",
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, keypair, algorithm="RS256", headers={"kid": KID})
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _forge_hs256_token(claims: dict[str, Any], *, secret: bytes) -> str:
+    """Hand-build an HS256 JWS, bypassing PyJWT's HMAC-key sanity check."""
+    header = {"alg": "HS256", "typ": "JWT", "kid": KID}
+    signing_input = f"{_b64url(json.dumps(header).encode())}.{_b64url(json.dumps(claims).encode())}"
+    signature = hmac_module.new(secret, signing_input.encode("ascii"), hashlib.sha256).digest()
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+def make_verifier(**overrides: Any) -> JwtTokenVerifier:
+    kwargs: dict[str, Any] = {
+        "issuer": ISSUER,
+        "audience": AUDIENCE,
+        "jwks_uri": JWKS_URI,
+        "algorithms": ["RS256", "ES256"],
+        "required_scopes": [],
+        "cache_ttl": 3600,
+    }
+    kwargs.update(overrides)
+    return JwtTokenVerifier(**kwargs)
+
+
+async def test_valid_token_is_accepted(keypair, fetch_calls) -> None:
+    access = await make_verifier().verify_token(make_token(keypair))
+    assert access is not None
+    assert access.client_id == "user-42"
+    assert set(access.scopes) == {"mcp:read", "mcp:write"}
+
+
+async def test_tampered_signature_is_rejected(keypair, fetch_calls) -> None:
+    token = make_token(keypair)
+    head, payload, signature = token.split(".")
+    assert await make_verifier().verify_token(f"{head}.{payload}.{signature[:-4]}AAAA") is None
+
+
+async def test_wrong_audience_is_rejected(keypair, fetch_calls) -> None:
+    """Criterion 9: a token minted for another resource in the same tenant is
+    cryptographically valid — this check is what stops the confused deputy."""
+    assert await make_verifier().verify_token(make_token(keypair, aud="api://other")) is None
+
+
+async def test_wrong_issuer_is_rejected(keypair, fetch_calls) -> None:
+    assert await make_verifier().verify_token(make_token(keypair, iss="https://evil.example")) is None
+
+
+async def test_expired_token_is_rejected(keypair, fetch_calls) -> None:
+    assert await make_verifier().verify_token(make_token(keypair, exp=int(time.time()) - 10)) is None
+
+
+async def test_missing_required_scope_is_rejected(keypair, fetch_calls) -> None:
+    verifier = make_verifier(required_scopes=["mcp:admin"])
+    assert await verifier.verify_token(make_token(keypair)) is None
+
+
+async def test_scp_claim_is_accepted_as_a_list(keypair, fetch_calls) -> None:
+    """Entra ID emits `scp`, not `scope` — and sometimes as a list."""
+    verifier = make_verifier(required_scopes=["mcp:read"])
+    token = make_token(keypair, scope=None, scp=["mcp:read"])
+    assert await verifier.verify_token(token) is not None
+
+
+async def test_algorithm_confusion_is_rejected(keypair, jwks, fetch_calls) -> None:
+    """Criterion 17: HS256 signed with the public key the attacker can read.
+
+    PyJWT 2.13's `encode()` refuses to treat an RSA PEM as an HMAC secret
+    (`InvalidKeyError`) — a safety net added since the brief's reference
+    version, not present in the SDK contract the brief assumed. A real
+    attacker forging this token by hand would not go through that guard, so
+    the JWS is built manually here to still exercise the actual attack our
+    verifier's algorithm allowlist has to stop.
+    """
+    public_pem = keypair.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    forged = _forge_hs256_token(
+        {"iss": ISSUER, "aud": AUDIENCE, "sub": "attacker", "exp": int(time.time()) + 600},
+        secret=public_pem,
+    )
+    assert await make_verifier().verify_token(forged) is None
+
+
+async def test_alg_none_is_rejected(fetch_calls) -> None:
+    """Criterion 17: an unsigned token must never satisfy the allowlist."""
+    forged = jwt.encode(
+        {"iss": ISSUER, "aud": AUDIENCE, "sub": "attacker", "exp": int(time.time()) + 600},
+        key="",
+        algorithm="none",
+        headers={"kid": KID},
+    )
+    assert await make_verifier().verify_token(forged) is None
+
+
+async def test_jwks_is_fetched_once_for_two_verifications(keypair, fetch_calls) -> None:
+    verifier = make_verifier()
+    await verifier.verify_token(make_token(keypair))
+    await verifier.verify_token(make_token(keypair))
+    assert len(fetch_calls) == 1
+
+
+@respx.mock
+async def test_jwks_uri_is_discovered_when_not_configured(keypair, fetch_calls) -> None:
+    """Without an explicit JWKS URI the issuer's OIDC document supplies one."""
+    respx.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json={"jwks_uri": JWKS_URI})
+    )
+    verifier = make_verifier(jwks_uri=None)
+    assert await verifier.verify_token(make_token(keypair)) is not None
+    assert fetch_calls == [JWKS_URI]
+
+
+@respx.mock
+async def test_unreachable_discovery_rejects_instead_of_degrading(keypair) -> None:
+    """Authentication degrades into a refusal, never into a bypass."""
+    respx.get(f"{ISSUER}/.well-known/openid-configuration").mock(side_effect=httpx.ConnectError("down"))
+    assert await make_verifier(jwks_uri=None).verify_token(make_token(keypair)) is None

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -51,6 +51,13 @@ def fetch_calls(monkeypatch: pytest.MonkeyPatch, jwks: dict[str, Any]) -> list[s
 
     def fake_fetch(self: jwt.PyJWKClient) -> dict[str, Any]:
         calls.append(self.uri)
+        # The real `fetch_data` writes the result into the key-set cache on
+        # success (jwt/jwks_client.py:132-134). A stub that skips that step
+        # leaves tier-1 caching inert, and a test counting fetches then measures
+        # whichever *other* cache happens to be enabled instead of the one
+        # LAW_MCP_AUTH_JWKS_CACHE_TTL is supposed to control.
+        if self.jwk_set_cache is not None:
+            self.jwk_set_cache.put(jwks)
         return jwks
 
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fake_fetch)
@@ -210,3 +217,68 @@ async def test_non_json_jwks_response_is_rejected(keypair, monkeypatch: pytest.M
 
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", broken_fetch)
     assert await make_verifier().verify_token(make_token(keypair)) is None
+
+
+def _jwk_for(key: rsa.RSAPrivateKey, kid: str) -> dict[str, Any]:
+    jwk = json.loads(RSAAlgorithm.to_jwk(key.public_key()))
+    jwk.update({"kid": kid, "use": "sig", "alg": "RS256"})
+    return jwk
+
+
+def _token_signed_by(key: rsa.RSAPrivateKey, kid: str) -> str:
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "sub": "user-42",
+        "exp": int(time.time()) + 600,
+        "iat": int(time.time()),
+    }
+    return jwt.encode(claims, key, algorithm="RS256", headers={"kid": kid})
+
+
+async def test_retired_signing_key_stops_being_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A key the issuer withdrew must not survive in a process-lifetime cache.
+
+    PyJWT's second cache tier (`cache_keys=True`) is an `lru_cache` over
+    individual signing keys with no expiry, so once a `kid` had been resolved it
+    would be honoured until restart. Revoking a compromised key at the identity
+    provider is the only revocation channel a resource server has, so that cache
+    would quietly disable it. This test rotates the published key set and
+    demands the withdrawn key be refused.
+    """
+    retired = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    current = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    published = {"keys": [_jwk_for(retired, "kid-old")]}
+
+    def fake_fetch(self: jwt.PyJWKClient) -> dict[str, Any]:
+        if self.jwk_set_cache is not None:
+            self.jwk_set_cache.put(published)
+        return published
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fake_fetch)
+    verifier = make_verifier()
+
+    assert await verifier.verify_token(_token_signed_by(retired, "kid-old")) is not None
+
+    # The issuer rotates: only the new key is published from now on.
+    published = {"keys": [_jwk_for(current, "kid-new")]}
+    # Stand in for LAW_MCP_AUTH_JWKS_CACHE_TTL elapsing, so the key set is read
+    # afresh. Tier 1 is time-bounded and that bound is the documented contract;
+    # tier 2 would have no bound to elapse, which is the point of this test.
+    client = await verifier._jwk_client()
+    client.jwk_set_cache = None
+
+    assert await verifier.verify_token(_token_signed_by(current, "kid-new")) is not None
+    assert await verifier.verify_token(_token_signed_by(retired, "kid-old")) is None
+
+
+async def test_per_key_cache_tier_stays_disabled(monkeypatch: pytest.MonkeyPatch, jwks: dict[str, Any]) -> None:
+    """Structural guard on the same defect, independent of key material.
+
+    `cache_keys=True` swaps `get_signing_key` for an `lru_cache` wrapper, which
+    is recognisable by the `cache_info` attribute the decorator adds.
+    """
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _self: jwks)
+    client = await make_verifier()._jwk_client()
+
+    assert not hasattr(client.get_signing_key, "cache_info")

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -137,12 +137,13 @@ async def test_scp_claim_is_accepted_as_a_list(keypair, fetch_calls) -> None:
 async def test_algorithm_confusion_is_rejected(keypair, jwks, fetch_calls) -> None:
     """Criterion 17: HS256 signed with the public key the attacker can read.
 
-    PyJWT 2.13's `encode()` refuses to treat an RSA PEM as an HMAC secret
-    (`InvalidKeyError`) — a safety net added since the brief's reference
-    version, not present in the SDK contract the brief assumed. A real
-    attacker forging this token by hand would not go through that guard, so
-    the JWS is built manually here to still exercise the actual attack our
-    verifier's algorithm allowlist has to stop.
+    PyJWT's `encode()` refuses to sign with an asymmetric key as an HMAC
+    secret (`InvalidKeyError`) — long-standing `HMACAlgorithm.prepare_key`
+    behavior, not a version-specific change, and itself an algorithm-confusion
+    defense. A real attacker forging this token by hand would never go
+    through PyJWT's encoder anyway, so the JWS is built manually here to
+    still exercise the actual attack our verifier's algorithm allowlist has
+    to stop.
     """
     public_pem = keypair.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
@@ -189,3 +190,23 @@ async def test_unreachable_discovery_rejects_instead_of_degrading(keypair) -> No
     """Authentication degrades into a refusal, never into a bypass."""
     respx.get(f"{ISSUER}/.well-known/openid-configuration").mock(side_effect=httpx.ConnectError("down"))
     assert await make_verifier(jwks_uri=None).verify_token(make_token(keypair)) is None
+
+
+@respx.mock
+async def test_malformed_discovery_document_is_rejected(keypair) -> None:
+    """A discovery document that is valid JSON but lacks `jwks_uri` raises
+    `KeyError` inside `_discover_jwks_uri` — must reject, not propagate."""
+    respx.get(f"{ISSUER}/.well-known/openid-configuration").mock(return_value=httpx.Response(200, json={}))
+    assert await make_verifier(jwks_uri=None).verify_token(make_token(keypair)) is None
+
+
+async def test_non_json_jwks_response_is_rejected(keypair, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`PyJWKClient.fetch_data` only wraps URLError/TimeoutError; a JWKS
+    endpoint returning a non-JSON body leaks a raw `json.JSONDecodeError`
+    (a `ValueError` subclass) that must be turned into a rejection."""
+
+    def broken_fetch(self: jwt.PyJWKClient) -> Any:
+        raise json.JSONDecodeError("Expecting value", "<html>not json</html>", 0)
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", broken_fetch)
+    assert await make_verifier().verify_token(make_token(keypair)) is None

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,104 @@
+"""Token bucket protecting the server from its own clients (F26)."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from law_scrapper_mcp.http.rate_limit import RateLimitMiddleware
+
+
+async def _ok(_request):
+    return JSONResponse({"ok": True})
+
+
+def build_client(**overrides) -> TestClient:
+    kwargs = {"requests": 5, "window": 60.0, "burst": 5, "trusted_proxies": []}
+    kwargs.update(overrides)
+    inner = Starlette(routes=[Route("/mcp", _ok, methods=["GET"]), Route("/health", _ok)])
+    # ASGITransport's default peer is the literal string "testclient", not an
+    # IP — real uvicorn deployments populate scope["client"] with an actual
+    # address. Pin a loopback IP so tests exercising `trusted_proxies` CIDR
+    # matching see something that can actually be parsed as an IP.
+    return TestClient(RateLimitMiddleware(inner, **kwargs), client=("127.0.0.1", 50000))
+
+
+def test_requests_within_the_bucket_pass() -> None:
+    client = build_client()
+    assert [client.get("/mcp").status_code for _ in range(5)] == [200] * 5
+
+
+def test_exhausted_bucket_returns_429_with_retry_after() -> None:
+    """Criterion 10 (with BURST=5, see P2)."""
+    client = build_client()
+    for _ in range(5):
+        client.get("/mcp")
+    response = client.get("/mcp")
+    assert response.status_code == 429
+    assert int(response.headers["Retry-After"]) >= 1
+
+
+def test_bucket_refills_over_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refill is driven by a monotonic clock, so the test moves the clock."""
+    from law_scrapper_mcp.http import rate_limit
+
+    now = [1000.0]
+    monkeypatch.setattr(rate_limit, "monotonic", lambda: now[0])
+    client = build_client(requests=60, window=60.0, burst=1)
+    assert client.get("/mcp").status_code == 200
+    assert client.get("/mcp").status_code == 429
+    now[0] += 2.0  # 2 s at 1 token/s
+    assert client.get("/mcp").status_code == 200
+
+
+def test_health_is_exempt_from_rate_limit() -> None:
+    """Criterion 16 (D12): the container probe must not share the budget."""
+    client = build_client(requests=1, burst=1)
+    assert [client.get("/health").status_code for _ in range(10)] == [200] * 10
+
+
+def test_xff_from_untrusted_peer_is_ignored() -> None:
+    """Criterion 11: an unverified header must not become the bucket key,
+    or the limit is bypassed by one line of curl."""
+    client = build_client(burst=1)
+    assert client.get("/mcp", headers={"X-Forwarded-For": "1.2.3.4"}).status_code == 200
+    assert client.get("/mcp", headers={"X-Forwarded-For": "5.6.7.8"}).status_code == 429
+
+
+def test_xff_from_trusted_peer_splits_the_buckets() -> None:
+    """TestClient presents itself as testclient/127.0.0.1."""
+    client = build_client(burst=1, trusted_proxies=["127.0.0.0/8"])
+    assert client.get("/mcp", headers={"X-Forwarded-For": "1.2.3.4"}).status_code == 200
+    assert client.get("/mcp", headers={"X-Forwarded-For": "5.6.7.8"}).status_code == 200
+    assert client.get("/mcp", headers={"X-Forwarded-For": "1.2.3.4"}).status_code == 429
+
+
+def test_idle_buckets_are_evicted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The counter itself must not become the memory-exhaustion vector."""
+    from law_scrapper_mcp.http import rate_limit
+
+    now = [1000.0]
+    monkeypatch.setattr(rate_limit, "monotonic", lambda: now[0])
+    middleware = RateLimitMiddleware(
+        Starlette(routes=[Route("/mcp", _ok, methods=["GET"])]),
+        requests=5,
+        window=60.0,
+        burst=5,
+        trusted_proxies=[],
+    )
+    client = TestClient(middleware)
+    client.get("/mcp")
+    assert len(middleware._buckets) == 1
+    now[0] += 121.0  # beyond two windows
+    client.get("/mcp")
+    assert len(middleware._buckets) == 1
+
+
+def test_non_http_scope_passes_through() -> None:
+    """Lifespan and websocket scopes carry no client address."""
+    client = build_client()
+    with client:  # entering the context manager runs the lifespan scope
+        assert client.get("/mcp").status_code == 200

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -171,6 +171,32 @@ def test_non_address_forwarded_for_falls_back_to_the_peer() -> None:
     assert middleware._buckets.keys() == {"127.0.0.1"}
 
 
+def test_duplicate_forwarded_for_headers_use_the_last_one() -> None:
+    """A caller's own header must not outrank the one the proxy appended.
+
+    A proxy that appends rather than edits produces a second `X-Forwarded-For`
+    header, so reading the first match would hand the bucket key straight to
+    the caller — an address it chose, which parses fine and so survives the
+    address check.
+    """
+    middleware = RateLimitMiddleware(
+        Starlette(routes=[Route("/mcp", _ok, methods=["GET"])]),
+        requests=5,
+        window=60.0,
+        burst=5,
+        trusted_proxies=["127.0.0.0/8"],
+    )
+    client = TestClient(middleware, client=("127.0.0.1", 50000))
+
+    # httpx sends one header per tuple, preserving order.
+    client.get(
+        "/mcp",
+        headers=[("X-Forwarded-For", "9.9.9.9"), ("X-Forwarded-For", "203.0.113.5")],
+    )
+
+    assert middleware._buckets.keys() == {"203.0.113.5"}
+
+
 def test_address_forwarded_for_still_becomes_the_key() -> None:
     """The counter-test: a real address from a trusted peer is still honoured."""
     middleware = RateLimitMiddleware(

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -89,12 +89,16 @@ def test_idle_buckets_are_evicted(monkeypatch: pytest.MonkeyPatch) -> None:
         burst=5,
         trusted_proxies=[],
     )
-    client = TestClient(middleware)
-    client.get("/mcp")
-    assert len(middleware._buckets) == 1
+    first_client = TestClient(middleware, client=("127.0.0.1", 50000))
+    first_client.get("/mcp")
+    assert middleware._buckets.keys() == {"127.0.0.1"}
     now[0] += 121.0  # beyond two windows
-    client.get("/mcp")
-    assert len(middleware._buckets) == 1
+    # A request from a DIFFERENT client key drives the next eviction sweep.
+    # Reusing the original key would pass even with a no-op `_evict_idle`,
+    # since re-touching the bucket keeps it alive either way.
+    second_client = TestClient(middleware, client=("10.0.0.1", 50000))
+    second_client.get("/mcp")
+    assert middleware._buckets.keys() == {"10.0.0.1"}
 
 
 def test_non_http_scope_passes_through() -> None:

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -8,7 +8,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from law_scrapper_mcp.http.rate_limit import RateLimitMiddleware
+from law_scrapper_mcp.http.rate_limit import ExemptPathCredentialStripper, RateLimitMiddleware
 
 
 async def _ok(_request):
@@ -122,6 +122,18 @@ def build_header_spy_client(**overrides) -> tuple[TestClient, list[list[str]]]:
     return TestClient(RateLimitMiddleware(inner, **kwargs), client=("127.0.0.1", 50000)), seen
 
 
+def build_stripper_client() -> tuple[TestClient, list[list[str]]]:
+    """The stripper alone, as `build_http_app()` installs it: outermost, always."""
+    seen: list[list[str]] = []
+
+    async def _record(request):
+        seen.append(sorted(request.headers.keys()))
+        return JSONResponse({"ok": True})
+
+    inner = Starlette(routes=[Route("/mcp", _record, methods=["GET"]), Route("/health", _record)])
+    return TestClient(ExemptPathCredentialStripper(inner), client=("127.0.0.1", 50000)), seen
+
+
 def test_health_reaches_the_app_without_the_authorization_header() -> None:
     """`/health` is exempt from the limiter, so it must not reach the verifier.
 
@@ -131,7 +143,7 @@ def test_health_reaches_the_app_without_the_authorization_header() -> None:
     set, turning an anonymous loop over `/health` into unmetered outbound
     traffic against the operator's identity provider.
     """
-    client, seen = build_header_spy_client()
+    client, seen = build_stripper_client()
 
     response = client.get("/health", headers={"Authorization": "Bearer some.jwt.value"})
 
@@ -141,9 +153,22 @@ def test_health_reaches_the_app_without_the_authorization_header() -> None:
 
 def test_mcp_keeps_the_authorization_header() -> None:
     """Stripping is confined to exempt paths — the counter-test to the above."""
-    client, seen = build_header_spy_client()
+    client, seen = build_stripper_client()
 
     client.get("/mcp", headers={"Authorization": "Bearer some.jwt.value"})
+
+    assert "authorization" in seen[0]
+
+
+def test_rate_limiter_alone_does_not_strip() -> None:
+    """The limiter exempts `/health`; removing the credential is not its job.
+
+    Recorded so the split stays deliberate: the strip was moved out precisely
+    because living here made it conditional on `LAW_MCP_RATE_LIMIT_ENABLED`.
+    """
+    client, seen = build_header_spy_client()
+
+    client.get("/health", headers={"Authorization": "Bearer some.jwt.value"})
 
     assert "authorization" in seen[0]
 

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -106,3 +106,82 @@ def test_non_http_scope_passes_through() -> None:
     client = build_client()
     with client:  # entering the context manager runs the lifespan scope
         assert client.get("/mcp").status_code == 200
+
+
+def build_header_spy_client(**overrides) -> tuple[TestClient, list[list[str]]]:
+    """A client whose inner app records the header names it was handed."""
+    seen: list[list[str]] = []
+
+    async def _record(request):
+        seen.append(sorted(request.headers.keys()))
+        return JSONResponse({"ok": True})
+
+    kwargs = {"requests": 5, "window": 60.0, "burst": 5, "trusted_proxies": []}
+    kwargs.update(overrides)
+    inner = Starlette(routes=[Route("/mcp", _record, methods=["GET"]), Route("/health", _record)])
+    return TestClient(RateLimitMiddleware(inner, **kwargs), client=("127.0.0.1", 50000)), seen
+
+
+def test_health_reaches_the_app_without_the_authorization_header() -> None:
+    """`/health` is exempt from the limiter, so it must not reach the verifier.
+
+    The SDK mounts its authentication backend as application-level middleware,
+    so a token presented here would be verified on the one route with no request
+    budget — in `oauth` mode an unknown `kid` makes PyJWKClient refetch the key
+    set, turning an anonymous loop over `/health` into unmetered outbound
+    traffic against the operator's identity provider.
+    """
+    client, seen = build_header_spy_client()
+
+    response = client.get("/health", headers={"Authorization": "Bearer some.jwt.value"})
+
+    assert response.status_code == 200
+    assert "authorization" not in seen[0]
+
+
+def test_mcp_keeps_the_authorization_header() -> None:
+    """Stripping is confined to exempt paths — the counter-test to the above."""
+    client, seen = build_header_spy_client()
+
+    client.get("/mcp", headers={"Authorization": "Bearer some.jwt.value"})
+
+    assert "authorization" in seen[0]
+
+
+def test_non_address_forwarded_for_falls_back_to_the_peer() -> None:
+    """A forwarded value that is not an address must not become a bucket key.
+
+    A proxy that forwards the caller's own header instead of appending to it
+    would otherwise let one client mint an unbounded number of buckets, each
+    keyed by a string it chooses. Sharing the peer's bucket throttles harder
+    than intended, which is the safe direction to be wrong in.
+    """
+    middleware = RateLimitMiddleware(
+        Starlette(routes=[Route("/mcp", _ok, methods=["GET"])]),
+        requests=5,
+        window=60.0,
+        burst=5,
+        trusted_proxies=["127.0.0.0/8"],
+    )
+    client = TestClient(middleware, client=("127.0.0.1", 50000))
+
+    for junk in ("not-an-address", "a" * 400, "unknown"):
+        client.get("/mcp", headers={"X-Forwarded-For": junk})
+
+    assert middleware._buckets.keys() == {"127.0.0.1"}
+
+
+def test_address_forwarded_for_still_becomes_the_key() -> None:
+    """The counter-test: a real address from a trusted peer is still honoured."""
+    middleware = RateLimitMiddleware(
+        Starlette(routes=[Route("/mcp", _ok, methods=["GET"])]),
+        requests=5,
+        window=60.0,
+        burst=5,
+        trusted_proxies=["127.0.0.0/8"],
+    )
+    client = TestClient(middleware, client=("127.0.0.1", 50000))
+
+    client.get("/mcp", headers={"X-Forwarded-For": "203.0.113.7"})
+
+    assert middleware._buckets.keys() == {"203.0.113.7"}

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -74,7 +74,9 @@ def test_http_app_pins_security_critical_kwargs(monkeypatch) -> None:
     server_module.build_http_app()
 
     assert len(calls) == 1
-    assert calls[0]["transport_security"] is server_module.LOOPBACK_TRANSPORT_SECURITY
+    # `build_transport_security()` reads `Settings` fresh on every call rather
+    # than returning a shared singleton, so this compares by value.
+    assert calls[0]["transport_security"] == server_module.build_transport_security()
     assert calls[0]["stateless_http"] is True
     assert calls[0]["host"] == server_module.settings.host
     assert calls[0]["streamable_http_path"] == "/mcp"

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -130,3 +130,19 @@ def test_main_stdio_branch_is_untouched(monkeypatch) -> None:
     server_module.main()
 
     assert calls == [{"transport": "stdio"}]
+
+
+def test_uvicorn_does_not_rewrite_the_client_from_forwarded_headers() -> None:
+    """`LAW_MCP_TRUSTED_PROXIES` must be the only gate on `X-Forwarded-For`.
+
+    uvicorn defaults `proxy_headers` to True and wraps the application in
+    `ProxyHeadersMiddleware` from the outside, so for any peer matching its own
+    `forwarded_allow_ips` (default `127.0.0.1` — a local reverse proxy, which is
+    the documented deployment) it rewrites `scope["client"]` from the header
+    before our rate limiter reads it. The limiter would then key off a header no
+    operator authorised, which is precisely what criterion 11 forbids, and the
+    unit tests would not notice because they drive the ASGI app directly.
+    """
+    config = server_module.build_uvicorn_config()
+
+    assert config.proxy_headers is False

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -132,17 +132,35 @@ def test_main_stdio_branch_is_untouched(monkeypatch) -> None:
     assert calls == [{"transport": "stdio"}]
 
 
-def test_uvicorn_does_not_rewrite_the_client_from_forwarded_headers() -> None:
+def test_uvicorn_does_not_rewrite_the_client_by_default() -> None:
     """`LAW_MCP_TRUSTED_PROXIES` must be the only gate on `X-Forwarded-For`.
 
     uvicorn defaults `proxy_headers` to True and wraps the application in
     `ProxyHeadersMiddleware` from the outside, so for any peer matching its own
-    `forwarded_allow_ips` (default `127.0.0.1` — a local reverse proxy, which is
-    the documented deployment) it rewrites `scope["client"]` from the header
-    before our rate limiter reads it. The limiter would then key off a header no
-    operator authorised, which is precisely what criterion 11 forbids, and the
-    unit tests would not notice because they drive the ASGI app directly.
+    `forwarded_allow_ips` — which falls back to `127.0.0.1`, and this server
+    binds loopback by default — it rewrites `scope["client"]` from the header
+    before our rate limiter reads it. Any local process could then choose its
+    own bucket, which is what criterion 11 forbids. The unit tests would not
+    notice, because they drive the ASGI app directly with uvicorn out of the
+    stack.
     """
     config = server_module.build_uvicorn_config()
 
     assert config.proxy_headers is False
+    assert config.forwarded_allow_ips == []
+
+
+def test_uvicorn_trusts_exactly_the_configured_proxies(monkeypatch) -> None:
+    """With proxies declared, uvicorn may resolve the client — for those only.
+
+    Keeping the two in step preserves correct access logs and `scope["scheme"]`
+    behind a TLS-terminating proxy, and passing `forwarded_allow_ips` explicitly
+    stops the bare `FORWARDED_ALLOW_IPS` environment variable — read by uvicorn
+    outside this project's namespace — from widening the boundary unseen.
+    """
+    monkeypatch.setattr(server_module.settings, "trusted_proxies", ["10.0.0.1"])
+
+    config = server_module.build_uvicorn_config()
+
+    assert config.proxy_headers is True
+    assert config.forwarded_allow_ips == ["10.0.0.1"]

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -43,11 +43,16 @@ def test_uvicorn_config_follows_the_configured_window(monkeypatch) -> None:
     assert config.timeout_graceful_shutdown == 25.0
 
 
-def test_http_app_still_serves_the_health_route() -> None:
+def test_http_app_still_serves_the_health_route(monkeypatch: pytest.MonkeyPatch) -> None:
     """`streamable_http_app()` must carry `custom_route` registrations over.
 
     If it did not, moving off `app.run()` would silently drop `/health`.
+    Rate limiting is disabled here because it wraps the returned ASGI app,
+    which would otherwise hide `.routes` behind `RateLimitMiddleware` — a
+    concern this test does not cover (see `tests/unit/test_rate_limit.py`).
     """
+    monkeypatch.setattr(server_module.settings, "rate_limit_enabled", False)
+
     paths = {getattr(route, "path", None) for route in server_module.build_http_app().routes}
 
     assert "/health" in paths

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -153,6 +153,19 @@ def test_uvicorn_does_not_rewrite_the_client_by_default() -> None:
     assert config.forwarded_allow_ips == []
 
 
+def test_uvicorn_refuses_websocket_upgrades() -> None:
+    """No route speaks WebSocket, and the middlewares only handle `http`.
+
+    Starlette's `AuthenticationMiddleware` also handles `websocket` scopes and
+    calls the verifier on them, while `RateLimitMiddleware` and
+    `ExemptPathCredentialStripper` pass anything non-http straight through — so
+    an upgrade would reach `verify_token` past both the budget and the strip.
+    Leaving uvicorn's `ws="auto"` made that hinge on whether an optional package
+    was installed rather than on a decision.
+    """
+    assert server_module.build_uvicorn_config().ws == "none"
+
+
 def test_uvicorn_rewrite_stays_off_even_with_trusted_proxies(monkeypatch) -> None:
     """Declaring a proxy must not switch uvicorn's own rewrite back on.
 
@@ -170,15 +183,21 @@ def test_uvicorn_rewrite_stays_off_even_with_trusted_proxies(monkeypatch) -> Non
     assert config.forwarded_allow_ips == []
 
 
-def test_health_credential_is_stripped_with_the_limiter_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("rate_limit_enabled", [True, False])
+def test_health_credential_is_stripped(monkeypatch: pytest.MonkeyPatch, rate_limit_enabled: bool) -> None:
     """The strip must not inherit `LAW_MCP_RATE_LIMIT_ENABLED`.
 
     It first lived inside `RateLimitMiddleware`, and `build_http_app()` returns
     the bare app when rate limiting is off — so a setting about request budgets
     silently decided whether a credential could reach the token verifier on the
     one unmetered path.
+
+    Both branches, deliberately. Covering only the disabled one left the
+    *default* branch — the one that actually deploys — unasserted: a mutation
+    that skipped the strip solely when wrapping the limiter passed the whole
+    suite. That is the same defect shape one layer up, in the tests.
     """
-    monkeypatch.setattr(server_module.settings, "rate_limit_enabled", False)
+    monkeypatch.setattr(server_module.settings, "rate_limit_enabled", rate_limit_enabled)
     seen: list[list[bytes]] = []
 
     async def _record(scope, receive, send) -> None:
@@ -190,6 +209,9 @@ def test_health_credential_is_stripped_with_the_limiter_disabled(monkeypatch: py
     scope = {
         "type": "http",
         "path": "/health",
+        # The limiter reads the peer address, so it must be present for the
+        # enabled branch to get as far as the inner app.
+        "client": ("127.0.0.1", 50000),
         "headers": [(b"authorization", b"Bearer forged.jwt.value"), (b"accept", b"*/*")],
     }
     import asyncio

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -82,6 +82,10 @@ def test_http_app_pins_security_critical_kwargs(monkeypatch) -> None:
     # `build_transport_security()` reads `Settings` fresh on every call rather
     # than returning a shared singleton, so this compares by value.
     assert calls[0]["transport_security"] == server_module.build_transport_security()
+    # The value itself, not just its presence: nothing else in the unit suite
+    # asserts DNS-rebinding protection is actually on (the only other proof is
+    # an integration-marked live-subprocess test).
+    assert calls[0]["transport_security"].enable_dns_rebinding_protection is True
     assert calls[0]["stateless_http"] is True
     assert calls[0]["host"] == server_module.settings.host
     assert calls[0]["streamable_http_path"] == "/mcp"

--- a/tests/unit/test_server_bootstrap.py
+++ b/tests/unit/test_server_bootstrap.py
@@ -53,7 +53,10 @@ def test_http_app_still_serves_the_health_route(monkeypatch: pytest.MonkeyPatch)
     """
     monkeypatch.setattr(server_module.settings, "rate_limit_enabled", False)
 
-    paths = {getattr(route, "path", None) for route in server_module.build_http_app().routes}
+    # `build_http_app()` always wraps the app in `ExemptPathCredentialStripper`
+    # (a security property that must not depend on rate limiting being on),
+    # so reach through it to inspect the routes underneath.
+    paths = {getattr(route, "path", None) for route in server_module.build_http_app()._app.routes}
 
     assert "/health" in paths
     assert "/mcp" in paths
@@ -150,17 +153,47 @@ def test_uvicorn_does_not_rewrite_the_client_by_default() -> None:
     assert config.forwarded_allow_ips == []
 
 
-def test_uvicorn_trusts_exactly_the_configured_proxies(monkeypatch) -> None:
-    """With proxies declared, uvicorn may resolve the client — for those only.
+def test_uvicorn_rewrite_stays_off_even_with_trusted_proxies(monkeypatch) -> None:
+    """Declaring a proxy must not switch uvicorn's own rewrite back on.
 
-    Keeping the two in step preserves correct access logs and `scope["scheme"]`
-    behind a TLS-terminating proxy, and passing `forwarded_allow_ips` explicitly
-    stops the bare `FORWARDED_ALLOW_IPS` environment variable — read by uvicorn
-    outside this project's namespace — from widening the boundary unseen.
+    Tying `proxy_headers` to `trusted_proxies` was tried and reverted:
+    `ProxyHeadersMiddleware` writes the header into `scope["client"]` without
+    checking it is an address, and it runs before ours, so `_client_key` would
+    take a forged string as the peer and never reach its own address check.
+    `_client_key` owns `X-Forwarded-For` end to end instead.
     """
     monkeypatch.setattr(server_module.settings, "trusted_proxies", ["10.0.0.1"])
 
     config = server_module.build_uvicorn_config()
 
-    assert config.proxy_headers is True
-    assert config.forwarded_allow_ips == ["10.0.0.1"]
+    assert config.proxy_headers is False
+    assert config.forwarded_allow_ips == []
+
+
+def test_health_credential_is_stripped_with_the_limiter_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The strip must not inherit `LAW_MCP_RATE_LIMIT_ENABLED`.
+
+    It first lived inside `RateLimitMiddleware`, and `build_http_app()` returns
+    the bare app when rate limiting is off — so a setting about request budgets
+    silently decided whether a credential could reach the token verifier on the
+    one unmetered path.
+    """
+    monkeypatch.setattr(server_module.settings, "rate_limit_enabled", False)
+    seen: list[list[bytes]] = []
+
+    async def _record(scope, receive, send) -> None:
+        seen.append([name for name, _ in scope["headers"]])
+
+    monkeypatch.setattr(server_module.app, "streamable_http_app", lambda **kwargs: _record)
+
+    http_app = server_module.build_http_app()
+    scope = {
+        "type": "http",
+        "path": "/health",
+        "headers": [(b"authorization", b"Bearer forged.jwt.value"), (b"accept", b"*/*")],
+    }
+    import asyncio
+
+    asyncio.run(http_app(scope, None, None))
+
+    assert seen == [[b"accept"]]

--- a/tests/unit/test_static_token_verifier.py
+++ b/tests/unit/test_static_token_verifier.py
@@ -1,0 +1,55 @@
+"""The bearer mode: one shared secret, compared in constant time."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from law_scrapper_mcp.auth.static_token import STATIC_CLIENT_ID, StaticTokenVerifier
+
+TOKEN = "s" * 32
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_correct_token_is_accepted() -> None:
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=[])
+    access = await verifier.verify_token(TOKEN)
+    assert access is not None
+    assert access.client_id == STATIC_CLIENT_ID
+
+
+async def test_wrong_token_is_rejected() -> None:
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=[])
+    assert await verifier.verify_token("t" * 32) is None
+
+
+async def test_empty_token_is_rejected() -> None:
+    """An empty Authorization value must never satisfy the comparison."""
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=[])
+    assert await verifier.verify_token("") is None
+
+
+async def test_prefix_of_the_token_is_rejected() -> None:
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=[])
+    assert await verifier.verify_token(TOKEN[:-1]) is None
+
+
+async def test_configured_scopes_are_returned() -> None:
+    """RequireAuthMiddleware enforces scopes against exactly this list."""
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=["mcp:read"])
+    access = await verifier.verify_token(TOKEN)
+    assert access is not None
+    assert access.scopes == ["mcp:read"]
+
+
+async def test_token_from_file_loses_its_trailing_newline(tmp_path: Path) -> None:
+    """A secret file written by Docker or Kubernetes ends with a newline."""
+    from law_scrapper_mcp.config import Settings
+
+    token_file = tmp_path / "token"
+    token_file.write_text(f"{TOKEN}\n", encoding="utf-8")
+    current = Settings(auth_mode="bearer", auth_token_file=token_file)
+    verifier = StaticTokenVerifier(token=current.resolve_auth_token(), scopes=[])
+    assert await verifier.verify_token(TOKEN) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -469,6 +469,7 @@ dependencies = [
     { name = "pdfplumber" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dateutil" },
 ]
 
@@ -493,6 +494,7 @@ requires-dist = [
     { name = "pdfplumber", specifier = ">=0.11.10" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "law-scrapper-mcp"
-version = "3.1.2"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary

Closes F17 (no authentication), F18 (non-configurable Host/Origin allowlist), F26 (no inbound rate limiting) from the 2026-08-06 MCP audit.

- Two authentication modes for the Streamable HTTP transport: `bearer` (static shared secret, constant-time comparison) and `oauth` (OAuth 2.1 / OIDC resource server — JWKS + discovery, algorithm-confusion resistant, works with Entra ID, Google, AWS Cognito, Okta, Auth0)
- Configurable `Host`/`Origin` allowlist (`LAW_MCP_ALLOWED_HOSTS`/`LAW_MCP_ALLOWED_ORIGINS`), with startup validation that refuses to widen it unless an auth mode is configured
- Per-client HTTP rate limiting (token bucket, trusted-proxy-aware `X-Forwarded-For` handling, `/health` exempt)
- **BREAKING:** default HTTP bind moved from `0.0.0.0` to `127.0.0.1`; binding beyond loopback now requires an auth mode or the server refuses to start
- Deployment docs, Dockerfile/docker-compose.yml updates, audit report closure

Full detail: `CHANGELOG.md` / `docs/changelogs/v4.0.0.md`.

## Process

Built via subagent-driven development: 8 tasks, each through implementer → parallel spec+quality review → fix rounds where needed, plus a final whole-branch review (caught one CI-breaking test reading a deliberately-untracked file, and 3 documentation/comment accuracy gaps — all fixed in the last commit of this PR).

## Test plan

- [x] `pytest tests/unit/ -q` — 1127 passed
- [x] `pytest tests/integration/ -q -m integration` — 106 passed
- [x] `ruff check` / `ruff format --check` / `mypy` — all clean
- [x] `scripts/check_release.py --version 4.0.0` — passed
- [x] Live `docker compose config` verified (via Podman) — fails loudly without `LAW_MCP_AUTH_TOKEN`, resolves cleanly with it