### PR TITLE
fix: cleanup wave from Klaster 7 review findings (4.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-08-31
+
+See [docs/changelogs/v4.0.1.md](docs/changelogs/v4.0.1.md) for details.
+
+Cleanup release — hardening and test coverage from Klaster 7 review findings, no behavior change for existing correct configurations.
+
+### Fixed
+
+- **`trusted_proxies` CIDR validation** — Moved to startup instead of first request; binary `LAW_MCP_AUTH_TOKEN_FILE` files now produce a clean error instead of `UnicodeDecodeError`.
+- **OAuth JWKS discovery** — Rejects non-`https://` discovered JWKS URIs; JWKS/IdP communication failures now log at WARNING instead of INFO (including a fix for an except-clause ordering bug).
+
+### Changed
+
+- **Test coverage** — Added token boundary, rate-limit-zero, and timing-safety tests; fixed `caplog` scoping.
+- **Dependency and fixture hygiene** — `httpx2` is now an explicit dev dependency with its test client properly closed; the `bearer_app` test fixture no longer mutates global module state.
+- **Config module split** — Security-boundary validation extracted from `config.py` into `config_validation.py` and `config_primitives.py`. No behavior change.
+
 ## [4.0.0] - 2026-08-30
 
 See [docs/changelogs/v4.0.0.md](docs/changelogs/v4.0.0.md) for details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Law Scrapper MCP v4.0.0 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
+Law Scrapper MCP v4.0.1 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
 
 ## Development commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,5 @@ src/law_scrapper_mcp/
   Polish `CHANGELOG` entry, is a convention violation, not a style preference. Match the file's
   convention, not the nearest neighbouring lines — that is how both drifts started
 - asyncio.Lock for all in-memory stores (Cache, DocumentStore, ResultStore)
+- `docs/superpowers/` (specs and implementation plans) is **deliberately untracked** — do not
+  commit it, do not propose tracking it, and do not report it as a gap in a review or audit

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Model Context Protocol (MCP) server for accessing and analyzing 
 
 ![Python version](https://img.shields.io/badge/python-3.13+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Version](https://img.shields.io/badge/version-4.0.0-orange.svg)
+![Version](https://img.shields.io/badge/version-4.0.1-orange.svg)
 
 <a href="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp/badge" alt="Law Scrapper MCP server" />

--- a/docs/changelogs/v4.0.1.md
+++ b/docs/changelogs/v4.0.1.md
@@ -1,0 +1,24 @@
+# Changelog - v4.0.1
+
+All notable changes to the `law-scrapper-mcp` project for version v4.0.1 will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.1] - 2026-08-31
+
+Cleanup release — hardening and test coverage from Klaster 7 review findings, no behavior change for existing correct configurations.
+
+### Fixed
+
+- **`trusted_proxies` CIDR validation moved to startup** — Invalid `LAW_MCP_TRUSTED_PROXIES` entries now fail fast at configuration time instead of on the first proxied request.
+- **Binary auth token files no longer crash with `UnicodeDecodeError`** — `LAW_MCP_AUTH_TOKEN_FILE` pointing at a non-text file now produces a clean, Polish-language configuration error.
+- **OAuth JWKS discovery rejects non-`https://` URIs** — A discovered JWKS URI that isn't `https://` is refused instead of being fetched, closing a downgrade path.
+- **JWKS/IdP communication failures now log at WARNING instead of INFO** — Includes a fix for an except-clause ordering bug that had silently suppressed the intended WARNING level for these failures.
+
+### Changed
+
+- **Test coverage strengthened** — Added a 31-byte token boundary test, a rate-limit-zero rejection test, a `compare_digest` timing-safety spy, and fixed `caplog` scoping so auth-related log assertions can't leak between tests.
+- **`httpx2` declared as an explicit dev dependency** — It was previously an undeclared transitive dependency; its test client is now properly closed after use.
+- **`bearer_app` test fixture no longer mutates global module state** — Removed a use of `importlib.reload` that could leak state between tests.
+- **Security-boundary validation extracted from `config.py`** — Moved into a dedicated `config_validation.py` module, alongside a genuinely dependency-free `config_primitives.py` for shared leaf helpers. No behavior change; internal organization only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "law-scrapper-mcp"
-version = "4.0.0"
+version = "4.0.1"
 description = "LawScrapper MCP is an MCP server to monitoring and fetching Polish law acts published by the Polish Sejm, filters them by topic. Then with AI you can summarizes their content using an LLM."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "pytest-timeout>=2.3",
     "ruff>=0.9",
     "mypy>=1.14",
+    # mcp's streamable_http_client() types http_client as httpx2.AsyncClient,
+    # not httpx.AsyncClient — needed alongside httpx for the HTTP transport test.
+    "httpx2>=2.5.0",
 ]
 
 [project.scripts]

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -64,17 +64,25 @@ class JwtTokenVerifier:
                 issuer=self._issuer,
                 options={"require": ["exp", "iss", "aud"]},
             )
-        except (PyJWKClientError, httpx.HTTPError, KeyError, ValueError) as error:
+        except PyJWKClientError as error:
             # PyJWKClientError is a jwt.PyJWTError subclass, so this clause
             # MUST come before `except jwt.PyJWTError` below — Python matches
             # top-down, and the base-class clause would otherwise silently
             # swallow it, routing real IdP outages through the INFO path.
-            # KeyError/ValueError: a malformed discovery document (missing or
-            # non-https `jwks_uri`) or a non-JSON JWKS/discovery body —
-            # `json.JSONDecodeError` is a ValueError subclass, and neither
-            # escapes as PyJWTError or httpx.HTTPError. These signal that the
-            # identity provider is unreachable or misbehaving, worth a human
-            # noticing — WARNING, not INFO.
+            # Message stays type-name-only, unlike the WARNING branch below:
+            # PyJWT reads the unverified `kid` from the token's own header to
+            # build this error ("no signing key matches <kid>"), so `str(error)`
+            # can echo attacker-controlled content into the log.
+            logger.warning("Odrzucono token: %s", type(error).__name__)
+            return None
+        except (httpx.HTTPError, KeyError, ValueError) as error:
+            # A malformed discovery document (missing or non-https `jwks_uri`)
+            # or a non-JSON JWKS/discovery body — `json.JSONDecodeError` is a
+            # ValueError subclass, and neither escapes as PyJWTError or
+            # httpx.HTTPError. These describe the *response*, not the token,
+            # so `str(error)` is safe here and gives an operator something to
+            # act on. These signal that the identity provider is unreachable
+            # or misbehaving, worth a human noticing — WARNING, not INFO.
             logger.warning("Odrzucono token: %s: %s", type(error).__name__, error)
             return None
         except jwt.PyJWTError as error:

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -64,12 +64,20 @@ class JwtTokenVerifier:
                 issuer=self._issuer,
                 options={"require": ["exp", "iss", "aud"]},
             )
