### PR TITLE
feat: add result-set scope to prevent false negatives (Klaster 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `search_legal_acts` now sends `limit` upstream even when the caller does not supply one
   (default 20). Without it the API built a page of its own choosing — a measured 709 437 B
-  and 500 records for `DU/2024` — of which nineteen out of twenty records were discarded
-  locally. An explicit `limit` is still not clamped.
+  and 500 records for `DU/2024` — of which twenty-four out of twenty-five records were
+  discarded locally. An explicit `limit` is still not clamped.
 - Large searches now return `was_truncated=true` together with a pagination hint, which is a
   consequence of the `total_count` fix rather than a separate behaviour change.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_legal_acts` reported the size of the returned page as `total_count`, so a search
   matching 1984 acts answered `20` with `was_truncated=false` and no pagination hint at all.
   It now reads `totalCount` and falls back to `count` for responses that omit it (F31).
+  Clients that relied on `total_count` carrying the page size will see a different value.
+  This is shipped as a fix in a MINOR release, not as a breaking change in a MAJOR one:
+  the field always declared the size of the match set and no documentation ever promised
+  the page size, so the previous value was a defect rather than a contract.
 - The pagination hint from `browse_acts` pointed at `search_legal_acts`, sending the model to
   a different tool than the one it had called (F48).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Result-set scope (`result_set_scope`, and `scope` in `list_result_sets`) telling the caller
+  whether a stored set is the complete answer to its query or a window cut from a larger
+  corpus. `filter_results` inherits the reach of the set it filtered rather than deriving a
+  new one, and reports `source_scope` alongside it.
+- `no_match_is_inconclusive` on `filter_results`: set when a filter over a windowed set
+  matched nothing, so an empty result is not read as proof that no such act exists.
+- Pagination hints now carry the full next call — the tool that produced them plus every
+  source criterion, `limit` and `offset` — instead of an unparameterised suggestion.
+
+### Fixed
+
+- `search_legal_acts` reported the size of the returned page as `total_count`, so a search
+  matching 1984 acts answered `20` with `was_truncated=false` and no pagination hint at all.
+  It now reads `totalCount` and falls back to `count` for responses that omit it (F31).
+- The pagination hint from `browse_acts` pointed at `search_legal_acts`, sending the model to
+  a different tool than the one it had called (F48).
+
+### Changed
+
+- `search_legal_acts` now sends `limit` upstream even when the caller does not supply one
+  (default 20). Without it the API built a page of its own choosing — a measured 709 437 B
+  and 500 records for `DU/2024` — of which nineteen out of twenty records were discarded
+  locally. An explicit `limit` is still not clamped.
+- Large searches now return `was_truncated=true` together with a pagination hint, which is a
+  consequence of the `total_count` fix rather than a separate behaviour change.
+
 ## [4.0.2] - 2026-09-01
 
 See [docs/changelogs/v4.0.2.md](docs/changelogs/v4.0.2.md) for details.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,14 @@ Filter and narrow down previously retrieved search/browse/changes results.
 - Get top 10 most recent results
 ```
 
+**Result-set scope.** Every stored result set declares whether it is the whole answer
+(`complete`) or a window cut from a larger corpus (`page`), in the `result_set_scope` field
+of the response and in `list_result_sets`. The distinction matters because `filter_results`
+narrows the **set**, not the query: an empty filter over a `page` set means "no match among
+these twenty records", not "no such act exists". Responses say so explicitly — a filter that
+matches nothing over a window sets `no_match_is_inconclusive`. `track_legal_changes` is the
+one tool whose set is always `complete`, because it stores the whole fetched range.
+
 ### 5. get_act_details(eli, load_content, detail_level)
 
 Retrieve detailed information about a specific legal act and optionally load its content.

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, Field
@@ -40,6 +41,35 @@ class ActSummaryOutput(BaseModel):
     promulgation_date: str | None = None
     effective_date: str | None = None
     in_force: str | None = None
+
+
+class SetScope(StrEnum):
+    """Whether a stored result set is the whole answer or a window into it."""
+
+    COMPLETE = "complete"
+    PAGE = "page"
+
+
+class ResultSetScope(BaseModel):
+    """Zasięg zestawu wyników względem korpusu, z którego pochodzi."""
+
+    scope: SetScope = Field(
+        description=(
+            "'complete' — zestaw zawiera każdy rekord pasujący do zapytania w chwili wywołania. "
+            "'page' — zestaw jest oknem wyciętym z większego korpusu, więc brak dopasowania "
+            "w filter_results NIE dowodzi, że akt nie istnieje w zbiorze."
+        )
+    )
+    stored_count: int = Field(description="Liczba rekordów w tym zestawie.")
+    window_offset: int = Field(description="Pozycja początku okna w korpusie. Zero dla zestawu kompletnego.")
+    corpus_count: int | None = Field(
+        default=None,
+        description=(
+            "Rozmiar korpusu, z którego pochodzi zestaw. None, gdy nieznany — tak jest dla "
+            "zestawu powstałego z filtrowania okna: wiadomo, ile rekordów trafiło w oknie, "
+            "nie wiadomo, ile rekordów korpusu pasowałoby do tych samych kryteriów."
+        ),
+    )
 
 
 class SearchOutput(BaseModel):

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -171,6 +171,21 @@ class FilterOutput(BaseModel):
     original_count: int
     filtered_count: int
     filters_applied: dict[str, Any] = {}
+    source_scope: ResultSetScope = Field(
+        description="Zasięg zestawu, który filtrowano — decyduje, czego dowodzi pusty wynik."
+    )
+    result_set_scope: ResultSetScope | None = Field(
+        default=None,
+        description="Zasięg zestawu powstałego z filtrowania. None, gdy nic nie dopasowano.",
+    )
+    no_match_is_inconclusive: bool = Field(
+        default=False,
+        description=(
+            "True, gdy filtrowano okno i nic nie dopasowano. Wynik NIE rozstrzyga, "
+            "czy akt istnieje w zbiorze — przeszukano tylko okno. Poszerz zestaw "
+            "albo zawęź kryteria wyszukiwania przed wyciągnięciem wniosku."
+        ),
+    )
     page_info: PageInfo
 
 

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -80,6 +80,13 @@ class SearchOutput(BaseModel):
     query_summary: str
     returned_count: int
     result_set_id: str | None = None
+    result_set_scope: ResultSetScope | None = Field(
+        default=None,
+        description=(
+            "Zasięg zapisanego zestawu wyników. None, gdy zestaw nie powstał (zero wyników). "
+            "Wartość 'page' oznacza, że filter_results zawęża okno, a nie cały zbiór."
+        ),
+    )
     page_info: PageInfo
 
 
@@ -159,6 +166,13 @@ class ChangesOutput(BaseModel):
     changes: list[ActSummaryOutput]
     total_count: int
     result_set_id: str | None = None
+    result_set_scope: ResultSetScope | None = Field(
+        default=None,
+        description=(
+            "Zasięg zapisanego zestawu zmian. Zawsze 'complete' dla niepustego wyniku — "
+            "to jedyne narzędzie, którego zestaw filter_results przeszukuje w całości."
+        ),
+    )
     page_info: PageInfo
 
 
@@ -207,6 +221,9 @@ class ResultSetInfo(BaseModel):
     query_summary: str
     result_count: int
     total_count: int
+    scope: SetScope = Field(
+        description="Zasięg zestawu: 'complete' (cały zbiór) albo 'page' (okno z większego zbioru)."
+    )
     created_at: str
 
 

--- a/src/law_scrapper_mcp/services/changes_service.py
+++ b/src/law_scrapper_mcp/services/changes_service.py
@@ -33,7 +33,7 @@ class ChangesService:
         query_summary = f"changes: {date_range} | publisher={publisher}"
         if keywords:
             query_summary += f" | keywords={','.join(keywords)}"
-        result_set_id = await self._result_store.store(results, query_summary, len(results)) if results else None
+        result_set_id = (await self._result_store.store(results, query_summary, len(results)))[0] if results else None
         page_limit = effective_limit(limit, default=DEFAULT_ITEM_LIMIT, maximum=MAX_ITEM_LIMIT)
         page_offset = parse_non_negative(offset, name="offset", default=0)
         changes, page_info = paginate_items(results, limit=page_limit, offset=page_offset)

--- a/src/law_scrapper_mcp/services/changes_service.py
+++ b/src/law_scrapper_mcp/services/changes_service.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.models.pagination import DEFAULT_ITEM_LIMIT, MAX_ITEM_LIMIT
-from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, ChangesOutput
+from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, ChangesOutput, ResultSetScope
 from law_scrapper_mcp.services.pagination import effective_limit, paginate_items, parse_non_negative
 from law_scrapper_mcp.services.result_store import ResultStore
 
@@ -33,7 +33,18 @@ class ChangesService:
         query_summary = f"changes: {date_range} | publisher={publisher}"
         if keywords:
             query_summary += f" | keywords={','.join(keywords)}"
-        result_set_id = (await self._result_store.store(results, query_summary, len(results)))[0] if results else None
+        result_set_id: str | None = None
+        result_set_scope: ResultSetScope | None = None
+        if results:
+            # The full fetched list, stored whole and starting at the corpus origin, so the
+            # rule in `store()` derives COMPLETE without being told (D6). This has always
+            # been the behaviour; the cluster only makes it visible in the contract.
+            result_set_id, result_set_scope = await self._result_store.store(
+                results,
+                query_summary,
+                len(results),
+                window_offset=0,
+            )
         page_limit = effective_limit(limit, default=DEFAULT_ITEM_LIMIT, maximum=MAX_ITEM_LIMIT)
         page_offset = parse_non_negative(offset, name="offset", default=0)
         changes, page_info = paginate_items(results, limit=page_limit, offset=page_offset)
@@ -44,6 +55,7 @@ class ChangesService:
             changes=changes,
             total_count=len(results),
             result_set_id=result_set_id,
+            result_set_scope=result_set_scope,
             page_info=page_info,
         )
 

--- a/src/law_scrapper_mcp/services/response_enrichment.py
+++ b/src/law_scrapper_mcp/services/response_enrichment.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from law_scrapper_mcp.models.tool_outputs import (
+    FilterOutput,
     Hint,
     LoadedDocumentInfo,
     ResultSetInfo,
@@ -166,6 +167,64 @@ def search_hints(
                 parameters={"category": "keywords"},
             )
         )