-        except (PyJWKClientError, jwt.PyJWTError, httpx.HTTPError, KeyError, ValueError) as error:
-            # KeyError/ValueError: a malformed discovery document (missing
-            # `jwks_uri`) or a non-JSON JWKS/discovery body — `json.JSONDecodeError`
-            # is a ValueError subclass, and neither escapes as PyJWTError or
-            # httpx.HTTPError.
+        except jwt.PyJWTError as error:
+            # A plain token-validation failure (bad signature, expired,
+            # wrong audience/issuer, ...) is routine traffic, not an
+            # operational problem — stays at INFO.
             logger.info("Odrzucono token: %s", type(error).__name__)
+            return None
+        except (PyJWKClientError, httpx.HTTPError, KeyError, ValueError) as error:
+            # KeyError/ValueError: a malformed discovery document (missing or
+            # non-https `jwks_uri`) or a non-JSON JWKS/discovery body —
+            # `json.JSONDecodeError` is a ValueError subclass, and neither
+            # escapes as PyJWTError or httpx.HTTPError. These signal that the
+            # identity provider is unreachable or misbehaving, worth a human
+            # noticing — WARNING, not INFO.
+            logger.warning("Odrzucono token: %s", type(error).__name__)
             return None
 
         scopes = _scopes_of(claims)
@@ -112,7 +120,14 @@ class JwtTokenVerifier:
         async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT) as client:
             response = await client.get(url)
             response.raise_for_status()
-            return str(response.json()["jwks_uri"])
+            jwks_uri = str(response.json()["jwks_uri"])
+            if not jwks_uri.startswith("https://"):
+                # The discovery document itself arrived over HTTPS, but a
+                # misconfigured or compromised IdP could still point key
+                # fetching at plaintext HTTP — fail closed, same as every
+                # other rejection path here.
+                raise ValueError(f"Odkryty jwks_uri nie używa https: {jwks_uri!r}")
+            return jwks_uri
 
 
 def _scopes_of(claims: dict[str, Any]) -> set[str]:

--- a/src/law_scrapper_mcp/auth/jwt_verifier.py
+++ b/src/law_scrapper_mcp/auth/jwt_verifier.py
@@ -64,20 +64,26 @@ class JwtTokenVerifier:
                 issuer=self._issuer,
                 options={"require": ["exp", "iss", "aud"]},
             )
-        except jwt.PyJWTError as error:
-            # A plain token-validation failure (bad signature, expired,
-            # wrong audience/issuer, ...) is routine traffic, not an
-            # operational problem — stays at INFO.
-            logger.info("Odrzucono token: %s", type(error).__name__)
-            return None
         except (PyJWKClientError, httpx.HTTPError, KeyError, ValueError) as error:
+            # PyJWKClientError is a jwt.PyJWTError subclass, so this clause
+            # MUST come before `except jwt.PyJWTError` below — Python matches
+            # top-down, and the base-class clause would otherwise silently
+            # swallow it, routing real IdP outages through the INFO path.
             # KeyError/ValueError: a malformed discovery document (missing or
             # non-https `jwks_uri`) or a non-JSON JWKS/discovery body —
             # `json.JSONDecodeError` is a ValueError subclass, and neither
             # escapes as PyJWTError or httpx.HTTPError. These signal that the
             # identity provider is unreachable or misbehaving, worth a human
             # noticing — WARNING, not INFO.
-            logger.warning("Odrzucono token: %s", type(error).__name__)
+            logger.warning("Odrzucono token: %s: %s", type(error).__name__, error)
+            return None
+        except jwt.PyJWTError as error:
+            # A plain token-validation failure (bad signature, expired,
+            # wrong audience/issuer, ...) is routine traffic, not an
+            # operational problem — stays at INFO. Kept as type-name-only,
+            # unlike the WARNING branch: `error` here can echo attacker-
+            # controlled token content.
+            logger.info("Odrzucono token: %s", type(error).__name__)
             return None
 
         scopes = _scopes_of(claims)

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -104,57 +104,15 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _enforce_security_boundary(self) -> Settings:
-        if self.auth_mode == "bearer":
-            if self.auth_token is not None and self.auth_token_file is not None:
-                raise ValueError(
-                    "LAW_MCP_AUTH_TOKEN i LAW_MCP_AUTH_TOKEN_FILE ustawione jednocześnie. "
-                    "Wybierz jedno źródło tokenu — milcząca precedencja ukryłaby podmianę sekretu."
-                )
-            if self.auth_token is None and self.auth_token_file is None:
-                raise ValueError("Tryb 'bearer' wymaga tokenu. Ustaw LAW_MCP_AUTH_TOKEN albo LAW_MCP_AUTH_TOKEN_FILE.")
-            try:
-                token = self.resolve_auth_token()
-            except (OSError, UnicodeDecodeError) as error:
-                raise ValueError(
-                    f"Nie udało się odczytać LAW_MCP_AUTH_TOKEN_FILE ({self.auth_token_file}): {error}"
-                ) from error
-            if len(token.encode("utf-8")) < MIN_AUTH_TOKEN_BYTES:
-                raise ValueError(
-                    f"Token uwierzytelniający musi mieć co najmniej {MIN_AUTH_TOKEN_BYTES} bajtów UTF-8. "
-                    "Wygeneruj go poleceniem: openssl rand -base64 32"
-                )
+        """Delegates to `config_validation.enforce_security_boundary`.
 
-        if self.auth_mode == "oauth":
-            required = (
-                ("LAW_MCP_AUTH_ISSUER", self.auth_issuer),
-                ("LAW_MCP_AUTH_AUDIENCE", self.auth_audience),
-                ("LAW_MCP_AUTH_RESOURCE_SERVER_URL", self.auth_resource_server_url),
-            )
-            missing = [name for name, value in required if value is None]
-            if missing:
-                raise ValueError(
-                    f"Tryb 'oauth' wymaga zmiennych: {', '.join(missing)}. "
-                    "Serwer nie uruchomi się z niepełną konfiguracją OAuth."
-                )
+        Local import breaks the circular import: `config_validation` imports
+        constants/helpers from this module at its own module-load time, so it
+        cannot be imported at the top of this file.
+        """
+        from .config_validation import enforce_security_boundary
 
-        if self.auth_mode == "none":
-            if self.transport == "streamable-http" and not is_loopback_entry(self.host):
-                raise ValueError(
-                    f"Bind '{self.host}' wykracza poza pętlę zwrotną przy wyłączonym uwierzytelnianiu. "
-                    "Ustaw LAW_MCP_AUTH_MODE na 'bearer' albo 'oauth', albo binduj na 127.0.0.1."
-                )
-            for name, entries in (
-                ("LAW_MCP_ALLOWED_HOSTS", self.allowed_hosts),
-                ("LAW_MCP_ALLOWED_ORIGINS", self.allowed_origins),
-            ):
-                remote = [entry for entry in entries if not is_loopback_entry(entry)]
-                if remote:
-                    raise ValueError(
-                        f"{name} zawiera wpisy spoza pętli zwrotnej ({', '.join(remote)}) "
-                        "przy wyłączonym uwierzytelnianiu. Ustaw LAW_MCP_AUTH_MODE."
-                    )
-
-        return self
+        return enforce_security_boundary(self)
 
     # Graceful shutdown window handed to uvicorn as `timeout_graceful_shutdown`.
     # Shorter than `api_timeout` on purpose: the trade-off between restart speed

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -234,7 +234,7 @@ class Settings(BaseSettings):
 
     # Server info
     server_name: str = "law-scrapper-mcp"
-    server_version: str = "4.0.0"
+    server_version: str = "4.0.1"
 
     @property
     def user_agent(self) -> str:

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -4,12 +4,32 @@ from __future__ import annotations
 
 import json
 import logging
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_network
 from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import AnyHttpUrl, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+from .config_primitives import MIN_AUTH_TOKEN_BYTES, _host_of, is_loopback_entry
+from .config_validation import enforce_security_boundary
+
+# Re-exported: `_host_of`, `is_loopback_entry` and `MIN_AUTH_TOKEN_BYTES` live in
+# `config_primitives.py` (dependency-free, importable by `config_validation.py`
+# without a cycle), but stay accessible as `law_scrapper_mcp.config.*` because
+# `log_remote_bind_warning` below uses `is_loopback_entry`, and existing tests
+# (`test_config_helpers.py`, `test_auth_settings_validation.py`) import all three
+# straight from this module.
+__all__ = [
+    "MIN_AUTH_TOKEN_BYTES",
+    "Settings",
+    "USER_AGENT_CONTACT",
+    "_host_of",
+    "is_loopback_entry",
+    "log_pattern_limit_clamping",
+    "log_remote_bind_warning",
+    "settings",
+]
 
 MAX_PATTERN_LENGTH_FLOOR = 64
 MAX_PATTERN_LENGTH_CEILING = 4096
@@ -19,34 +39,8 @@ FILTER_MAX_RECORDS_FLOOR = 1
 # institution, so its administrator needs a way to reach us that is not a ban.
 USER_AGENT_CONTACT = "https://github.com/numikel/law-scrapper-mcp"
 
-MIN_AUTH_TOKEN_BYTES = 32
-
 LOOPBACK_ALLOWED_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
 LOOPBACK_ALLOWED_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
-
-
-def _host_of(entry: str) -> str:
-    """Strip scheme, port and brackets from an allowlist entry."""
-    value = entry.strip()
-    if "://" in value:
-        value = value.split("://", 1)[1]
-    if value.startswith("["):
-        return value[1 : value.index("]")] if "]" in value else value[1:]
-    # Bare IPv6 (contains multiple colons but no brackets): return unchanged
-    if value.count(":") > 1:
-        return value
-    return value.split(":")[0]
-
-
-def is_loopback_entry(entry: str) -> bool:
-    """Whether an allowlist entry or bind address stays inside the loopback."""
-    host = _host_of(entry).lower()
-    if host in {"localhost", "::1"}:
-        return True
-    try:
-        return ip_address(host).is_loopback
-    except ValueError:
-        return False
 
 
 class Settings(BaseSettings):
@@ -104,14 +98,7 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _enforce_security_boundary(self) -> Settings:
-        """Delegates to `config_validation.enforce_security_boundary`.
-
-        Local import breaks the circular import: `config_validation` imports
-        constants/helpers from this module at its own module-load time, so it
-        cannot be imported at the top of this file.
-        """
-        from .config_validation import enforce_security_boundary
-
+        """Delegates to `config_validation.enforce_security_boundary`."""
         return enforce_security_boundary(self)
 
     # Graceful shutdown window handed to uvicorn as `timeout_graceful_shutdown`.

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from ipaddress import ip_address
+from ipaddress import ip_address, ip_network
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -61,6 +61,22 @@ class Settings(BaseSettings):
     host: str = "127.0.0.1"
     port: int = 7683
 
+    @field_validator("trusted_proxies")
+    @classmethod
+    def _validate_trusted_proxies(cls, value: list[str]) -> list[str]:
+        """Reject malformed CIDR entries at startup instead of on the first request.
+
+        `RateLimitMiddleware.__init__` also calls `ip_network()` on this list —
+        without this validator, a bad entry there raises a raw `ValueError`
+        instead of a clean, Polish-language `ValidationError`.
+        """
+        for entry in value:
+            try:
+                ip_network(entry, strict=False)
+            except ValueError as error:
+                raise ValueError(f"LAW_MCP_TRUSTED_PROXIES zawiera nieprawidłowy wpis '{entry}': {error}") from error
+        return value
+
     @field_validator("transport", mode="before")
     @classmethod
     def _reject_unsupported_transport(cls, value: object) -> object:
@@ -98,7 +114,7 @@ class Settings(BaseSettings):
                 raise ValueError("Tryb 'bearer' wymaga tokenu. Ustaw LAW_MCP_AUTH_TOKEN albo LAW_MCP_AUTH_TOKEN_FILE.")
             try:
                 token = self.resolve_auth_token()
-            except OSError as error:
+            except (OSError, UnicodeDecodeError) as error:
                 raise ValueError(
                     f"Nie udało się odczytać LAW_MCP_AUTH_TOKEN_FILE ({self.auth_token_file}): {error}"
                 ) from error

--- a/src/law_scrapper_mcp/config_primitives.py
+++ b/src/law_scrapper_mcp/config_primitives.py
@@ -1,0 +1,41 @@
+"""Dependency-free leaves shared by `config.py` and `config_validation.py`.
+
+Split out (Task 6 fix round 1, Klaster 7 cleanup) because both modules need
+`MIN_AUTH_TOKEN_BYTES` / `is_loopback_entry`, and having either module import
+them from the other created a real circular import: `config.py` runs
+`settings = Settings()` at module scope, which triggers `Settings`'s
+security-boundary validator during `config.py`'s own import — so any import
+edge back into `config.py` from a module `config.py` also imports is live,
+not just theoretical. This module imports nothing from either, so it cannot
+participate in a cycle.
+"""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+
+MIN_AUTH_TOKEN_BYTES = 32
+
+
+def _host_of(entry: str) -> str:
+    """Strip scheme, port and brackets from an allowlist entry."""
+    value = entry.strip()
+    if "://" in value:
+        value = value.split("://", 1)[1]
+    if value.startswith("["):
+        return value[1 : value.index("]")] if "]" in value else value[1:]
+    # Bare IPv6 (contains multiple colons but no brackets): return unchanged
+    if value.count(":") > 1:
+        return value
+    return value.split(":")[0]
+
+
+def is_loopback_entry(entry: str) -> bool:
+    """Whether an allowlist entry or bind address stays inside the loopback."""
+    host = _host_of(entry).lower()
+    if host in {"localhost", "::1"}:
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False