+    return hints
+
+
+def _inconclusive_match_hint(output: FilterOutput, filter_max_records: int) -> Hint:
+    """Explain that an empty result proves nothing, and give a step that can be taken.
+
+    This hint deliberately carries **no** `tool`. `FilterOutput` does not record which
+    tool produced the source set, and naming `search_legal_acts` on a set that came from
+    `browse_acts` would reproduce F48 inside the fix for it. The model knows which call
+    it made; the server does not, and says so by omission rather than by guessing.
+    """
+    scope = output.source_scope
+    corpus = scope.corpus_count
+    seen = (
+        f"{scope.stored_count} rekordów z {corpus} dopasowań"
+        if corpus is not None
+        else f"{scope.stored_count} rekordów"
+    )
+    if corpus is not None and corpus <= filter_max_records:
+        step = (
+            f"Powtórz wyszukiwanie, które utworzyło {output.source_result_set_id}, "
+            f"z limit={corpus}, aby zestaw objął cały zbiór, i filtruj ponownie."
+        )
+    else:
+        step = (
+            f"Zawęź kryteria wyszukiwania (tytuł, typ aktu, słowa kluczowe albo zakres dat), "
+            f"aby zbiór zmieścił się w limicie filter_results ({filter_max_records} rekordów), "
+            f"i filtruj ponownie."
+        )
+    return Hint(
+        message=(
+            f"Brak dopasowań, ale filtrowano OKNO: {seen}. Ten wynik NIE dowodzi, że akt "
+            f"nie istnieje — pozostałe rekordy zbioru nie zostały sprawdzone. {step}"
+        )
+    )
+
+
+def filter_hints(output: FilterOutput, *, filter_max_records: int) -> list[Hint]:
+    """Generate hints for filtered results."""
+    hints = []
+    if output.results:
+        hints.append(
+            Hint(
+                message="Użyj get_act_details aby zobaczyć szczegóły wybranego aktu.",
+                tool="get_act_details",
+                parameters={"eli": output.results[0].eli},
+            )
+        )
+        if output.result_set_id:
+            hints.append(
+                Hint(
+                    message=f"Możesz dalej filtrować te wyniki używając result_set_id='{output.result_set_id}'.",
+                    tool="filter_results",
+                    parameters={"result_set_id": output.result_set_id},
+                )
+            )
+    if output.no_match_is_inconclusive:
+        hints.append(_inconclusive_match_hint(output, filter_max_records))
     return hints
 
 