--- a/src/law_scrapper_mcp/config_validation.py
+++ b/src/law_scrapper_mcp/config_validation.py
@@ -1,0 +1,74 @@
+"""Security-boundary validation for `Settings`.
+
+Extracted from `config.py` (Task 6, Klaster 7 cleanup) so the field list in
+`Settings` reads top-to-bottom without a ~65-line validator wedged between
+unrelated groups of fields. Behaviour is unchanged — only the home of the
+logic moved. Kept as a free function (not a method) so `config.py` can call
+it from inside `Settings._enforce_security_boundary` via a local import,
+which avoids a circular import at module load time (this module imports
+`Settings`-adjacent constants from `config.py`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .config import MIN_AUTH_TOKEN_BYTES, is_loopback_entry
+
+if TYPE_CHECKING:
+    from .config import Settings
+
+
+def enforce_security_boundary(current: Settings) -> Settings:
+    """Fail fast at startup: bind network exposure to the configured auth mode."""
+    if current.auth_mode == "bearer":
+        if current.auth_token is not None and current.auth_token_file is not None:
+            raise ValueError(
+                "LAW_MCP_AUTH_TOKEN i LAW_MCP_AUTH_TOKEN_FILE ustawione jednocześnie. "
+                "Wybierz jedno źródło tokenu — milcząca precedencja ukryłaby podmianę sekretu."
+            )
+        if current.auth_token is None and current.auth_token_file is None:
+            raise ValueError("Tryb 'bearer' wymaga tokenu. Ustaw LAW_MCP_AUTH_TOKEN albo LAW_MCP_AUTH_TOKEN_FILE.")
+        try:
+            token = current.resolve_auth_token()
+        except (OSError, UnicodeDecodeError) as error:
+            raise ValueError(
+                f"Nie udało się odczytać LAW_MCP_AUTH_TOKEN_FILE ({current.auth_token_file}): {error}"
+            ) from error
+        if len(token.encode("utf-8")) < MIN_AUTH_TOKEN_BYTES:
+            raise ValueError(
+                f"Token uwierzytelniający musi mieć co najmniej {MIN_AUTH_TOKEN_BYTES} bajtów UTF-8. "
+                "Wygeneruj go poleceniem: openssl rand -base64 32"
+            )
+
+    if current.auth_mode == "oauth":
+        required = (
+            ("LAW_MCP_AUTH_ISSUER", current.auth_issuer),
+            ("LAW_MCP_AUTH_AUDIENCE", current.auth_audience),
+            ("LAW_MCP_AUTH_RESOURCE_SERVER_URL", current.auth_resource_server_url),
+        )
+        missing = [name for name, value in required if value is None]
+        if missing:
+            raise ValueError(
+                f"Tryb 'oauth' wymaga zmiennych: {', '.join(missing)}. "
+                "Serwer nie uruchomi się z niepełną konfiguracją OAuth."
+            )
+
+    if current.auth_mode == "none":
+        if current.transport == "streamable-http" and not is_loopback_entry(current.host):
+            raise ValueError(
+                f"Bind '{current.host}' wykracza poza pętlę zwrotną przy wyłączonym uwierzytelnianiu. "
+                "Ustaw LAW_MCP_AUTH_MODE na 'bearer' albo 'oauth', albo binduj na 127.0.0.1."
+            )
+        for name, entries in (
+            ("LAW_MCP_ALLOWED_HOSTS", current.allowed_hosts),
+            ("LAW_MCP_ALLOWED_ORIGINS", current.allowed_origins),
+        ):
+            remote = [entry for entry in entries if not is_loopback_entry(entry)]
+            if remote:
+                raise ValueError(
+                    f"{name} zawiera wpisy spoza pętli zwrotnej ({', '.join(remote)}) "
+                    "przy wyłączonym uwierzytelnianiu. Ustaw LAW_MCP_AUTH_MODE."
+                )
+
+    return current

--- a/src/law_scrapper_mcp/config_validation.py
+++ b/src/law_scrapper_mcp/config_validation.py
@@ -59,6 +59,23 @@ def enforce_security_boundary(current: Settings) -> Settings:
                 f"Tryb 'oauth' wymaga zmiennych: {', '.join(missing)}. "
                 "Serwer nie uruchomi się z niepełną konfiguracją OAuth."
             )
+        # `auth_issuer`/`auth_jwks_uri` are `AnyHttpUrl`, which accepts plain
+        # `http://` as readily as `https://`. `_discover_jwks_uri` in
+        # jwt_verifier.py rejects a *discovered* jwks_uri that isn't https —
+        # but that check never runs when `auth_jwks_uri` is configured
+        # directly (discovery is skipped entirely), and it does nothing about
+        # the discovery *request* itself going out over plain HTTP against an
+        # insecure `auth_issuer`. Both are the same downgrade attack the
+        # discovery check exists to close, so enforce it here too.
+        for name, url in (
+            ("LAW_MCP_AUTH_ISSUER", current.auth_issuer),
+            ("LAW_MCP_AUTH_JWKS_URI", current.auth_jwks_uri),
+        ):
+            if url is not None and url.scheme != "https":
+                raise ValueError(
+                    f"{name} musi używać schematu https (otrzymano: {url.scheme}). "
+                    "Zwykłe http otwiera atak typu downgrade na komunikację z dostawcą tożsamości."
+                )
 
     if current.auth_mode == "none":
         if current.transport == "streamable-http" and not is_loopback_entry(current.host):

--- a/src/law_scrapper_mcp/config_validation.py
+++ b/src/law_scrapper_mcp/config_validation.py
@@ -3,17 +3,23 @@
 Extracted from `config.py` (Task 6, Klaster 7 cleanup) so the field list in
 `Settings` reads top-to-bottom without a ~65-line validator wedged between
 unrelated groups of fields. Behaviour is unchanged — only the home of the
-logic moved. Kept as a free function (not a method) so `config.py` can call
-it from inside `Settings._enforce_security_boundary` via a local import,
-which avoids a circular import at module load time (this module imports
-`Settings`-adjacent constants from `config.py`).
+logic moved. Kept as a free function (not a method); `config.py` imports it
+normally at module top level and calls it from inside
+`Settings._enforce_security_boundary`.
+
+Imports its constant/helper from `config_primitives.py`, not from `config.py`
+directly — `config.py` runs `settings = Settings()` at module scope, so an
+import edge back into `config.py` from here would be live (not just
+theoretical) the moment this module is imported before `config.py` finishes
+loading. `config_primitives.py` imports nothing from either module, so it
+cannot be part of a cycle.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .config import MIN_AUTH_TOKEN_BYTES, is_loopback_entry
+from .config_primitives import MIN_AUTH_TOKEN_BYTES, is_loopback_entry
 
 if TYPE_CHECKING:
     from .config import Settings

--- a/tests/integration/test_http_auth.py
+++ b/tests/integration/test_http_auth.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import importlib
-
 import pytest
 from starlette.testclient import TestClient
 
+from law_scrapper_mcp import server as server_module
 from law_scrapper_mcp.auth import build_auth
 from law_scrapper_mcp.config import Settings
 
@@ -18,26 +17,43 @@ LOOPBACK_HOST_HEADER = "127.0.0.1:7683"
 
 @pytest.fixture
 def bearer_app(monkeypatch: pytest.MonkeyPatch):
-    """Rebuild the server module against a bearer-mode configuration.
+    """Reconfigure the live server module for bearer auth without reloading it.
 
-    `MCPServer` reads `auth` and `token_verifier` in its constructor, so the
-    module must be re-imported after the settings change — patching afterwards
-    would leave the SDK's middleware stack unbuilt.
+    `importlib.reload(config)` would rebuild the `settings` singleton that five
+    service modules already captured by value at their own import time,
+    leaving them out of sync with `server.settings` until a second reload — a
+    global side effect that survives a setup failure (a reload raising
+    partway through skips this generator's post-`yield` teardown entirely).
+
+    Instead, this patches only what `server.py`'s call graph actually reads at
+    request time: the module-level `settings` name (read fresh by
+    `build_http_app`/`build_transport_security`/`health`, since Python looks up
+    module globals by name on every call) and the already-constructed `app`
+    instance's `settings.auth` / `_token_verifier` (read fresh by
+    `MCPServer.streamable_http_app` on every call — confirmed in the SDK
+    source, not assumed). Nothing under `sys.modules` is touched, so the five
+    service modules' own `settings` references are untouched by construction,
+    not by convention.
+
+    Every mutation goes through `monkeypatch.setattr`, whose own fixture
+    (`yield mpatch; mpatch.undo()`) records each change immediately and undoes
+    it in its own guaranteed teardown — independent of whether this fixture's
+    body raises before reaching `yield`. There is nothing left for a manual
+    `try/finally` to protect that `monkeypatch` doesn't already protect.
     """
-    monkeypatch.setenv("LAW_MCP_TRANSPORT", "streamable-http")
-    monkeypatch.setenv("LAW_MCP_AUTH_MODE", "bearer")
-    monkeypatch.setenv("LAW_MCP_AUTH_TOKEN", TOKEN)
-    monkeypatch.setenv("LAW_MCP_RATE_LIMIT_ENABLED", "false")
-    # `server.py` binds `settings` by value at import time (`from ...config import
-    # settings`); reloading only `server` would leave it pointing at the module-level
-    # singleton built under the pre-monkeypatch environment. Reload `config` first so
-    # a fresh `Settings()` picks up the patched env vars, then `server` picks up that.
-    importlib.reload(importlib.import_module("law_scrapper_mcp.config"))
-    server_module = importlib.reload(importlib.import_module("law_scrapper_mcp.server"))
+    bearer_settings = Settings(
+        transport="streamable-http",
+        auth_mode="bearer",
+        auth_token=TOKEN,
+        rate_limit_enabled=False,
+    )
+    auth_settings, token_verifier = build_auth(bearer_settings)
+
+    monkeypatch.setattr(server_module, "settings", bearer_settings)
+    monkeypatch.setattr(server_module.app.settings, "auth", auth_settings)
+    monkeypatch.setattr(server_module.app, "_token_verifier", token_verifier)
+
     yield server_module.build_http_app()