--- a/src/law_scrapper_mcp/services/response_enrichment.py
+++ b/src/law_scrapper_mcp/services/response_enrichment.py
@@ -3,8 +3,67 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 
-from law_scrapper_mcp.models.tool_outputs import Hint, LoadedDocumentInfo, ResultSetInfo
+from law_scrapper_mcp.models.tool_outputs import (
+    Hint,
+    LoadedDocumentInfo,
+    ResultSetInfo,
+    ResultSetScope,
+    SetScope,
+)
+
+
+def _filter_results_hint(result_set_id: str, scope: ResultSetScope | None) -> Hint:
+    """Say what filtering actually narrows — the set, which may be a window."""
+    if scope is not None and scope.scope is SetScope.PAGE and scope.corpus_count is not None:
+        message = (
+            f"Użyj filter_results aby zawęzić wyniki. UWAGA: zawężaniu podlega zestaw "
+            f"{scope.stored_count} rekordów, który jest OKNEM z {scope.corpus_count} dopasowań. "
+            f"Brak dopasowania w filtrze nie dowodzi, że akt nie istnieje w zbiorze."
+        )
+    else:
+        message = (
+            "Użyj filter_results aby zawęzić wyniki, np. po typie dokumentu "
+            "(Ustawa, Rozporządzenie) lub wzorcem regex w tytule."
+        )
+    return Hint(message=message, tool="filter_results", parameters={"result_set_id": result_set_id})
+
+
+def _complete_set_hint(
+    tool_name: str,
+    next_call_params: dict[str, Any],
+    corpus_count: int,
+    filter_max_records: int,
+) -> Hint:
+    """Tell the model how to get a complete set — or that it cannot, and what to do instead.
+
+    The suggested limit is clamped to the filter ceiling (D9). Suggesting `limit=1984`
+    would be unexecutable: the resulting set is rejected by `ResultSetTooLargeError` on
+    the first `filter_results` call, so the hint would be an instruction the model cannot
+    carry out — the same defect as F48, one level up.
+    """
+    if corpus_count <= filter_max_records:
+        return Hint(
+            message=(
+                f"Aby zestaw objął CAŁY zbiór ({corpus_count} dopasowań) i filtrowanie było "
+                f"rozstrzygające, powtórz to wywołanie z limit={corpus_count}."
+            ),
+            tool=tool_name,
+            # No `offset` key on purpose. Zero is the default, so omitting it keeps the
+            # call correct — and it keeps this hint distinguishable from the pagination
+            # one, which is defined by carrying an offset.
+            parameters={**next_call_params, "limit": corpus_count},
+        )
+    return Hint(
+        message=(
+            f"Zbiór liczy {corpus_count} dopasowań i przekracza limit filter_results "
+            f"({filter_max_records} rekordów), więc powiększenie okna nie da zestawu "
+            f"kompletnego — taki zestaw zostanie odrzucony przy filtrowaniu. "
+            f"Zawęź kryteria wyszukiwania (tytuł, typ aktu, słowa kluczowe albo zakres dat)."
+        ),
+        tool=tool_name,
+    )
 
 
 def search_hints(
@@ -13,11 +72,22 @@ def search_hints(
     eli: str | None = None,
     result_set_id: str | None = None,
     *,
+    tool_name: str,
+    next_call_params: dict[str, Any],
+    filter_max_records: int,
+    scope: ResultSetScope | None = None,
     offset: int = 0,
     returned_count: int = 0,
     applied_limit: int | None = None,
 ) -> list[Hint]:
-    """Generate hints for search results."""
+    """Generate hints for search and browse results.
+
+    `tool_name` and `next_call_params` are required and have no defaults on purpose.
+    This function used to hard-code `search_legal_acts`, so every hint `browse_acts`
+    produced pointed the model at a different tool than the one it had called (F48).
+    A default would let that come back. Only the calling tool knows which parameters
+    it accepts, so it builds `next_call_params` itself.
+    """
     hints = []
     if has_results and eli:
         hints.append(
@@ -28,42 +98,45 @@ def search_hints(
             )
         )
     if has_results and result_set_id:
-        hints.append(
-            Hint(
-                message="Użyj filter_results aby zawęzić wyniki, np. po typie dokumentu (Ustawa, Rozporządzenie) lub wzorcem regex w tytule.",
-                tool="filter_results",
-                parameters={"result_set_id": result_set_id},
-            )
-        )
+        hints.append(_filter_results_hint(result_set_id, scope))
+
     was_truncated = offset + returned_count < total_count
     if was_truncated and applied_limit:
+        # A hint the model can copy and run: every source criterion, plus the window.
+        # The previous version said "użyj limit/offset" without saying which values,
+        # while `PageInfo.next_offset` had already computed one of them.
         hints.append(
             Hint(
-                message=f"Wyniki ograniczone do {applied_limit} (z {total_count} dostępnych). "
-                f"Użyj limit/offset do paginacji lub filter_results do zawężenia.",
-                tool="search_legal_acts",
+                message=(
+                    f"Zwrócono {returned_count} z {total_count} dopasowań. "
+                    f"Następna strona to wywołanie z offset={offset + returned_count}."
+                ),
+                tool=tool_name,
+                parameters={
+                    **next_call_params,
+                    "limit": applied_limit,
+                    "offset": offset + returned_count,
+                },
             )
         )
-    elif total_count > 20 and was_truncated:
-        hints.append(
-            Hint(
-                message="Użyj parametrów 'limit' i 'offset' do paginacji wyników.",
-                tool="search_legal_acts",
-            )
-        )
+
+    if scope is not None and scope.scope is SetScope.PAGE and scope.corpus_count is not None:
+        hints.append(_complete_set_hint(tool_name, next_call_params, scope.corpus_count, filter_max_records))
+
     if not has_results:
-        hints.append(
-            Hint(
-                message="Brak wyników. UWAGA: Słowa kluczowe API działają z logiką AND — "
-                "wszystkie muszą wystąpić jednocześnie. Spróbuj mniej słów kluczowych "
-                "lub szukaj każdego osobno (logika OR).",
-                tool="search_legal_acts",
+        if next_call_params.get("keywords"):
+            hints.append(
+                Hint(
+                    message="Brak wyników. UWAGA: Słowa kluczowe API działają z logiką AND — "
+                    "wszystkie muszą wystąpić jednocześnie. Spróbuj mniej słów kluczowych "
+                    "lub szukaj każdego osobno (logika OR).",
+                    tool=tool_name,
+                )
             )
-        )
         hints.append(
             Hint(
                 message="Spróbuj poszerzyć kryteria: usuń filtry dat, zmień typ dokumentu lub rok.",
-                tool="search_legal_acts",
+                tool=tool_name,
             )
         )
         hints.append(

--- a/src/law_scrapper_mcp/services/response_enrichment.py
+++ b/src/law_scrapper_mcp/services/response_enrichment.py
@@ -35,15 +35,22 @@ def _complete_set_hint(
     next_call_params: dict[str, Any],
     corpus_count: int,
     filter_max_records: int,
+    max_result_limit: int | None = None,
 ) -> Hint:
     """Tell the model how to get a complete set — or that it cannot, and what to do instead.
 
-    The suggested limit is clamped to the filter ceiling (D9). Suggesting `limit=1984`
-    would be unexecutable: the resulting set is rejected by `ResultSetTooLargeError` on
-    the first `filter_results` call, so the hint would be an instruction the model cannot
-    carry out — the same defect as F48, one level up.
+    The suggested limit is clamped to whichever ceiling actually binds (D9): the
+    `filter_results` ceiling, or the calling tool's own hard cap on `limit`
+    (`max_result_limit`, e.g. `browse_acts`'s page-size clamp), whichever is lower.
+    Suggesting a `limit` above either would be unexecutable — either
+    `ResultSetTooLargeError` on the first `filter_results` call, or the calling tool
+    silently clamping the value before it ever reaches the result store, handing back
+    another PAGE instead of the COMPLETE set the hint promised. Both are the same
+    defect as F48, one level up. `max_result_limit=None` means the calling tool's
+    `limit` is genuinely unbounded (true for `search_legal_acts`).
     """
-    if corpus_count <= filter_max_records:
+    effective_ceiling = filter_max_records if max_result_limit is None else min(filter_max_records, max_result_limit)
+    if corpus_count <= effective_ceiling:
         return Hint(
             message=(
                 f"Aby zestaw objął CAŁY zbiór ({corpus_count} dopasowań) i filtrowanie było "
@@ -55,12 +62,16 @@ def _complete_set_hint(
             # one, which is defined by carrying an offset.
             parameters={**next_call_params, "limit": corpus_count},
         )
+    if max_result_limit is not None and max_result_limit < filter_max_records:
+        limiting_reason = f"limit narzędzia {tool_name} ({max_result_limit} rekordów)"
+    else:
+        limiting_reason = f"limit filter_results ({filter_max_records} rekordów)"
     return Hint(
         message=(
-            f"Zbiór liczy {corpus_count} dopasowań i przekracza limit filter_results "
-            f"({filter_max_records} rekordów), więc powiększenie okna nie da zestawu "
-            f"kompletnego — taki zestaw zostanie odrzucony przy filtrowaniu. "
-            f"Zawęź kryteria wyszukiwania (tytuł, typ aktu, słowa kluczowe albo zakres dat)."
+            f"Zbiór liczy {corpus_count} dopasowań i przekracza {limiting_reason}, "
+            f"więc powiększenie okna nie da zestawu kompletnego — taki zestaw zostanie "
+            f"odrzucony lub przycięty. Zawęź kryteria wyszukiwania (tytuł, typ aktu, "
+            f"słowa kluczowe albo zakres dat)."
         ),
         tool=tool_name,
     )
@@ -79,6 +90,7 @@ def search_hints(
     offset: int = 0,
     returned_count: int = 0,
     applied_limit: int | None = None,
+    max_result_limit: int | None = None,
 ) -> list[Hint]:
     """Generate hints for search and browse results.
 
@@ -121,7 +133,15 @@ def search_hints(
         )
 
     if scope is not None and scope.scope is SetScope.PAGE and scope.corpus_count is not None:
-        hints.append(_complete_set_hint(tool_name, next_call_params, scope.corpus_count, filter_max_records))
+        hints.append(
+            _complete_set_hint(
+                tool_name,
+                next_call_params,
+                scope.corpus_count,
+                filter_max_records,
+                max_result_limit,
+            )
+        )
 
     if not has_results:
         if next_call_params.get("keywords"):

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -9,7 +9,14 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from law_scrapper_mcp.models.pagination import DEFAULT_ITEM_LIMIT, MAX_ITEM_LIMIT
-from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, FilterOutput, ResultSetInfo, ResultSetListOutput
+from law_scrapper_mcp.models.tool_outputs import (
+    ActSummaryOutput,
+    FilterOutput,
+    ResultSetInfo,
+    ResultSetListOutput,
+    ResultSetScope,
+    SetScope,
+)
 from law_scrapper_mcp.services.pagination import effective_limit, paginate_items, parse_non_negative
 from law_scrapper_mcp.services.pattern_matching import CompiledPattern, compile_pattern
 
@@ -24,8 +31,20 @@ class StoredResultSet:
     results: list[ActSummaryOutput]
     query_summary: str
     total_count: int
+    scope: SetScope = SetScope.COMPLETE
+    window_offset: int = 0
+    corpus_count: int | None = None
     created_at: float = field(default_factory=time.time)
     last_accessed: float = field(default_factory=time.time)
+
+    def scope_view(self) -> ResultSetScope:
+        """Describe this set's reach for the tool contract."""
+        return ResultSetScope(
+            scope=self.scope,
+            stored_count=len(self.results),
+            window_offset=self.window_offset,
+            corpus_count=self.corpus_count,
+        )
 
 
 @dataclass
@@ -63,8 +82,36 @@ class ResultStore:
         results: list[ActSummaryOutput],
         query_summary: str,
         total_count: int,
-    ) -> str:
-        """Store a result set and return its ID."""
+        *,
+        window_offset: int = 0,
+        scope: SetScope | None = None,
+    ) -> tuple[str, ResultSetScope]:
+        """Store a result set and return its ID together with its reach.
+
+        Returns both because the caller needs both, and reading the reach back
+        through `get()` would refresh `last_accessed` and corrupt the LRU order.
+
+        `scope=None` means "derive it": a set is complete exactly when it starts at
+        the corpus origin and holds as many records as the corpus has. A caller
+        passes `scope` explicitly only to *inherit* a reach it already knows —
+        `filter_and_store` does, because a filtered subset of a window is complete
+        with respect to the window and to nothing else.
+
+        `corpus_count` follows from that same distinction and is deliberately not a
+        parameter. When the reach is derived, `total_count` IS the corpus size. When
+        it is inherited as PAGE, `total_count` describes the derived set and the
+        corpus count is genuinely unknown: how many corpus records would have matched
+        was never computed. Do not "fix" that None by filling in the source set's
+        corpus size — it answers a question nobody asked and states it as fact.
+        """
+        corpus_count: int | None
+        if scope is None:
+            resolved = SetScope.COMPLETE if window_offset == 0 and len(results) == total_count else SetScope.PAGE
+            corpus_count = total_count
+        else:
+            resolved = scope
+            corpus_count = total_count if resolved is SetScope.COMPLETE else None
+
         async with self._lock:
             self._evict_expired()
 
@@ -74,17 +121,27 @@ class ResultStore:
             self._counter += 1
             result_set_id = f"rs_{self._counter}"
 
-            self._store[result_set_id] = StoredResultSet(
+            stored = StoredResultSet(
                 result_set_id=result_set_id,
                 results=results,
                 query_summary=query_summary,
                 total_count=total_count,
+                scope=resolved,
+                window_offset=window_offset,
+                corpus_count=corpus_count,
             )
-            logger.info("Stored result set %s: %d results (total %d)", result_set_id, len(results), total_count)
+            self._store[result_set_id] = stored
+            logger.info(
+                "Stored result set %s: %d results (total %d, scope %s)",
+                result_set_id,
+                len(results),
+                total_count,
+                resolved,
+            )
             # The query text can be sensitive on its own; keep it recoverable
             # but off the default production level.
             logger.debug("Result set %s query: %s", result_set_id, query_summary)
-            return result_set_id
+            return result_set_id, stored.scope_view()
 
     async def get(self, result_set_id: str) -> StoredResultSet | None:
         """Get a stored result set by ID."""
@@ -108,6 +165,7 @@ class ResultStore:
                     "query_summary": rs.query_summary,
                     "result_count": len(rs.results),
                     "total_count": rs.total_count,
+                    "scope": rs.scope,
                     "created_at": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(rs.created_at)),
                 }
                 for rs in self._store.values()
@@ -247,7 +305,7 @@ class ResultStore:
                 date_from=date_from,
                 date_to=date_to,
             )
-            new_set_id = await self.store(
+            new_set_id, _ = await self.store(
                 filtered,
                 f"filtered({result_set_id}): {description}",
                 len(filtered),

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -422,7 +422,7 @@ class ResultSetTooLargeError(Exception):
             f"date_from/date_to lub dodaj keywords. Wynik częściowy nie jest "
             f"zwracany, aby brak dopasowania zawsze oznaczał "
             f"przeszukanie całego ZESTAWU. Uwaga: to gwarancja o zestawie, nie o zbiorze "
-            f"— jeśli zestaw jest oknem (pole set_scope w odpowiedzi ma wartość 'page'), "
+            f"— jeśli zestaw jest oknem (pole result_set_scope w odpowiedzi ma wartość 'page'), "
             f"brak dopasowania nadal nie dowodzi, że akt nie istnieje."
         )
 

--- a/src/law_scrapper_mcp/services/result_store.py
+++ b/src/law_scrapper_mcp/services/result_store.py
@@ -189,9 +189,23 @@ class ResultStore:
             page_info=page_info,
         )
 
-    async def filter_results(
+    async def _require(self, result_set_id: str) -> StoredResultSet:
+        """Fetch a set for filtering, or explain why it cannot be filtered.
+
+        Split out so `filter_and_store` reads the set exactly once. Calling `get()`
+        a second time to recover the source reach would refresh `last_accessed` and
+        move the set to the front of the LRU order as a side effect of describing it.
+        """
+        rs = await self.get(result_set_id)
+        if rs is None:
+            raise ResultSetNotFoundError(result_set_id)
+        if len(rs.results) > self.max_records:
+            raise ResultSetTooLargeError(result_set_id, len(rs.results), self.max_records)
+        return rs
+
+    def _apply_filters(
         self,
-        result_set_id: str,
+        rs: StoredResultSet,
         *,
         pattern: str | None = None,
         field: str = "title",
@@ -204,14 +218,7 @@ class ResultStore:
         sort_by: str | None = None,
         sort_desc: bool = False,
     ) -> tuple[list[ActSummaryOutput], int]:
-        """Filter a stored result set. Returns (filtered_results, original_count)."""
-        rs = await self.get(result_set_id)
-        if rs is None:
-            raise ResultSetNotFoundError(result_set_id)
-
-        if len(rs.results) > self.max_records:
-            raise ResultSetTooLargeError(result_set_id, len(rs.results), self.max_records)
-
+        """Apply every filter in memory. Returns (filtered_results, original_count)."""
         filtered = list(rs.results)
         original_count = len(filtered)
 
@@ -244,6 +251,37 @@ class ResultStore:
 
         return filtered, original_count
 
+    async def filter_results(
+        self,
+        result_set_id: str,
+        *,
+        pattern: str | None = None,
+        field: str = "title",
+        type_equals: str | None = None,
+        status_equals: str | None = None,
+        year_equals: int | None = None,
+        date_field: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        sort_by: str | None = None,
+        sort_desc: bool = False,
+    ) -> tuple[list[ActSummaryOutput], int]:
+        """Filter a stored result set. Returns (filtered_results, original_count)."""
+        rs = await self._require(result_set_id)
+        return self._apply_filters(
+            rs,
+            pattern=pattern,
+            field=field,
+            type_equals=type_equals,
+            status_equals=status_equals,
+            year_equals=year_equals,
+            date_field=date_field,
+            date_from=date_from,
+            date_to=date_to,
+            sort_by=sort_by,
+            sort_desc=sort_desc,
+        )
+
     async def filter_and_store(
         self,
         result_set_id: str,
@@ -262,8 +300,10 @@ class ResultStore:
         offset: int = 0,
     ) -> FilterOutput:
         """Filter one set, persist the result, and build its public output."""
-        filtered, original_count = await self.filter_results(
-            result_set_id,
+        rs = await self._require(result_set_id)
+        source_scope = rs.scope_view()
+        filtered, original_count = self._apply_filters(
+            rs,
             pattern=pattern,
             field=field,
             type_equals=type_equals,
@@ -293,7 +333,8 @@ class ResultStore:
         if sort_by:
             filters_applied.update(sort_by=sort_by, sort_desc=sort_desc)
 
-        new_set_id = None
+        new_set_id: str | None = None
+        new_scope: ResultSetScope | None = None
         if filtered:
             description = _build_filters_description(
                 pattern=pattern,
@@ -305,10 +346,15 @@ class ResultStore:
                 date_from=date_from,
                 date_to=date_to,
             )
-            new_set_id, _ = await self.store(
+            # Inherited, not derived: a subset of a window is complete with respect
+            # to the window only. Letting `store()` derive the reach here would call
+            # it COMPLETE — every filtered set starts at index 0 and holds exactly as
+            # many records as it holds — and that would be false.
+            new_set_id, new_scope = await self.store(
                 filtered,
                 f"filtered({result_set_id}): {description}",
                 len(filtered),
+                scope=source_scope.scope,
             )
         page_limit = effective_limit(limit, default=DEFAULT_ITEM_LIMIT, maximum=MAX_ITEM_LIMIT)
         page_offset = parse_non_negative(offset, name="offset", default=0)
@@ -324,6 +370,12 @@ class ResultStore:
             original_count=original_count,
             filtered_count=len(filtered),
             filters_applied=filters_applied,
+            source_scope=source_scope,
+            result_set_scope=new_scope,
+            # Both conditions matter. Without the window check the flag would be
+            # wrong; without the empty check it would fire on every window filter
+            # and stop being read.
+            no_match_is_inconclusive=source_scope.scope is SetScope.PAGE and not filtered,
             page_info=page_info,
         )
 
@@ -368,8 +420,10 @@ class ResultSetTooLargeError(Exception):
             f"limit={limit}, węższe kryteria w browse_acts, albo — dla "
             f"track_legal_changes, które nie ma parametru limit — zawęź "
             f"date_from/date_to lub dodaj keywords. Wynik częściowy nie jest "
-            f"zwracany, aby brak dopasowania zawsze oznaczał przeszukanie "
-            f"całego zestawu."
+            f"zwracany, aby brak dopasowania zawsze oznaczał "
+            f"przeszukanie całego ZESTAWU. Uwaga: to gwarancja o zestawie, nie o zbiorze "
+            f"— jeśli zestaw jest oknem (pole set_scope w odpowiedzi ma wartość 'page'), "
+            f"brak dopasowania nadal nie dowodzi, że akt nie istnieje."
         )
 
 

--- a/src/law_scrapper_mcp/services/search_service.py
+++ b/src/law_scrapper_mcp/services/search_service.py
@@ -7,7 +7,7 @@ from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.models.enums import DetailLevel
 from law_scrapper_mcp.models.pagination import DEFAULT_ITEM_LIMIT
-from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, SearchOutput
+from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, ResultSetScope, SearchOutput
 from law_scrapper_mcp.services.pagination import item_page_info
 from law_scrapper_mcp.services.result_store import ResultStore
 
@@ -48,13 +48,26 @@ class SearchService:
         local_offset = max(page_offset - window_offset, 0)
         page = results[local_offset : local_offset + page_limit]
         total = max(total_count, page_offset + len(page)) if page else total_count
-        result_set_id = (await self._result_store.store(page, query_summary, total))[0] if page else None
+        result_set_id: str | None = None
+        result_set_scope: ResultSetScope | None = None
+        if page:
+            # `page_offset`, not the `window_offset` parameter above: the store wants the
+            # window's position in the corpus, while this method's `window_offset` means
+            # "how much the API already skipped". They are equal for both current callers,
+            # which is exactly why passing the wrong one would go unnoticed.
+            result_set_id, result_set_scope = await self._result_store.store(
+                page,
+                query_summary,
+                total,
+                window_offset=page_offset,
+            )
         return SearchOutput(
             results=page,
             total_count=total,
             query_summary=query_summary,
             returned_count=len(page),
             result_set_id=result_set_id,
+            result_set_scope=result_set_scope,
             page_info=item_page_info(
                 limit=page_limit,
                 offset=page_offset,

--- a/src/law_scrapper_mcp/services/search_service.py
+++ b/src/law_scrapper_mcp/services/search_service.py
@@ -48,7 +48,7 @@ class SearchService:
         local_offset = max(page_offset - window_offset, 0)
         page = results[local_offset : local_offset + page_limit]
         total = max(total_count, page_offset + len(page)) if page else total_count
-        result_set_id = await self._result_store.store(page, query_summary, total) if page else None
+        result_set_id = (await self._result_store.store(page, query_summary, total))[0] if page else None
         return SearchOutput(
             results=page,
             total_count=total,

--- a/src/law_scrapper_mcp/services/search_service.py
+++ b/src/law_scrapper_mcp/services/search_service.py
@@ -109,20 +109,33 @@ class SearchService:
         if in_force is not None:
             params["inForce"] = in_force
             summary_parts.append(f"in_force={in_force}")
-        if limit:
-            params["limit"] = limit
+        # Always sent now, the default included (D7). Without it the API builds a page
+        # of its own choosing: a measured 709 437 B and 500 records for DU/2024
+        # (tests/fixtures/search_default_page.provenance.md), of which `_output` keeps
+        # twenty and discards the rest locally. An explicit `limit` is still not clamped
+        # — `search_legal_acts` remains the one list tool without a ceiling, pinned by
+        # `test_limit_above_the_shared_maximum_is_not_clamped`.
+        #
+        # Floored at 1 for the same reason `browse()` floors it: what the search endpoint
+        # does with `limit=0` is unverified, and a zero-item page still owes the caller a
+        # truthful `totalCount`. `_output` slices the record away either way.
+        params["limit"] = max(limit if limit is not None else DEFAULT_ITEM_LIMIT, 1)
         if offset:
             params["offset"] = offset
 
         data = await self._client.get_json("acts/search", params=params, cache_ttl=settings.cache_search_ttl)
 
         items = data.get("items", [])
-        # Reads `count` (page size), while `browse()` reads `totalCount` (year size).
-        # Noted during the Klaster 8 audit/review: this reading is believed wrong for a
-        # search that spans more than one page, but fixing it changes what `total_count`
-        # and `truncated` mean for every existing caller of `search()`, which is a
-        # product decision this branch does not make.
-        total_count = data.get("count", len(items))
+        # `totalCount` is the size of the corpus, `count` the size of the returned page.
+        # Reading `count` here made a search matching 1984 acts report twenty, and with it
+        # `was_truncated=False` and no pagination hint at all — the model was told "that is
+        # everything there is". The product decision Klaster 8 deferred was taken in
+        # Klaster 9 (D1): docs/superpowers/specs/2026-09-01-klaster-9.md.
+        #
+        # The fallback chain is not decoration. Responses without `totalCount` keep their
+        # previous meaning, which is what lets every existing pagination test pass
+        # unmodified — the change shows up where the API supplies the truth and nowhere else.
+        total_count = data.get("totalCount", data.get("count", len(items)))
 
         results = [self._format_act(item, detail_level) for item in items]
         query_summary = " | ".join(summary_parts)

--- a/src/law_scrapper_mcp/tools/browse.py
+++ b/src/law_scrapper_mcp/tools/browse.py
@@ -1,12 +1,13 @@
 """Browse legal acts by publisher and year."""
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from pydantic import Field
 
+from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.context import AppContext, get_app_context
 from law_scrapper_mcp.models.enums import DetailLevel
 from law_scrapper_mcp.models.tool_outputs import EnrichedResponse, SearchOutput
@@ -116,6 +117,10 @@ def register(mcp: MCPServer[AppContext]) -> None:
         applied_limit = limit_int if limit_int is not None else DEFAULT_BROWSE_LIMIT
         first_eli = output.results[0].eli if output.results else None
 
+        next_call_params: dict[str, Any] = {"publisher": publisher, "year": year_int}
+        if detail_enum is not DetailLevel.STANDARD:
+            next_call_params["detail_level"] = detail_enum.value
+
         return EnrichedResponse[SearchOutput](
             data=output,
             hints=search_hints(
@@ -123,6 +128,10 @@ def register(mcp: MCPServer[AppContext]) -> None:
                 output.returned_count > 0,
                 first_eli,
                 output.result_set_id,
+                tool_name="browse_acts",
+                next_call_params=next_call_params,
+                filter_max_records=settings.effective_filter_max_records,
+                scope=output.result_set_scope,
                 offset=offset_int or 0,
                 returned_count=output.returned_count,
                 applied_limit=applied_limit,

--- a/src/law_scrapper_mcp/tools/browse.py
+++ b/src/law_scrapper_mcp/tools/browse.py
@@ -135,5 +135,6 @@ def register(mcp: MCPServer[AppContext]) -> None:
                 offset=offset_int or 0,
                 returned_count=output.returned_count,
                 applied_limit=applied_limit,
+                max_result_limit=MAX_ITEM_LIMIT,
             ),
         )

--- a/src/law_scrapper_mcp/tools/filter_results.py
+++ b/src/law_scrapper_mcp/tools/filter_results.py
@@ -8,17 +8,17 @@ from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from pydantic import Field
 
+from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.context import AppContext, get_app_context
 from law_scrapper_mcp.models.pagination import DEFAULT_ITEM_LIMIT
 from law_scrapper_mcp.models.tool_outputs import (
     EnrichedResponse,
     FilterOutput,
-    Hint,
     ResultSetListOutput,
 )
 from law_scrapper_mcp.services.pagination import parse_non_negative
 from law_scrapper_mcp.services.pattern_matching import SUPPORTED_SYNTAX_HINT
-from law_scrapper_mcp.services.response_enrichment import result_sets_hints
+from law_scrapper_mcp.services.response_enrichment import filter_hints, result_sets_hints
 from law_scrapper_mcp.tools.error_handling import handle_tool_errors
 
 logger = logging.getLogger(__name__)
@@ -134,6 +134,10 @@ def register(mcp: MCPServer[AppContext]) -> None:
 
         Kiedy użyć: Po search_legal_acts/browse_acts/track_legal_changes aby zawęzić wyniki.
         Kiedy NIE używać: Gdy potrzebujesz nowych wyników z API → użyj search_legal_acts.
+        Kiedy NIE używać: Do dowodzenia, że akt nie istnieje, dopóki pole source_scope
+        odpowiedzi ma wartość 'page' — filtrowane jest wtedy okno, a nie cały zbiór,
+        więc pusty wynik nie rozstrzyga. Odpowiedź sygnalizuje to polem
+        no_match_is_inconclusive.
 
         Przykłady:
         - filter_results(result_set_id="rs_1", type_equals="Rozporządzenie") - Tylko rozporządzenia
@@ -171,25 +175,10 @@ def register(mcp: MCPServer[AppContext]) -> None:
             offset=offset_int,
         )
 
-        hints = []
-        if output.results:
-            hints.append(
-                Hint(
-                    message="Użyj get_act_details aby zobaczyć szczegóły wybranego aktu.",
-                    tool="get_act_details",
-                    parameters={"eli": output.results[0].eli},
-                )
-            )
-            if output.result_set_id:
-                hints.append(
-                    Hint(
-                        message=f"Możesz dalej filtrować te wyniki używając result_set_id='{output.result_set_id}'.",
-                        tool="filter_results",
-                        parameters={"result_set_id": output.result_set_id},
-                    )
-                )
-
-        return EnrichedResponse[FilterOutput](data=output, hints=hints)
+        return EnrichedResponse[FilterOutput](
+            data=output,
+            hints=filter_hints(output, filter_max_records=settings.effective_filter_max_records),
+        )
 
     @mcp.tool(meta={"tags": ["utility", "filter"]})
     @handle_tool_errors

--- a/src/law_scrapper_mcp/tools/search.py
+++ b/src/law_scrapper_mcp/tools/search.py
@@ -2,12 +2,13 @@
 
 import contextlib
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from pydantic import Field
 
+from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.context import AppContext, get_app_context
 from law_scrapper_mcp.models.enums import DetailLevel
 from law_scrapper_mcp.models.tool_outputs import EnrichedResponse, SearchOutput
@@ -178,6 +179,31 @@ def register(mcp: MCPServer[AppContext]) -> None:
         effective_limit = limit_int if limit_int is not None else DEFAULT_SEARCH_LIMIT
         first_eli = output.results[0].eli if output.results else None
 
+        # Only this tool knows which parameters it accepts, so it builds the next call
+        # itself (D8). Values are the parsed ones, not the raw string inputs, so the hint
+        # round-trips: what the model copies back is what this call actually used.
+        next_call_params: dict[str, Any] = {"publisher": publisher}
+        if year_int is not None:
+            next_call_params["year"] = year_int
+        if keywords:
+            next_call_params["keywords"] = keywords
+        if date_from:
+            next_call_params["date_from"] = date_from
+        if date_to:
+            next_call_params["date_to"] = date_to
+        if title:
+            next_call_params["title"] = title
+        if act_type:
+            next_call_params["act_type"] = act_type
+        if pub_date_from:
+            next_call_params["pub_date_from"] = pub_date_from
+        if pub_date_to:
+            next_call_params["pub_date_to"] = pub_date_to
+        if in_force_bool is not None:
+            next_call_params["in_force"] = in_force_bool
+        if detail_enum is not DetailLevel.STANDARD:
+            next_call_params["detail_level"] = detail_enum.value
+
         return EnrichedResponse[SearchOutput](
             data=output,
             hints=search_hints(
@@ -185,6 +211,10 @@ def register(mcp: MCPServer[AppContext]) -> None:
                 output.returned_count > 0,
                 first_eli,
                 output.result_set_id,
+                tool_name="search_legal_acts",
+                next_call_params=next_call_params,
+                filter_max_records=settings.effective_filter_max_records,
+                scope=output.result_set_scope,
                 offset=offset_int or 0,
                 returned_count=output.returned_count,
                 applied_limit=effective_limit,

--- a/tests/fixtures/search_default_page.provenance.md
+++ b/tests/fixtures/search_default_page.provenance.md
@@ -1,0 +1,45 @@
+# Provenance of the default `acts/search` page measurement (D7)
+
+**This file records a measurement, not a fixture.** No payload is stored: the response is
+709 437 B, and the recording that tests actually load is `browse_page.json` (`limit=5`).
+This file exists so the claim "sending `limit` unconditionally reduces outbound traffic"
+rests on a number somebody measured rather than on a direction somebody assumed.
+
+## Capture
+
+```
+Date:     2026-09-01
+Command:  GET https://api.sejm.gov.pl/eli/acts/search?publisher=DU&year=2024
+          (no `limit` parameter — this is the point of the measurement)
+Headers:  User-Agent: law-scrapper-mcp/4.0.2 (+https://github.com/numikel/law-scrapper-mcp)
+          Accept: application/json
+Response: HTTP 200, 709 437 B, count=500, totalCount=1984, 500 items, 27 fields per item
+Window:   DU/2024/1984 … DU/2024/1485 (descending by pos, contiguous)
+Elapsed:  0.735 s
+```
+
+Top-level keys are `count`, `items`, `offset`, `searchQuery`, `totalCount` — the same set
+`browse_page.json` carries, so the two measurements describe one endpoint shape.
+
+## What this establishes (decision D7)
+
+| Request | Bytes | Records | Bytes / record |
+|---|---|---|---|
+| `acts/search?publisher=DU&year=2024` (no `limit`) | 709 437 | 500 | ~1 419 |
+| `acts/search?publisher=DU&year=2024&limit=5` (recorded) | 6 452 | 5 | ~1 290 |
+
+1. **The API caps its own default page at 500 records**, not at the whole year: `count=500`
+   against `totalCount=1984`. The unbounded default is therefore not the 1 093 220 B
+   catastrophe F30 found on `acts/{publisher}/{year}` — it is a 709 437 B one.
+2. **500 records is 25× the tool's default `limit` of 20.** A `search_legal_acts()` call
+   with no explicit limit downloads and deserialises 500 records to return 20.
+3. Sending `limit=20` unconditionally therefore cuts the default request by roughly the
+   same factor. The exact figure for a `limit=20` page was **not** measured — that would
+   have cost a second request, and the per-record cost above is enough to size the win.
+
+## Refreshing this measurement
+
+Re-run only when upstream is suspected of having changed its default page size, and never
+from CI. `api.sejm.gov.pl` belongs to a public institution; the politeness Klaster 8
+implements applies to our own probes too. This measurement is one request. Update the date
+and every number above in the same commit.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -23,8 +23,10 @@ from law_scrapper_mcp.models.tool_outputs import (
     FilterOutput,
     Hint,
     MetadataOutput,
+    ResultSetScope,
     SearchInActOutput,
     SearchOutput,
+    SetScope,
 )
 from law_scrapper_mcp.services.pagination import paginate_items
 
@@ -299,6 +301,12 @@ class TestPaginationModels:
                 results=[],
                 original_count=0,
                 filtered_count=0,
+                source_scope=ResultSetScope(
+                    scope=SetScope.COMPLETE,
+                    stored_count=0,
+                    window_offset=0,
+                    corpus_count=0,
+                ),
                 page_info=page_info,
             ).page_info
             == page_info

--- a/tests/unit/test_response_enrichment.py
+++ b/tests/unit/test_response_enrichment.py
@@ -180,6 +180,52 @@ def test_an_unreachable_corpus_is_told_to_narrow_instead() -> None:
     assert any("Zawęź kryteria" in h.message for h in hints)
 
 
+def test_max_result_limit_caps_the_suggestion_below_the_filter_ceiling() -> None:
+    """A corpus fits under filter_max_records but exceeds the calling tool's own cap.
+
+    `browse_acts` clamps `limit` to MAX_ITEM_LIMIT (100) regardless of
+    `filter_max_records`. Suggesting limit=300 here would be silently clamped by
+    `browse_acts` before it reaches the result store, handing back another PAGE
+    instead of the COMPLETE set the hint promised — the exact defect this task exists
+    to eliminate, one level removed.
+    """
+    hints = search_hints(
+        300,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="browse_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=500,
+        scope=_page_scope(corpus=300),
+        returned_count=20,
+        applied_limit=20,
+        max_result_limit=100,
+    )
+    limits = [h.parameters["limit"] for h in hints if h.parameters and "limit" in h.parameters]
+    assert all(value <= 100 for value in limits)
+    assert any("Zawęź kryteria" in h.message for h in hints)
+
+
+def test_max_result_limit_allows_the_suggestion_when_corpus_fits_both_ceilings() -> None:
+    """Mirror image: a corpus under both ceilings still gets a concrete limit."""
+    hints = search_hints(
+        60,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="browse_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=500,
+        scope=_page_scope(corpus=60),
+        returned_count=20,
+        applied_limit=20,
+        max_result_limit=100,
+    )
+    suggested = [h for h in hints if h.parameters and h.parameters.get("limit") == 60]
+    assert suggested, "a corpus below both ceilings should get a concrete limit suggestion"
+
+
 def test_the_filter_hint_says_what_is_being_narrowed() -> None:
     hints = search_hints(
         1_984,

--- a/tests/unit/test_response_enrichment.py
+++ b/tests/unit/test_response_enrichment.py
@@ -1,7 +1,8 @@
 """Tests for search/browse response hint generation."""
 
-from law_scrapper_mcp.models.tool_outputs import Hint, ResultSetScope, SetScope
-from law_scrapper_mcp.services.response_enrichment import metadata_hints, search_hints
+from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, FilterOutput, Hint, ResultSetScope, SetScope
+from law_scrapper_mcp.services.pagination import paginate_items
+from law_scrapper_mcp.services.response_enrichment import filter_hints, metadata_hints, search_hints
 
 
 def _page_scope(stored: int = 20, corpus: int = 1_984, offset: int = 0) -> ResultSetScope:
@@ -271,3 +272,78 @@ def test_context_chars_within_the_limit_produces_no_hint() -> None:
     from law_scrapper_mcp.services.response_enrichment import search_in_act_hints
 
     assert search_in_act_hints(300, 300) == []
+
+
+def _filter_output(
+    *,
+    source_scope: ResultSetScope,
+    filtered: list[ActSummaryOutput],
+    inconclusive: bool,
+    result_set_id: str | None = None,
+) -> FilterOutput:
+    page, page_info = paginate_items(filtered, limit=20, offset=0)
+    return FilterOutput(
+        source_result_set_id="rs_1",
+        result_set_id=result_set_id,
+        results=page,
+        original_count=source_scope.stored_count,
+        filtered_count=len(filtered),
+        source_scope=source_scope,
+        no_match_is_inconclusive=inconclusive,
+        page_info=page_info,
+    )
+
+
+def test_an_empty_match_on_a_window_gets_an_executable_next_step() -> None:
+    """Criterion 14. The worst failure mode in a legal domain is a confident 'no'."""
+    output = _filter_output(
+        source_scope=_page_scope(stored=20, corpus=60),
+        filtered=[],
+        inconclusive=True,
+    )
+
+    hints = filter_hints(output, filter_max_records=100)
+
+    assert hints, "an inconclusive empty match must not be answered with silence"
+    message = hints[0].message
+    assert "OKNO" in message
+    assert "NIE dowodzi" in message
+    assert "limit=60" in message
+
+
+def test_an_unreachable_corpus_is_told_to_narrow_the_search() -> None:
+    output = _filter_output(
+        source_scope=_page_scope(stored=20, corpus=1_984),
+        filtered=[],
+        inconclusive=True,
+    )
+
+    hints = filter_hints(output, filter_max_records=100)
+
+    assert "Zawęź kryteria" in hints[0].message
+
+
+def test_a_conclusive_empty_match_gets_no_warning() -> None:
+    """Criterion 15 seen from the hint side: silence is the correct answer here."""
+    output = _filter_output(
+        source_scope=_complete_scope(stored=5),
+        filtered=[],
+        inconclusive=False,
+    )
+
+    assert filter_hints(output, filter_max_records=100) == []
+
+
+def test_the_inconclusive_hint_names_no_tool() -> None:
+    """Deliberate: FilterOutput does not carry which tool produced the source set.
+
+    Guessing `search_legal_acts` when the source came from `browse_acts` would
+    reproduce F48 inside the fix for F48. The model knows which tool it called.
+    """
+    output = _filter_output(
+        source_scope=_page_scope(stored=20, corpus=60),
+        filtered=[],
+        inconclusive=True,
+    )
+
+    assert filter_hints(output, filter_max_records=100)[0].tool is None

--- a/tests/unit/test_response_enrichment.py
+++ b/tests/unit/test_response_enrichment.py
@@ -1,48 +1,201 @@
 """Tests for search/browse response hint generation."""
 
+from law_scrapper_mcp.models.tool_outputs import Hint, ResultSetScope, SetScope
 from law_scrapper_mcp.services.response_enrichment import metadata_hints, search_hints
+
+
+def _page_scope(stored: int = 20, corpus: int = 1_984, offset: int = 0) -> ResultSetScope:
+    return ResultSetScope(scope=SetScope.PAGE, stored_count=stored, window_offset=offset, corpus_count=corpus)
+
+
+def _complete_scope(stored: int = 5) -> ResultSetScope:
+    return ResultSetScope(scope=SetScope.COMPLETE, stored_count=stored, window_offset=0, corpus_count=stored)
+
+
+def _pagination_hint(hints: list[Hint]) -> Hint | None:
+    return next((h for h in hints if h.parameters and "offset" in h.parameters), None)
 
 
 def test_search_hints_detects_more_results_after_offset_page() -> None:
     hints = search_hints(
-        total_count=100,
-        has_results=True,
-        eli="DU/2024/1",
-        result_set_id="rs_1",
+        100,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(corpus=100),
         offset=20,
         returned_count=20,
         applied_limit=20,
     )
-
-    assert any("ograniczone do 20" in hint.message for hint in hints)
+    hint = _pagination_hint(hints)
+    assert hint is not None
+    assert hint.parameters is not None
+    assert hint.parameters["offset"] == 40
 
 
 def test_search_hints_no_truncation_when_offset_page_is_final() -> None:
     hints = search_hints(
-        total_count=40,
-        has_results=True,
-        eli="DU/2024/1",
-        result_set_id="rs_1",
+        40,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(corpus=40, offset=20),
         offset=20,
         returned_count=20,
         applied_limit=20,
     )
-
-    assert not any("ograniczone do" in hint.message for hint in hints)
+    assert _pagination_hint(hints) is None
 
 
 def test_search_hints_detects_truncation_on_first_page_without_offset() -> None:
     hints = search_hints(
-        total_count=50,
-        has_results=True,
-        eli="DU/2024/1",
-        result_set_id="rs_1",
-        offset=0,
+        50,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(corpus=50),
         returned_count=20,
         applied_limit=20,
     )
+    hint = _pagination_hint(hints)
+    assert hint is not None
+    assert hint.parameters is not None
+    assert hint.parameters["offset"] == 20
 
-    assert any("ograniczone do 20" in hint.message for hint in hints)
+
+def test_pagination_hint_names_the_tool_that_produced_it() -> None:
+    """Criterion 10 — this is the F48 regression test.
+
+    `browse_acts` used to hand the model a hint pointing at `search_legal_acts`.
+    """
+    hints = search_hints(
+        1_984,
+        True,
+        "DU/2024/1984",
+        "rs_1",
+        tool_name="browse_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(),
+        returned_count=20,
+        applied_limit=20,
+    )
+    hint = _pagination_hint(hints)
+    assert hint is not None
+    assert hint.tool == "browse_acts"
+    assert hint.parameters == {"publisher": "DU", "year": 2024, "limit": 20, "offset": 20}
+
+
+def test_pagination_hint_names_search_when_search_produced_it() -> None:
+    """Criterion 11."""
+    hints = search_hints(
+        1_984,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "title": "budżet"},
+        filter_max_records=100,
+        scope=_page_scope(),
+        returned_count=20,
+        applied_limit=20,
+    )
+    hint = _pagination_hint(hints)
+    assert hint is not None
+    assert hint.tool == "search_legal_acts"
+    assert hint.parameters == {
+        "publisher": "DU",
+        "title": "budżet",
+        "limit": 20,
+        "offset": 20,
+    }
+
+
+def test_a_complete_set_gets_no_pagination_hint() -> None:
+    """Criterion 12."""
+    hints = search_hints(
+        5,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_complete_scope(),
+        returned_count=5,
+        applied_limit=20,
+    )
+    assert _pagination_hint(hints) is None
+
+
+def test_suggested_limit_never_exceeds_the_filter_ceiling() -> None:
+    """Criterion 13, first half: a reachable corpus gets a concrete limit."""
+    hints = search_hints(
+        60,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(corpus=60),
+        returned_count=20,
+        applied_limit=20,
+    )
+    suggested = [h for h in hints if h.parameters and h.parameters.get("limit") == 60]
+    assert suggested, "a corpus below the ceiling should get a concrete limit suggestion"
+    assert suggested[0].parameters is not None
+    assert suggested[0].parameters["limit"] <= 100
+
+
+def test_an_unreachable_corpus_is_told_to_narrow_instead() -> None:
+    """Criterion 13, second half: suggesting limit=1984 would be unexecutable.
+
+    A 1984-record set is rejected by ResultSetTooLargeError on the first filter,
+    so telling the model to widen the window would reproduce F48 one level up.
+    """
+    hints = search_hints(
+        1_984,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(),
+        returned_count=20,
+        applied_limit=20,
+    )
+    limits = [h.parameters["limit"] for h in hints if h.parameters and "limit" in h.parameters]
+    assert all(value <= 100 for value in limits)
+    assert any("Zawęź kryteria" in h.message for h in hints)
+
+
+def test_the_filter_hint_says_what_is_being_narrowed() -> None:
+    hints = search_hints(
+        1_984,
+        True,
+        "DU/2024/1",
+        "rs_1",
+        tool_name="search_legal_acts",
+        next_call_params={"publisher": "DU", "year": 2024},
+        filter_max_records=100,
+        scope=_page_scope(),
+        returned_count=20,
+        applied_limit=20,
+    )
+    filter_hint = next(h for h in hints if h.tool == "filter_results")
+    assert "20" in filter_hint.message
+    assert "1984" in filter_hint.message
 
 
 def test_metadata_hints_name_the_failed_categories() -> None:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 from mcp import Client
@@ -58,6 +60,33 @@ async def test_all_tools_have_concrete_output_schemas() -> None:
         assert tool.output_schema is not None
         assert set(tool.output_schema["properties"]) >= {"data", "hints", "metadata"}
         assert set(tool.output_schema["properties"]) != {"result"}
+
+
+async def test_scope_fields_reach_the_output_schemas() -> None:
+    """Criterion 20: the new contract is visible to clients, and nothing was dropped."""
+    expected_new = {
+        "search_legal_acts": "result_set_scope",
+        "browse_acts": "result_set_scope",
+        "track_legal_changes": "result_set_scope",
+        "filter_results": "no_match_is_inconclusive",
+        "list_result_sets": "scope",
+    }
+    expected_kept = {
+        "search_legal_acts": "total_count",
+        "browse_acts": "result_set_id",
+        "track_legal_changes": "date_range",
+        "filter_results": "filtered_count",
+        "list_result_sets": "result_count",
+    }
+
+    async with Client(app) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+
+    for name, field in expected_new.items():
+        assert tools[name].output_schema is not None
+        assert field in json.dumps(tools[name].output_schema), f"{name} lost {field}"
+    for name, field in expected_kept.items():
+        assert field in json.dumps(tools[name].output_schema), f"{name} dropped {field}"
 
 
 async def test_lifespan_yields_services() -> None:

--- a/tests/unit/test_services/test_changes_service.py
+++ b/tests/unit/test_services/test_changes_service.py
@@ -194,3 +194,24 @@ class TestChangesService:
         assert output.changes[0].eli == "DU/2024/1"
         assert output.changes[0].type is None
         assert output.changes[0].promulgation_date is None
+
+    @respx.mock
+    async def test_tracked_changes_are_a_complete_set(self, service: ChangesService, search_results: dict):
+        """Criterion 4 (D6). The one tool whose set filter_results searches whole.
+
+        No behaviour changes here — `ChangesService` already stored the full fetched
+        list. The cluster only gives that fact a name in the contract.
+        """
+        respx.get("https://api.sejm.gov.pl/eli/acts/search").mock(return_value=Response(200, json=search_results))
+
+        output = await service.track_changes(
+            publisher="DU",
+            date_from="2024-01-01",
+            date_to="2024-12-31",
+        )
+
+        assert output.result_set_id is not None
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope == "complete"
+        assert output.result_set_scope.window_offset == 0
+        assert output.result_set_scope.corpus_count == output.total_count

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -76,13 +76,13 @@ class TestResultStore:
     async def test_store_returns_incremental_ids(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        id1 = await store.store(sample_results[:2], "query1", 2)
-        id2 = await store.store(sample_results[2:], "query2", 3)
+        id1, _ = await store.store(sample_results[:2], "query1", 2)
+        id2, _ = await store.store(sample_results[2:], "query2", 3)
         assert id1 == "rs_1"
         assert id2 == "rs_2"
 
     async def test_get_returns_stored_results(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test query", 5)
+        rs_id, _ = await store.store(sample_results, "test query", 5)
         rs = await store.get(rs_id)
         assert rs is not None
         assert len(rs.results) == 5
@@ -112,50 +112,50 @@ class TestResultStore:
     async def test_evicts_expired(self) -> None:
         store = ResultStore(max_sets=5, ttl=0)  # TTL=0 → immediate expiry
         act = _make_act()
-        rs_id = await store.store([act], "query", 1)
+        rs_id, _ = await store.store([act], "query", 1)
         time.sleep(0.01)
         assert await store.get(rs_id) is None
 
 
 class TestResultStoreFiltering:
     async def test_filter_by_type_equals(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, original = await store.filter_results(rs_id, type_equals="Ustawa")
         assert original == 5
         assert len(filtered) == 2
         assert all(r.type == "Ustawa" for r in filtered)
 
     async def test_filter_by_status_equals(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, status_equals="akt jednorazowy")
         assert len(filtered) == 1
         assert filtered[0].eli == "DU/2024/5"
 
     async def test_filter_by_year_equals(self, store: ResultStore) -> None:
         results = [_make_act(year=2023), _make_act(year=2024), _make_act(year=2024)]
-        rs_id = await store.store(results, "test", 3)
+        rs_id, _ = await store.store(results, "test", 3)
         filtered, _ = await store.filter_results(rs_id, year_equals=2024)
         assert len(filtered) == 2
 
     async def test_filter_by_regex_pattern_title(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, pattern="zdrow|Zdrowia")
         assert len(filtered) == 2  # Minister Zdrowia appears in 2 titles
 
     async def test_filter_by_regex_pattern_or(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, pattern="podatk|transport")
         assert len(filtered) == 2
 
     async def test_filter_by_regex_field_eli(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, pattern="DU/2024/[12]$", field="eli")
         assert len(filtered) == 2
 
     async def test_filter_by_date_range(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(
             rs_id,
             date_field="promulgation_date",
@@ -165,7 +165,7 @@ class TestResultStoreFiltering:
         assert len(filtered) == 3
 
     async def test_filter_combined(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(
             rs_id,
             type_equals="Rozporządzenie",
@@ -175,7 +175,7 @@ class TestResultStoreFiltering:
         assert "Zdrowia" in filtered[0].title
 
     async def test_filter_sort_by(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, sort_by="promulgation_date", sort_desc=True)
         dates = [r.promulgation_date for r in filtered]
         assert dates == sorted(dates, key=lambda d: d or "", reverse=True)
@@ -183,7 +183,7 @@ class TestResultStoreFiltering:
     async def test_filter_returns_full_set_before_pagination(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id)
         assert len(filtered) == 5
 
@@ -194,27 +194,27 @@ class TestResultStoreFiltering:
     async def test_filter_invalid_regex_raises(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         with pytest.raises(PatternValidationError, match="nie jest obsługiwany"):
             await store.filter_results(rs_id, pattern="[invalid")
 
     async def test_filter_invalid_field_defaults_to_title(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         # Invalid field should default to title
         filtered, _ = await store.filter_results(rs_id, pattern="podatk", field="nonexistent")
         assert len(filtered) == 1
 
     async def test_filter_empty_results(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, _ = await store.filter_results(rs_id, pattern="xyznonexistent")
         assert len(filtered) == 0
 
     async def test_filter_no_filters_returns_all(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
         filtered, original = await store.filter_results(rs_id)
         assert len(filtered) == 5
         assert original == 5
@@ -245,7 +245,7 @@ class TestResultStoreReDoSRegression:
         catastrophic pattern (where code after `filter_results` would never be
         reached on a regression to `re`).
         """
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         captured: list[CompiledPattern] = []
 
@@ -275,7 +275,7 @@ class TestResultStoreReDoSRegression:
     @pytest.mark.timeout(5)
     async def test_catastrophic_pattern_returns_promptly(self, store: ResultStore) -> None:
         results = [_make_act(f"DU/2024/{i}", _REALISTIC_LONG_TITLE) for i in range(1, 11)]
-        rs_id = await store.store(results, "test", len(results))
+        rs_id, _ = await store.store(results, "test", len(results))
 
         filtered, original = await store.filter_results(rs_id, pattern="(.+)+!", field="title")
 
@@ -286,7 +286,7 @@ class TestResultStoreReDoSRegression:
     async def test_documented_patterns_still_work(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         health, _ = await store.filter_results(rs_id, pattern="zdrow|Minister Zdrowia|apteka|lekar")
         wildcard, _ = await store.filter_results(rs_id, pattern="Ustawa.*danych")
@@ -302,7 +302,7 @@ class TestResultStoreReDoSRegression:
     async def test_alternation_matches_when_form_agrees(self, store: ResultStore) -> None:
         """Positive control for an alternation pattern — without it the test above is blind."""
         results = [_make_act("DU/2024/9", "Ustawa o podatek akcyza VAT")]
-        rs_id = await store.store(results, "test", 1)
+        rs_id, _ = await store.store(results, "test", 1)
 
         filtered, _ = await store.filter_results(rs_id, pattern="podatek|VAT|akcyza")
 
@@ -311,7 +311,7 @@ class TestResultStoreReDoSRegression:
     async def test_lookaround_is_rejected_with_polish_message(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         with pytest.raises(PatternValidationError) as exc_info:
             await store.filter_results(rs_id, pattern="(?<=Ustawa)o")
@@ -320,7 +320,7 @@ class TestResultStoreReDoSRegression:
 
     async def test_pattern_over_limit_is_rejected(self, sample_results: list[ActSummaryOutput]) -> None:
         store = ResultStore(max_sets=5, ttl=60, max_pattern_length=64)
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         with pytest.raises(PatternValidationError, match="za długi"):
             await store.filter_results(rs_id, pattern="a" * 65)
@@ -328,7 +328,7 @@ class TestResultStoreReDoSRegression:
     async def test_pattern_at_limit_is_accepted(self, sample_results: list[ActSummaryOutput]) -> None:
         """Boundary: a pattern whose length equals the limit exactly is not rejected."""
         store = ResultStore(max_sets=5, ttl=60, max_pattern_length=64)
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         filtered, _ = await store.filter_results(rs_id, pattern="a" * 64)
 
@@ -340,7 +340,7 @@ class TestResultStoreRecordCap:
 
     async def test_oversized_set_is_refused(self, sample_results: list[ActSummaryOutput]) -> None:
         store = ResultStore(max_sets=5, ttl=60, max_records=3)
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         with pytest.raises(ResultSetTooLargeError) as exc_info:
             await store.filter_results(rs_id, pattern="Ustawa")
@@ -352,14 +352,14 @@ class TestResultStoreRecordCap:
     async def test_refusal_applies_without_pattern_too(self, sample_results: list[ActSummaryOutput]) -> None:
         """Refusal applies to the call, not only to the regex path."""
         store = ResultStore(max_sets=5, ttl=60, max_records=3)
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         with pytest.raises(ResultSetTooLargeError):
             await store.filter_results(rs_id, type_equals="Ustawa")
 
     async def test_set_at_limit_is_processed(self, sample_results: list[ActSummaryOutput]) -> None:
         store = ResultStore(max_sets=5, ttl=60, max_records=5)
-        rs_id = await store.store(sample_results, "test", 5)
+        rs_id, _ = await store.store(sample_results, "test", 5)
 
         filtered, original = await store.filter_results(rs_id, type_equals="Ustawa")
 
@@ -371,7 +371,7 @@ class TestResultStoreFilterAndStore:
     async def test_filter_and_store_persists_chained_result_set(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        source_id = await store.store(sample_results, "search query", len(sample_results))
+        source_id, _ = await store.store(sample_results, "search query", len(sample_results))
 
         output = await store.filter_and_store(
             source_id,
@@ -417,7 +417,7 @@ class TestResultStoreFilterAndStore:
     async def test_filter_and_store_records_applied_filters(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        source_id = await store.store(sample_results, "search query", len(sample_results))
+        source_id, _ = await store.store(sample_results, "search query", len(sample_results))
 
         output = await store.filter_and_store(
             source_id,
@@ -438,7 +438,7 @@ class TestResultStoreFilterAndStore:
     async def test_filter_and_store_stores_full_set_but_pages_response(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        source_id = await store.store(sample_results, "search query", len(sample_results))
+        source_id, _ = await store.store(sample_results, "search query", len(sample_results))
 
         output = await store.filter_and_store(
             source_id,
@@ -460,7 +460,7 @@ class TestResultStoreFilterAndStore:
     async def test_filter_and_store_leaves_result_set_id_none_for_empty_matches(
         self, store: ResultStore, sample_results: list[ActSummaryOutput]
     ) -> None:
-        source_id = await store.store(sample_results, "search query", len(sample_results))
+        source_id, _ = await store.store(sample_results, "search query", len(sample_results))
 
         output = await store.filter_and_store(
             source_id,
@@ -487,7 +487,7 @@ async def test_store_keeps_query_text_off_info(caplog: pytest.LogCaptureFixture)
     # test that runs `setup_logging()` earlier in the session would leave the
     # DEBUG record below filtered out before `caplog` ever sees it.
     with caplog.at_level(logging.DEBUG, logger="law_scrapper_mcp"):
-        result_set_id = await store.store(results=[], query_summary=query, total_count=7)
+        result_set_id, _ = await store.store(results=[], query_summary=query, total_count=7)
 
     info_records = [r for r in caplog.records if r.levelno == logging.INFO]
     debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -589,3 +589,73 @@ class TestSetScope:
         await store.store(sample_results, "query", 1984)
         listed = await store.list_sets()
         assert listed[0]["scope"] is SetScope.PAGE
+
+
+class TestInheritedScope:
+    """A filtered subset is complete with respect to its source, not to the corpus."""
+
+    async def test_filtering_a_window_yields_a_window(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        source_id, source_scope = await store.store(sample_results, "query", 1984)
+        assert source_scope.scope is SetScope.PAGE
+
+        output = await store.filter_and_store(source_id, type_equals="Ustawa")
+
+        assert output.source_scope.scope is SetScope.PAGE
+        assert output.source_scope.corpus_count == 1984
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope is SetScope.PAGE
+        # We know how many records matched inside the window. We do not know how
+        # many corpus records would have matched, and must not invent it.
+        assert output.result_set_scope.corpus_count is None
+
+    async def test_filtering_a_complete_set_yields_a_complete_set(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        source_id, source_scope = await store.store(sample_results, "query", len(sample_results))
+        assert source_scope.scope is SetScope.COMPLETE
+
+        output = await store.filter_and_store(source_id, type_equals="Ustawa")
+
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope is SetScope.COMPLETE
+        assert output.result_set_scope.corpus_count == output.filtered_count
+
+
+class TestInconclusiveEmptyMatch:
+    """An empty filter on a window is the failure mode this cluster exists to stop."""
+
+    async def test_empty_match_on_a_window_is_inconclusive(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        source_id, _ = await store.store(sample_results, "query", 1984)
+
+        output = await store.filter_and_store(source_id, pattern="nie-ma-takiego-slowa")
+
+        assert output.filtered_count == 0
+        assert output.no_match_is_inconclusive is True
+        # No derived set is created for an empty match; the source reach still is.
+        assert output.result_set_scope is None
+        assert output.source_scope.scope is SetScope.PAGE
+
+    async def test_empty_match_on_a_complete_set_is_conclusive(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        source_id, _ = await store.store(sample_results, "query", len(sample_results))
+
+        output = await store.filter_and_store(source_id, pattern="nie-ma-takiego-slowa")
+
+        assert output.filtered_count == 0
+        assert output.no_match_is_inconclusive is False
+
+    async def test_a_non_empty_match_on_a_window_is_not_flagged(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        """A warning shown on every window filter would stop meaning anything."""
+        source_id, _ = await store.store(sample_results, "query", 1984)
+
+        output = await store.filter_and_store(source_id, type_equals="Ustawa")
+
+        assert output.filtered_count > 0
+        assert output.no_match_is_inconclusive is False

--- a/tests/unit/test_services/test_result_store.py
+++ b/tests/unit/test_services/test_result_store.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from law_scrapper_mcp.models.pagination import PageUnit
-from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput
+from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, SetScope
 from law_scrapper_mcp.services.pattern_matching import (
     CompiledPattern,
     PatternValidationError,
@@ -496,3 +496,96 @@ async def test_store_keeps_query_text_off_info(caplog: pytest.LogCaptureFixture)
     assert all(query not in r.getMessage() for r in info_records)
     assert any(result_set_id in r.getMessage() for r in info_records)
     assert any(query in r.getMessage() for r in debug_records)
+
+
+class TestSetScope:
+    """The rule that decides whether a stored set is the answer or a window into it."""
+
+    @pytest.mark.parametrize(
+        ("window_offset", "stored_count", "total_count", "expected"),
+        [
+            # The whole answer: starts at the corpus origin, holds everything.
+            (0, 20, 20, SetScope.COMPLETE),
+            # The default search page: twenty records cut out of 1984.
+            (0, 20, 1984, SetScope.PAGE),
+            # The tail of a corpus is still a window — the twenty records that
+            # precede it are not in the set, so a filter that finds nothing here
+            # has not searched them.
+            (20, 5, 25, SetScope.PAGE),
+        ],
+    )
+    async def test_scope_follows_offset_and_size(
+        self,
+        store: ResultStore,
+        window_offset: int,
+        stored_count: int,
+        total_count: int,
+        expected: SetScope,
+    ) -> None:
+        records = [
+            ActSummaryOutput(
+                eli=f"DU/2024/{n}",
+                publisher="DU",
+                year=2024,
+                pos=n,
+                title=f"Akt {n}",
+                status="obowiązujący",
+            )
+            for n in range(stored_count)
+        ]
+        _, scope = await store.store(
+            records,
+            "query",
+            total_count,
+            window_offset=window_offset,
+        )
+        assert scope.scope is expected
+        assert scope.stored_count == stored_count
+        assert scope.window_offset == window_offset
+        assert scope.corpus_count == total_count
+
+    async def test_forced_page_scope_reports_an_unknown_corpus(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        """An inherited PAGE reach means `total_count` describes the set, not a corpus.
+
+        The number of corpus records that would have matched was never computed,
+        so `corpus_count` must stay None rather than repeat the set size.
+        """
+        _, scope = await store.store(
+            sample_results,
+            "filtered(rs_1): pattern=zdrow",
+            len(sample_results),
+            scope=SetScope.PAGE,
+        )
+        assert scope.scope is SetScope.PAGE
+        assert scope.corpus_count is None
+
+    async def test_forced_complete_scope_keeps_the_corpus_count(
+        self, store: ResultStore, sample_results: list[ActSummaryOutput]
+    ) -> None:
+        _, scope = await store.store(
+            sample_results,
+            "filtered(rs_1): pattern=zdrow",
+            len(sample_results),
+            scope=SetScope.COMPLETE,
+        )
+        assert scope.scope is SetScope.COMPLETE
+        assert scope.corpus_count == len(sample_results)
+
+    async def test_an_empty_set_is_never_produced_by_callers(self, store: ResultStore) -> None:
+        """The rule does not blow up on a zero-record set, but nobody stores one.
+
+        Every producer guards with `if results:` — criterion 1's fourth row
+        ("(0, 0, 0) -> the set is not created") is a property of the callers, and
+        is asserted against them in Task 4. This test only pins that the rule
+        itself stays total.
+        """
+        _, scope = await store.store([], "query", 0)
+        assert scope.scope is SetScope.COMPLETE
+        assert scope.stored_count == 0
+
+    async def test_listing_exposes_the_scope(self, store: ResultStore, sample_results: list[ActSummaryOutput]) -> None:
+        await store.store(sample_results, "query", 1984)
+        listed = await store.list_sets()
+        assert listed[0]["scope"] is SetScope.PAGE

--- a/tests/unit/test_services/test_search_corpus_size.py
+++ b/tests/unit/test_services/test_search_corpus_size.py
@@ -26,8 +26,6 @@ from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.services.result_store import ResultStore
 from law_scrapper_mcp.services.search_service import SearchService
 
-pytestmark = pytest.mark.asyncio
-
 SEARCH_URL = "https://api.sejm.gov.pl/eli/acts/search"
 
 
@@ -46,6 +44,7 @@ async def service() -> AsyncGenerator[SearchService]:
     await client.close()
 
 
+@pytest.mark.asyncio
 @respx.mock
 async def test_total_count_is_the_corpus_not_the_page(service: SearchService, browse_page: dict[str, Any]) -> None:
     """Criterion 5. Before D1 this returned total_count=5 and was_truncated=False."""
@@ -59,6 +58,7 @@ async def test_total_count_is_the_corpus_not_the_page(service: SearchService, br
     assert output.page_info.next_offset == 5
 
 
+@pytest.mark.asyncio
 @respx.mock
 async def test_a_response_without_total_count_still_reads_count(service: SearchService) -> None:
     """Criterion 6. The fallback chain keeps every existing pagination test honest."""
@@ -85,6 +85,7 @@ async def test_a_response_without_total_count_still_reads_count(service: SearchS
     assert output.page_info.was_truncated is False
 
 
+@pytest.mark.asyncio
 @respx.mock
 async def test_a_default_call_asks_for_twenty_records(service: SearchService, browse_page: dict[str, Any]) -> None:
     """Criterion 7. Without this the API builds a 500-record page (measured)."""
@@ -96,6 +97,7 @@ async def test_a_default_call_asks_for_twenty_records(service: SearchService, br
     assert route.calls.last.request.url.params["limit"] == "20"
 
 
+@pytest.mark.asyncio
 @respx.mock
 async def test_an_explicit_limit_is_not_clamped(service: SearchService) -> None:
     """Criterion 8. `search_legal_acts` stays the one list tool without a ceiling."""

--- a/tests/unit/test_services/test_search_corpus_size.py
+++ b/tests/unit/test_services/test_search_corpus_size.py
@@ -1,0 +1,133 @@
+"""`search()` reports the corpus size and pays for one page (D1, D7).
+
+Before this change `search()` read `count` — the size of the returned page — as
+`total_count`, so a query matching 1984 acts answered "twenty" and produced
+`was_truncated=False`. It also sent `limit` only when the caller supplied one, so a
+default call downloaded whatever page the API felt like building.
+
+The size of that default page is measured, not assumed: see
+`tests/fixtures/search_default_page.provenance.md` — 709 437 B, 500 records.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import respx
+from httpx import Response
+
+from law_scrapper_mcp.client.cache import TTLCache
+from law_scrapper_mcp.client.sejm_client import SejmApiClient
+from law_scrapper_mcp.services.result_store import ResultStore
+from law_scrapper_mcp.services.search_service import SearchService
+
+pytestmark = pytest.mark.asyncio
+
+SEARCH_URL = "https://api.sejm.gov.pl/eli/acts/search"
+
+
+@pytest.fixture
+def browse_page() -> dict[str, Any]:
+    """The recorded `acts/search` response: count=5, totalCount=1984."""
+    path = Path(__file__).parents[2] / "fixtures" / "browse_page.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest_asyncio.fixture
+async def service() -> AsyncGenerator[SearchService]:
+    client = SejmApiClient(cache=TTLCache(max_entries=100), timeout=5.0)
+    await client.start()
+    yield SearchService(client, ResultStore())
+    await client.close()
+
+
+@respx.mock
+async def test_total_count_is_the_corpus_not_the_page(service: SearchService, browse_page: dict[str, Any]) -> None:
+    """Criterion 5. Before D1 this returned total_count=5 and was_truncated=False."""
+    respx.get(SEARCH_URL).mock(return_value=Response(200, json=browse_page))
+
+    output = await service.search(year=2024, limit=5)
+
+    assert output.total_count == 1984
+    assert output.page_info.total_count == 1984
+    assert output.page_info.was_truncated is True
+    assert output.page_info.next_offset == 5
+
+
+@respx.mock
+async def test_a_response_without_total_count_still_reads_count(service: SearchService) -> None:
+    """Criterion 6. The fallback chain keeps every existing pagination test honest."""
+    payload = {
+        "count": 3,
+        "items": [
+            {
+                "ELI": f"DU/2024/{n}",
+                "publisher": "DU",
+                "year": 2024,
+                "pos": n,
+                "title": f"Akt {n}",
+                "status": "akt obowiązujący",
+                "type": "Ustawa",
+            }
+            for n in range(3)
+        ],
+    }
+    respx.get(SEARCH_URL).mock(return_value=Response(200, json=payload))
+
+    output = await service.search(year=2024, limit=3)
+
+    assert output.total_count == 3
+    assert output.page_info.was_truncated is False
+
+
+@respx.mock
+async def test_a_default_call_asks_for_twenty_records(service: SearchService, browse_page: dict[str, Any]) -> None:
+    """Criterion 7. Without this the API builds a 500-record page (measured)."""
+    route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=browse_page))
+
+    await service.search(year=2024)
+
+    assert route.called
+    assert route.calls.last.request.url.params["limit"] == "20"
+
+
+@respx.mock
+async def test_an_explicit_limit_is_not_clamped(service: SearchService) -> None:
+    """Criterion 8. `search_legal_acts` stays the one list tool without a ceiling."""
+    payload = {
+        "count": 150,
+        "totalCount": 150,
+        "items": [
+            {
+                "ELI": f"DU/2024/{n}",
+                "publisher": "DU",
+                "year": 2024,
+                "pos": n,
+                "title": f"Akt {n}",
+                "status": "akt obowiązujący",
+                "type": "Ustawa",
+            }
+            for n in range(150)
+        ],
+    }
+    route = respx.get(SEARCH_URL).mock(return_value=Response(200, json=payload))
+
+    output = await service.search(year=2024, limit=150)
+
+    assert route.calls.last.request.url.params["limit"] == "150"
+    assert output.returned_count == 150
+
+
+def test_the_default_page_measurement_is_on_record() -> None:
+    """Criterion 9. D7 rests on a measurement; deleting it would strand the claim."""
+    path = Path(__file__).parents[2] / "fixtures" / "search_default_page.provenance.md"
+    text = path.read_text(encoding="utf-8")
+
+    assert "709 437 B" in text
+    assert "count=500" in text
+    assert "totalCount=1984" in text

--- a/tests/unit/test_services/test_search_pagination.py
+++ b/tests/unit/test_services/test_search_pagination.py
@@ -121,6 +121,45 @@ class TestSearchPage:
         assert negative.returned_count == 20
         assert negative.page_info.offset == 0
 
+    async def test_a_windowed_page_declares_itself_a_window(self) -> None:
+        service, _ = _service({"items": [_item(n) for n in range(20)], "totalCount": 1_984})
+
+        output = await service.search(year=2024, limit=20)
+
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope == "page"
+        assert output.result_set_scope.stored_count == 20
+        assert output.result_set_scope.window_offset == 0
+        assert output.result_set_scope.corpus_count == 1_984
+
+    async def test_a_page_holding_the_whole_corpus_declares_itself_complete(self) -> None:
+        service, _ = _service({"items": [_item(n) for n in range(5)], "totalCount": 5})
+
+        output = await service.search(year=2024, limit=20)
+
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope == "complete"
+
+    async def test_the_tail_of_a_corpus_is_still_a_window(self) -> None:
+        """Criterion 1, third row: nothing follows it, but twenty records precede it."""
+        service, _ = _paging_service(total=25)
+
+        output = await service.search(year=2024, limit=20, offset=20)
+
+        assert output.returned_count == 5
+        assert output.result_set_scope is not None
+        assert output.result_set_scope.scope == "page"
+        assert output.result_set_scope.window_offset == 20
+
+    async def test_an_empty_page_stores_no_set_and_reports_no_scope(self) -> None:
+        """Criterion 1, fourth row: the set is not created, so the field is None."""
+        service, _ = _service({"items": [], "totalCount": 0})
+
+        output = await service.search(year=2024)
+
+        assert output.result_set_id is None
+        assert output.result_set_scope is None
+
 
 class TestBrowsePage:
     async def test_browse_pages_come_from_the_api_window(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "law-scrapper-mcp"
-version = "4.0.1"
+version = "4.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary

Introduces **result-set scope** — every stored result set (from `search_legal_acts`, `browse_acts`, `filter_results`, `track_legal_changes`) now declares whether it is `complete` (the whole answer to its query) or a `page` (a window cut from a larger corpus). Goal: stop the calling model from concluding "no such act exists" off an empty `filter_results` match over a 20-record window into a 1984-record corpus.

- **Scope lives in one place** — `SetScope`/`ResultSetScope` types, with the derivation rule centralized in `ResultStore.store()` (`scope = complete ⟺ window_offset == 0 and len(results) == total_count`). `filter_and_store` **inherits** the source set's scope instead of re-deriving it, and sets `no_match_is_inconclusive` when an empty match happened over a `page` set.
- **D1 fix** — `search_legal_acts` used to read `count` (page size) into `total_count`, so a query matching 1984 acts reported `20`. Now reads `totalCount` (corpus size), falling back to `count` for responses that omit it.
- **D7 fix** — `search()` only sent `limit` upstream when the caller supplied one; without it the Sejm API built its own default page (measured: 500 records / 709,437 B for `DU/2024`, of which 480 were discarded locally). `limit` is now always sent, defaulting to 20.
- **F48 fix** — pagination hints hard-coded `tool="search_legal_acts"` regardless of which tool actually produced them, so `browse_acts` callers were told to call a different tool for the next page. `search_hints()` now takes `tool_name`/`next_call_params` as required keyword-only parameters (no default — a default would silently reintroduce the bug).
- Scope is surfaced on `SearchOutput`, `ChangesOutput`, `ResultSetInfo`; `filter_results`'s own hints moved into the same hint-builder layer as `search_hints`, and warn explicitly when an empty match proves nothing.

No MCP tool changes signature, parameter names, or the substantive content of its responses (same records, same fields, same order).

**Known follow-up, deliberately out of this scope:** `track_legal_changes` still doesn't send `limit` or read `totalCount`, so a very wide date range (>500 matching acts) could be silently truncated and still get labeled `complete`. This is the same pattern as a previous finding (F30) applied to a wide date range, and needs its own decision (also touching whether `filter_max_records=100` is the right ceiling for a "complete" set) rather than a fix folded into this PR.

## How this was built

Implemented via subagent-driven development: 7 tasks, each with a fresh implementer (Sonnet 5), then two independent Opus 5 reviewers per task (spec-compliance and code-quality, run in parallel), with fix loops where needed. Closed with a whole-branch review (Opus 5) that independently re-ran all quality gates, confirmed the "scope lives in one place" architecture holds end-to-end (exactly one derivation site, one inheritance site across the whole diff), and caught one stray `pytest-asyncio` warning (fixed) plus several documentation/wording items now tracked as follow-ups rather than blocking.

## Test plan

- [x] Full unit suite: 1252 passed (baseline on `main` was 1152), zero warnings
- [x] Integration suite (`-m integration`): 109 passed, live network
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean
- [x] `outputSchema` pinning test confirms the new fields (`result_set_scope`, `no_match_is_inconclusive`, `scope`) reach MCP clients on all five affected tools without dropping any existing field