-    monkeypatch.undo()
-    importlib.reload(importlib.import_module("law_scrapper_mcp.config"))
-    importlib.reload(importlib.import_module("law_scrapper_mcp.server"))
 
 
 def _mcp_headers(token: str | None) -> dict[str, str]:

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -311,18 +311,16 @@ async def test_live_http_discovery_tools_success_and_error(live_http_server: str
     import httpx2
     from mcp.client.streamable_http import streamable_http_client
 
-    transport = streamable_http_client(
-        live_http_server,
-        http_client=httpx2.AsyncClient(headers={"Authorization": f"Bearer {LIVE_SERVER_TOKEN}"}),
-    )
-    async with Client(transport) as client:
-        assert date.fromisoformat(client.protocol_version) >= PROTOCOL_FLOOR
-        tools = (await client.list_tools()).tools
-        success = await client.call_tool(
-            "calculate_legal_date",
-            {"days": 1, "base_date": "2026-01-01"},
-        )
-        failure = await client.call_tool("get_act_details", {"eli": "INVALID"})
+    async with httpx2.AsyncClient(headers={"Authorization": f"Bearer {LIVE_SERVER_TOKEN}"}) as http_client:
+        transport = streamable_http_client(live_http_server, http_client=http_client)
+        async with Client(transport) as client:
+            assert date.fromisoformat(client.protocol_version) >= PROTOCOL_FLOOR
+            tools = (await client.list_tools()).tools
+            success = await client.call_tool(
+                "calculate_legal_date",
+                {"days": 1, "base_date": "2026-01-01"},
+            )
+            failure = await client.call_tool("get_act_details", {"eli": "INVALID"})
 
     assert len(tools) == 13
     assert success.is_error is False

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from pathlib import Path
 
 import pytest
@@ -19,7 +21,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     pydantic-settings reads os.environ at construction time, so a developer with
     LAW_MCP_AUTH_MODE exported would otherwise see failures no one can reproduce.
     """
-    for name in list(__import__("os").environ):
+    for name in list(os.environ):
         if name.startswith("LAW_MCP_"):
             monkeypatch.delenv(name, raising=False)
 
@@ -73,6 +75,13 @@ def test_short_token_is_rejected() -> None:
     """Criterion 4 (D8): length only — entropy is not, and cannot be, measured."""
     with pytest.raises(ValidationError) as exc_info:
         Settings(auth_mode="bearer", auth_token="za-krotki")
+    assert str(MIN_AUTH_TOKEN_BYTES) in str(exc_info.value)
+
+
+def test_token_one_byte_short_of_the_minimum_is_rejected() -> None:
+    """Off-by-one guard: MIN_AUTH_TOKEN_BYTES - 1 bytes must still fail."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token="x" * (MIN_AUTH_TOKEN_BYTES - 1))
     assert str(MIN_AUTH_TOKEN_BYTES) in str(exc_info.value)
 
 
@@ -163,6 +172,16 @@ def test_rate_limit_defaults_follow_d17() -> None:
     assert current.trusted_proxies == []
 
 
+def test_rate_limit_requests_zero_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(rate_limit_requests=0)
+
+
+def test_rate_limit_window_zero_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(rate_limit_window=0)
+
+
 class TestRemoteBindWarning:
     """Criterion 6 (D7): a visible signal instead of silent exposure."""
 
@@ -171,17 +190,18 @@ class TestRemoteBindWarning:
 
         current = Settings(transport="streamable-http")
         with caplog.at_level("WARNING"):
-            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
-        assert caplog.records == []
+            log_remote_bind_warning(current, logging.getLogger("test"))
+        assert [r for r in caplog.records if r.name == "test"] == []
 
     def test_remote_bind_logs_one_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         from law_scrapper_mcp.config import log_remote_bind_warning
 
         current = Settings(transport="streamable-http", host="0.0.0.0", auth_mode="bearer", auth_token=VALID_TOKEN)
         with caplog.at_level("WARNING"):
-            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
-        assert len(caplog.records) == 1
-        assert "0.0.0.0" in caplog.records[0].getMessage()
+            log_remote_bind_warning(current, logging.getLogger("test"))
+        records = [r for r in caplog.records if r.name == "test"]
+        assert len(records) == 1
+        assert "0.0.0.0" in records[0].getMessage()
 
     def test_stdio_transport_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         """The bind address is meaningless without an HTTP listener."""
@@ -189,13 +209,5 @@ class TestRemoteBindWarning:
 
         current = Settings(transport="stdio", host="0.0.0.0", auth_mode="bearer", auth_token=VALID_TOKEN)
         with caplog.at_level("WARNING"):
-            log_remote_bind_warning(current, __import__("logging").getLogger("test"))
-        assert caplog.records == []
-
-
-def test_config_contains_no_wildcard_bind() -> None:
-    """Criterion 13: the wildcard bind must not survive anywhere in config.py."""
-    from pathlib import Path as _Path
-
-    source = (_Path(__file__).parents[2] / "src/law_scrapper_mcp/config.py").read_text(encoding="utf-8")
-    assert "0.0.0.0" not in source
+            log_remote_bind_warning(current, logging.getLogger("test"))
+        assert [r for r in caplog.records if r.name == "test"] == []

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -157,6 +157,41 @@ def test_oauth_with_full_configuration_is_accepted() -> None:
     assert current.auth_jwks_cache_ttl == 3600
 
 
+def test_oauth_http_issuer_is_rejected() -> None:
+    """`AnyHttpUrl` accepts plain `http://` as readily as `https://`; the
+    discovery request built from `auth_issuer` would otherwise go out over an
+    unauthenticated channel an attacker could MITM to substitute a malicious
+    discovery document."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            auth_mode="oauth",
+            auth_issuer="http://login.microsoftonline.com/tenant/v2.0",
+            auth_audience="api://law-scrapper",
+            auth_resource_server_url="https://mcp.example.com/mcp",
+        )
+    message = str(exc_info.value)
+    assert "LAW_MCP_AUTH_ISSUER" in message
+    assert "https" in message
+
+
+def test_oauth_http_jwks_uri_is_rejected() -> None:
+    """A directly-configured `auth_jwks_uri` skips `_discover_jwks_uri`
+    entirely, so its own https-only discovery check never runs — this must be
+    enforced independently, or a plain-http `LAW_MCP_AUTH_JWKS_URI` bypasses
+    the downgrade protection completely."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            auth_mode="oauth",
+            auth_issuer="https://login.microsoftonline.com/tenant/v2.0",
+            auth_jwks_uri="http://login.microsoftonline.com/tenant/discovery/keys",
+            auth_audience="api://law-scrapper",
+            auth_resource_server_url="https://mcp.example.com/mcp",
+        )
+    message = str(exc_info.value)
+    assert "LAW_MCP_AUTH_JWKS_URI" in message
+    assert "https" in message
+
+
 def test_secret_is_not_in_the_repr() -> None:
     """SecretStr keeps the token out of crash dumps and config logging."""
     current = Settings(auth_mode="bearer", auth_token=VALID_TOKEN)
@@ -222,3 +257,19 @@ class TestRemoteBindWarning:
         with caplog.at_level("WARNING"):
             log_remote_bind_warning(current, logging.getLogger("test"))
         assert [r for r in caplog.records if r.name == "test"] == []
+
+
+def test_config_contains_no_wildcard_bind() -> None:
+    """Criterion 13: the wildcard bind must not survive anywhere in config.py.
+
+    The security-boundary validator that used to enforce this at runtime now
+    lives in `config_validation.py` (with shared helpers in
+    `config_primitives.py`), so the source-scan must cover all three modules
+    the split produced, not just the one that kept the `Settings` class.
+    """
+    from pathlib import Path as _Path
+
+    src = _Path(__file__).parents[2] / "src/law_scrapper_mcp"
+    for module in ("config.py", "config_validation.py", "config_primitives.py"):
+        source = (src / module).read_text(encoding="utf-8")
+        assert "0.0.0.0" not in source, module

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -117,6 +117,17 @@ def test_invalid_trusted_proxy_cidr_is_rejected() -> None:
     assert "nie-cidr" in message
 
 
+def test_bracketed_ipv6_trusted_proxy_is_rejected() -> None:
+    """`[::1]:*` is valid in LAW_MCP_ALLOWED_HOSTS, so writing `[::1]` here by
+    analogy is the obvious mistake — but bracketed notation is an HTTP host
+    convention, never valid CIDR syntax, and trusted_proxies must be `::1`."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(trusted_proxies=["[::1]"])
+    message = str(exc_info.value)
+    assert "LAW_MCP_TRUSTED_PROXIES" in message
+    assert "[::1]" in message
+
+
 def test_valid_trusted_proxy_cidr_is_accepted() -> None:
     current = Settings(trusted_proxies=["10.0.0.0/8", "192.168.1.1"])
     assert current.trusted_proxies == ["10.0.0.0/8", "192.168.1.1"]

--- a/tests/unit/test_auth_settings_validation.py
+++ b/tests/unit/test_auth_settings_validation.py
@@ -90,6 +90,29 @@ def test_missing_token_file_is_rejected(tmp_path: Path) -> None:
     assert "LAW_MCP_AUTH_TOKEN_FILE" in str(exc_info.value)
 
 
+def test_binary_token_file_is_rejected(tmp_path: Path) -> None:
+    """A non-UTF-8 token file must raise ValidationError, not a raw UnicodeDecodeError."""
+    token_file = tmp_path / "token"
+    token_file.write_bytes(b"\xff\xfe\x00\x01")
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(auth_mode="bearer", auth_token_file=token_file)
+    assert "LAW_MCP_AUTH_TOKEN_FILE" in str(exc_info.value)
+
+
+def test_invalid_trusted_proxy_cidr_is_rejected() -> None:
+    """Malformed CIDR entries must fail at Settings construction, not on first request."""
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(trusted_proxies=["nie-cidr"])
+    message = str(exc_info.value)
+    assert "LAW_MCP_TRUSTED_PROXIES" in message
+    assert "nie-cidr" in message
+
+
+def test_valid_trusted_proxy_cidr_is_accepted() -> None:
+    current = Settings(trusted_proxies=["10.0.0.0/8", "192.168.1.1"])
+    assert current.trusted_proxies == ["10.0.0.0/8", "192.168.1.1"]
+
+
 def test_oauth_without_issuer_is_rejected() -> None:
     """Criterion 5 (D2, A5): no silent downgrade to the shared-secret mode."""
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -118,7 +118,7 @@ class TestSettingsDefaults:
         """Test default server info."""
         settings = Settings()
         assert settings.server_name == "law-scrapper-mcp"
-        assert settings.server_version == "4.0.0"
+        assert settings.server_version == "4.0.1"
 
 
 class TestSettingsFromEnvironment:

--- a/tests/unit/test_env_list_parsing.py
+++ b/tests/unit/test_env_list_parsing.py
@@ -55,11 +55,17 @@ def test_json_array_still_reads_as_a_list(monkeypatch: pytest.MonkeyPatch) -> No
         "LAW_MCP_ALLOWED_ORIGINS",
         "LAW_MCP_AUTH_REQUIRED_SCOPES",
         "LAW_MCP_AUTH_ALGORITHMS",
-        "LAW_MCP_TRUSTED_PROXIES",
     ],
 )
 def test_every_list_setting_accepts_a_flat_value(monkeypatch: pytest.MonkeyPatch, variable: str) -> None:
-    """One decoding rule, not four — a new list field must not reintroduce the trap."""
+    """One decoding rule, not four — a new list field must not reintroduce the trap.
+
+    `LAW_MCP_TRUSTED_PROXIES` is deliberately excluded: unlike these four
+    arbitrary-string fields, it carries its own CIDR validator
+    (`Settings._validate_trusted_proxies`), so an arbitrary flat string is
+    rightly rejected there. `test_trusted_proxies_accepts_a_flat_cidr_value`
+    below exercises the same decoding path with a value that satisfies both.
+    """
     monkeypatch.setenv(variable, "https://mcp.example.com")
     monkeypatch.setenv("LAW_MCP_AUTH_MODE", "bearer")
     monkeypatch.setenv("LAW_MCP_AUTH_TOKEN", "x" * 32)
@@ -70,20 +76,28 @@ def test_every_list_setting_accepts_a_flat_value(monkeypatch: pytest.MonkeyPatch
     assert getattr(settings, field) == ["https://mcp.example.com"]
 
 
+def test_trusted_proxies_accepts_a_flat_cidr_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same decoding path as the other list fields, with a value its CIDR
+    validator also accepts — trusted_proxies just narrows what counts as valid."""
+    monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "10.0.0.0/8")
+
+    assert Settings().trusted_proxies == ["10.0.0.0/8"]
+
+
 def test_bracketed_ipv6_is_not_mistaken_for_json(monkeypatch: pytest.MonkeyPatch) -> None:
     """A bracketed IPv6 literal opens and closes like a JSON array.
 
     `[::1]:*` is this project's own default allowlist entry, so the JSON branch
-    must not swallow it — and a lone `[::1]` in the proxy list is
-    indistinguishable from an array by shape alone.
+    must not swallow it. `trusted_proxies` is not exercised here: it is
+    CIDR-validated, and bracketed notation (an HTTP host convention) is never
+    valid CIDR syntax, so the array-shape ambiguity this test targets cannot
+    arise for that field once a value reaches its validator.
     """
     monkeypatch.setenv("LAW_MCP_ALLOWED_HOSTS", "[::1]:*, 127.0.0.1:*")
-    monkeypatch.setenv("LAW_MCP_TRUSTED_PROXIES", "[::1]")
 
     settings = Settings()
 
     assert settings.allowed_hosts == ["[::1]:*", "127.0.0.1:*"]
-    assert settings.trusted_proxies == ["[::1]"]
 
 
 def test_the_shipped_default_allowlist_survives_a_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -11,6 +11,7 @@ import base64
 import hashlib
 import hmac as hmac_module
 import json
+import logging
 import time
 from typing import Any
 
@@ -217,6 +218,49 @@ async def test_non_json_jwks_response_is_rejected(keypair, monkeypatch: pytest.M
 
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", broken_fetch)
     assert await make_verifier().verify_token(make_token(keypair)) is None
+
+
+@respx.mock
+async def test_discovered_http_jwks_uri_is_rejected(keypair, fetch_calls) -> None:
+    """A discovery document must not be trusted to point key fetching at
+    plaintext HTTP, even though the document itself arrived over HTTPS.
+
+    `fetch_calls` fakes `PyJWKClient.fetch_data` to succeed with a valid key
+    set — without the scheme check, verification would go on to succeed,
+    so this genuinely fails red before the fix rather than passing by
+    accident because of a network error to a fake host.
+    """
+    respx.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json={"jwks_uri": "http://login.example.com/tenant/discovery/keys"})
+    )
+    assert await make_verifier(jwks_uri=None).verify_token(make_token(keypair)) is None
+    assert fetch_calls == []
+
+
+async def test_token_validation_failure_logs_at_info(keypair, fetch_calls, caplog: pytest.LogCaptureFixture) -> None:
+    """A routine rejection (expired token) is everyday traffic, not an
+    operational problem — it must stay at INFO."""
+    with caplog.at_level(logging.INFO, logger="law_scrapper_mcp.auth.jwt_verifier"):
+        result = await make_verifier().verify_token(make_token(keypair, exp=int(time.time()) - 10))
+    assert result is None
+    assert any(record.levelno == logging.INFO for record in caplog.records)
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+async def test_jwks_communication_failure_logs_at_warning(
+    keypair, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed/unreachable JWKS response is an infrastructure problem
+    worth a human noticing, so it must log at WARNING, not INFO."""
+
+    def broken_fetch(self: jwt.PyJWKClient) -> Any:
+        raise json.JSONDecodeError("Expecting value", "<html>not json</html>", 0)
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", broken_fetch)
+    with caplog.at_level(logging.INFO, logger="law_scrapper_mcp.auth.jwt_verifier"):
+        result = await make_verifier().verify_token(make_token(keypair))
+    assert result is None
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
 
 
 def _jwk_for(key: rsa.RSAPrivateKey, kid: str) -> dict[str, Any]:

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -347,3 +347,25 @@ async def test_per_key_cache_tier_stays_disabled(monkeypatch: pytest.MonkeyPatch
     client = await make_verifier()._jwk_client()
 
     assert not hasattr(client.get_signing_key, "cache_info")
+
+
+async def test_unknown_kid_does_not_leak_into_the_warning_log(
+    keypair, fetch_calls, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`PyJWKClientError`'s message embeds the token's own unverified `kid`
+    header (PyJWT reads it before any signature check), so it must never be
+    logged verbatim — the WARNING branch has to stay type-name-only for this
+    exception class specifically, unlike JWKS/discovery transport failures."""
+    sentinel_kid = "attacker-controlled-marker-xyz123"
+    forged = jwt.encode(
+        {"iss": ISSUER, "aud": AUDIENCE, "sub": "user-42", "exp": int(time.time()) + 600},
+        keypair,
+        algorithm="RS256",
+        headers={"kid": sentinel_kid},
+    )
+    with caplog.at_level(logging.INFO, logger="law_scrapper_mcp.auth.jwt_verifier"):
+        result = await make_verifier().verify_token(forged)
+    assert result is None
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+    for record in caplog.records:
+        assert sentinel_kid not in record.getMessage()

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -22,6 +22,7 @@ import respx
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt.algorithms import RSAAlgorithm
+from jwt.exceptions import PyJWKClientConnectionError
 
 from law_scrapper_mcp.auth.jwt_verifier import JwtTokenVerifier
 
@@ -261,6 +262,26 @@ async def test_jwks_communication_failure_logs_at_warning(
         result = await make_verifier().verify_token(make_token(keypair))
     assert result is None
     assert any(record.levelno == logging.WARNING for record in caplog.records)
+    assert not any(record.levelno == logging.INFO for record in caplog.records)
+
+
+async def test_jwks_connection_failure_logs_at_warning(
+    keypair, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`PyJWKClientConnectionError` is a `PyJWTError` subclass (DNS failure,
+    timeout, TLS handshake failure fetching the key set) — it must not be
+    swallowed by the `except jwt.PyJWTError` clause meant for ordinary
+    token-validation failures, or it silently logs at INFO instead of WARNING."""
+
+    def broken_fetch(self: jwt.PyJWKClient) -> Any:
+        raise PyJWKClientConnectionError("boom")
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", broken_fetch)
+    with caplog.at_level(logging.INFO, logger="law_scrapper_mcp.auth.jwt_verifier"):
+        result = await make_verifier().verify_token(make_token(keypair))
+    assert result is None
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+    assert not any(record.levelno == logging.INFO for record in caplog.records)
 
 
 def _jwk_for(key: rsa.RSAPrivateKey, kid: str) -> dict[str, Any]:

--- a/tests/unit/test_static_token_verifier.py
+++ b/tests/unit/test_static_token_verifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 from pathlib import Path
 
 import pytest
@@ -42,6 +43,21 @@ async def test_configured_scopes_are_returned() -> None:
     access = await verifier.verify_token(TOKEN)
     assert access is not None
     assert access.scopes == ["mcp:read"]
+
+
+async def test_verify_token_uses_hmac_compare_digest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guards against a regression to a non-constant-time `==` comparison."""
+    calls = []
+    real_compare_digest = hmac.compare_digest
+
+    def spy(a: bytes, b: bytes) -> bool:
+        calls.append((a, b))
+        return real_compare_digest(a, b)
+
+    monkeypatch.setattr(hmac, "compare_digest", spy)
+    verifier = StaticTokenVerifier(token=TOKEN, scopes=[])
+    assert await verifier.verify_token(TOKEN) is not None
+    assert len(calls) == 1
 
 
 async def test_token_from_file_loses_its_trailing_newline(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -488,6 +489,7 @@ dev = [
 requires-dist = [
     { name = "google-re2", specifier = ">=1.1.20251105" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.5.0" },
     { name = "markdownify", specifier = ">=0.14" },
     { name = "mcp", extras = ["cli"], specifier = "==2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "law-scrapper-mcp"
-version = "4.0.0"
+version = "4.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary

The deferred half of Klaster 7. Twelve Minor findings were raised while reviewing tasks 1–6 of the authentication work, accepted as real but not allowed to block that release; this branch implements them, plus two findings that surfaced later. No behaviour changes for a configuration that was already correct, so this goes out as **4.0.1**.

Branched off #37 and rebased onto `main` after that PR was squash-merged, so the twelve commits here are only this branch's own work. The code depends on the auth and configuration surface #37 introduced.

## What is in it

**Configuration hardening**
- `trusted_proxies` entries are validated as CIDR at startup instead of blowing up on the first HTTP request, with a Polish message naming the variable and the offending entry. Bracketed IPv6 (`[::1]`) is explicitly rejected there — it is valid in `LAW_MCP_ALLOWED_HOSTS` and not in a proxy list, which is the obvious mistake to make by analogy.
- A binary token file raises a clean `ValidationError` rather than an unhandled `UnicodeDecodeError`.
- The security-boundary validator moved to its own module, so the `Settings` field block reads top to bottom without ~65 lines of validation logic in the middle; the import cycle that extraction initially created is closed in the same branch.

**Token verification**
- A `jwks_uri` discovered over plain `http://` is refused.
- Failures talking to the identity provider log at WARNING rather than INFO — those are outages, not the everyday rejection of a bad token, which stays at INFO.
- `PyJWKClientError` no longer reaches a log line carrying its message. PyJWT builds that message from the `kid` read out of the token's **unverified** header (`jwks_client.py:208-216`), so logging it echoed attacker-controlled text into the operator's logs. That clause now logs the exception type only; the other three exception types in the tuple keep their message, since they describe the response rather than the token.

**Tests**
- Boundary cases that were missing: a 31-byte token, `rate_limit_requests=0`, `rate_limit_window=0`.
- A spy asserting `hmac.compare_digest` is actually on the token comparison path, so a regression to `==` fails loudly rather than silently reintroducing a timing side channel.
- `caplog` assertions filter by logger name instead of catching any stray WARNING.
- The `bearer_app` fixture no longer mutates global module state through `importlib.reload`.
- `httpx2` is a declared dev dependency with its client properly closed, rather than an undeclared transitive import.

## Relationship to #37's review

Two of these were found by the review of #37 and routed here rather than fixed there: the `kid` leak (introduced on this branch, absent at #37's base) and the CIDR validation gap. In the other direction, #37's fix making list settings readable from flat environment values is what makes the CIDR validator reachable at all — before it, `LAW_MCP_TRUSTED_PROXIES=10.0.0.0/8` died in the settings source before any validator ran.

The one semantic conflict from rebasing onto #37's tip is resolved in `c55fbda`: `trusted_proxies` is excluded from the generic flat-value parametrize, since it now narrows what counts as a valid entry, and a dedicated test covers the same decoding path with a CIDR-valid value.

## Test plan

- [x] `pytest tests/unit/ -q` — 1164 passed
- [x] `ruff check src tests` — All checks passed
- [x] `ruff format --check src tests` — 110 files already formatted
- [x] `mypy src/law_scrapper_mcp/` — no issues in 53 source files
- [x] `scripts/check_release.py --version 4.0.1` — PASSED

All five re-run after the rebase onto `main`, not carried over from before it.
