### PR TITLE
fix: fail clearly on content loading errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ readable text; `isError=true` means the upstream is unreachable and a retry may 
 ### Fixed
 
 - A failure to load content is no longer indistinguishable from an act without text.
-- `validation`, `not_found`, `precondition` and `unavailable` error messages are now
-  length-bounded.
+- `validation`, `not_found`, `precondition`, `content_too_large` and `unavailable` error messages
+  are now length-bounded.
 
 ## [4.2.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ readable text; `isError=true` means the upstream is unreachable and a retry may 
 
 - `ActService._load_content` no longer swallows exceptions; only a permanent absence of readable
   text (no HTML/PDF URL, a 404 on the PDF fetch, or an empty extraction) is handled internally.
-- Hints for an act with no readable content point at the source PDF URL instead of tools that
-  would fail against it.
+- Hints for an act with no readable content point at the source PDF URL when the act has one,
+  instead of tools that would fail against it.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-09-06
+
+See [docs/changelogs/v4.3.0.md](docs/changelogs/v4.3.0.md) for details.
+
+Failed content loading now looks like a failure. Closes audit findings F33 and the remainder of
+F39, and freezes the protocol guarantees v3.0.0 introduced for F16.
+
+### BREAKING — content loading failures are protocol errors
+
+`get_act_details(eli=..., load_content=True)` used to return a successful response with
+`is_loaded=false` whenever loading failed. Such calls now fail with `isError=true`. A
+**successful** response with `content_status="unavailable"` means the act permanently has no
+readable text; `isError=true` means the upstream is unreachable and a retry may succeed.
+
+### Added
+
+- `content_status` field on `get_act_details` output (`not_requested`, `loaded`, `unavailable`),
+  part of the tool's `outputSchema` and `structuredContent`.
+- `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` (default `500`, range 80-10000) caps the length of error
+  messages built from an exception's own text; truncation is announced in the message.
+- Every tool error message now ends with a fixed one-sentence remediation hint, one per error
+  category.
+
+### Changed
+
+- `ActService._load_content` no longer swallows exceptions; only a permanent absence of readable
+  text (no HTML/PDF URL, a 404 on the PDF fetch, or an empty extraction) is handled internally.
+- Hints for an act with no readable content point at the source PDF URL instead of tools that
+  would fail against it.
+
+### Removed
+
+- The placeholder documents stored for acts with no readable content — they made `is_loaded=true`
+  untrue and were matched by `search_in_act`.
+
+### Fixed
+
+- F33: a failure to load content is no longer indistinguishable from an act without text.
+- F39 (remainder): `validation`, `not_found`, `precondition` and `unavailable` messages are now
+  length-bounded.
+
 ## [4.2.0] - 2026-09-02
 
 See [docs/changelogs/v4.2.0.md](docs/changelogs/v4.2.0.md) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [docs/changelogs/v4.3.0.md](docs/changelogs/v4.3.0.md) for details.
 
-Failed content loading now looks like a failure. Closes audit findings F33 and the remainder of
-F39, and freezes the protocol guarantees v3.0.0 introduced for F16.
+Failed content loading now looks like a failure: a transient upstream problem during
+`get_act_details(load_content=True)` now fails the call itself instead of surfacing as a
+successful, textless response. A new regression test also pins the existing guarantee that any
+domain exception surfaces as a protocol error rather than a success body.
 
 ### BREAKING — content loading failures are protocol errors
 
@@ -44,8 +46,8 @@ readable text; `isError=true` means the upstream is unreachable and a retry may 
 
 ### Fixed
 
-- F33: a failure to load content is no longer indistinguishable from an act without text.
-- F39 (remainder): `validation`, `not_found`, `precondition` and `unavailable` messages are now
+- A failure to load content is no longer indistinguishable from an act without text.
+- `validation`, `not_found`, `precondition` and `unavailable` error messages are now
   length-bounded.
 
 ## [4.2.0] - 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ readable text; `isError=true` means the upstream is unreachable and a retry may 
 ### Changed
 
 - `ActService._load_content` no longer swallows exceptions; only a permanent absence of readable
-  text (no HTML/PDF URL, a 404 on the PDF fetch, or an empty extraction) is handled internally.
+  text (no HTML/PDF URL, a 404 on either text fetch, or an empty extraction) is handled
+  internally, and remembered for the metadata cache TTL so a repeated load does not re-fetch.
 - Hints for an act with no readable content point at the source PDF URL when the act has one,
   instead of tools that would fail against it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Law Scrapper MCP v4.2.0 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
+Law Scrapper MCP v4.3.0 is a modular Python MCP server that exposes 13 tools for searching and analyzing Polish legal acts from the Sejm API (`api.sejm.gov.pl/eli/`). Built with the official Python MCP SDK (`mcp[cli]==2.0.0`, `MCPServer[AppContext]`), it supports STDIO (default) and stateless Streamable HTTP at `/mcp` on port 7683.
 
 ## Development commands
 

--- a/README.md
+++ b/README.md
@@ -410,10 +410,10 @@ Retrieve detailed information about a specific legal act and optionally load its
 **Returns:** Act metadata (title, publication date, status, type, etc.), table of contents if load_content=true
 
 **`content_status`:** Outcome of the content-loading half of this call, one of:
-- `not_requested` - `load_content` was not set; no loading was attempted
+- `not_requested` - `load_content` was not set and the act was not already in the Document Store
 - `loaded` - content is in the Document Store, ready for `read_act_content` / `search_in_act`
-- `unavailable` - the act permanently has no readable text (no HTML/PDF source, or empty
-  extraction from either); retrying will not change that
+- `unavailable` - the act permanently has no readable text (no HTML/PDF source, a 404 on the PDF
+  fetch, or an empty extraction from either format); retrying will not change that
 
 A transient upstream failure during loading (an open circuit breaker, a timeout, an HTTP 5xx
 from `api.sejm.gov.pl`) is **not** a `content_status` value — it fails the call itself with

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Model Context Protocol (MCP) server for accessing and analyzing 
 
 ![Python version](https://img.shields.io/badge/python-3.13+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Version](https://img.shields.io/badge/version-4.2.0-orange.svg)
+![Version](https://img.shields.io/badge/version-4.3.0-orange.svg)
 
 <a href="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@numikel/law-scrapper-mcp/badge" alt="Law Scrapper MCP server" />
@@ -195,6 +195,7 @@ The list-valued settings — `LAW_MCP_ALLOWED_HOSTS`, `LAW_MCP_ALLOWED_ORIGINS`,
 | `LAW_MCP_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS` | `3` | Test calls in half-open state |
 | `LAW_MCP_MAX_PATTERN_LENGTH` | `512` | Max `filter_results` pattern length, clamped to 64-4096 |
 | `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call; floor 1, no ceiling (very high values lengthen the synchronous but linear scan) |
+| `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` | `500` | Cap on error-message length for categories whose message text is built from an exception's own string (`validation`, `not_found`, `precondition`, `unavailable`), which can be of unbounded length; accepted range `80`-`10000`. Truncation is announced in the message rather than silent |
 | `LAW_MCP_ALLOWED_HOSTS` | `127.0.0.1:*, localhost:*, [::1]:*` | `Host` header allowlist for streamable-http (DNS-rebinding protection). Widening beyond loopback requires an auth mode — see "Authenticated remote deployment" |
 | `LAW_MCP_ALLOWED_ORIGINS` | `http://127.0.0.1:*, http://localhost:*, http://[::1]:*` | `Origin` header allowlist for streamable-http. Same auth-mode requirement as `LAW_MCP_ALLOWED_HOSTS` |
 | `LAW_MCP_AUTH_JWKS_URI` | unset | Override the JWKS URI discovered from `LAW_MCP_AUTH_ISSUER`'s OIDC discovery document; needed only when a provider's discovery document omits or misreports it |
@@ -407,6 +408,17 @@ Retrieve detailed information about a specific legal act and optionally load its
 - `detail_level` (string, default: "standard") - Response detail: "minimal", "standard", or "full"
 
 **Returns:** Act metadata (title, publication date, status, type, etc.), table of contents if load_content=true
+
+**`content_status`:** Outcome of the content-loading half of this call, one of:
+- `not_requested` - `load_content` was not set; no loading was attempted
+- `loaded` - content is in the Document Store, ready for `read_act_content` / `search_in_act`
+- `unavailable` - the act permanently has no readable text (no HTML/PDF source, or empty
+  extraction from either); retrying will not change that
+
+A transient upstream failure during loading (an open circuit breaker, a timeout, an HTTP 5xx
+from `api.sejm.gov.pl`) is **not** a `content_status` value — it fails the call itself with
+`isError=true`, distinct from `content_status="unavailable"`. Retrying a transient failure may
+succeed; retrying an `unavailable` act will not.
 
 **Examples:**
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The list-valued settings — `LAW_MCP_ALLOWED_HOSTS`, `LAW_MCP_ALLOWED_ORIGINS`,
 | `LAW_MCP_CIRCUIT_BREAKER_HALF_OPEN_MAX_CALLS` | `3` | Test calls in half-open state |
 | `LAW_MCP_MAX_PATTERN_LENGTH` | `512` | Max `filter_results` pattern length, clamped to 64-4096 |
 | `LAW_MCP_FILTER_MAX_RECORDS` | `100` | Max records `filter_results` processes per call; floor 1, no ceiling (very high values lengthen the synchronous but linear scan) |
-| `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` | `500` | Cap on error-message length for categories whose message text is built from an exception's own string (`validation`, `not_found`, `precondition`, `unavailable`), which can be of unbounded length; accepted range `80`-`10000`. Truncation is announced in the message rather than silent |
+| `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` | `500` | Cap on error-message length for categories whose message text is built from an exception's own string (`validation`, `not_found`, `precondition`, `content_too_large`, `unavailable`), which can be of unbounded length; accepted range `80`-`10000`. Truncation is announced in the message rather than silent |
 | `LAW_MCP_ALLOWED_HOSTS` | `127.0.0.1:*, localhost:*, [::1]:*` | `Host` header allowlist for streamable-http (DNS-rebinding protection). Widening beyond loopback requires an auth mode — see "Authenticated remote deployment" |
 | `LAW_MCP_ALLOWED_ORIGINS` | `http://127.0.0.1:*, http://localhost:*, http://[::1]:*` | `Origin` header allowlist for streamable-http. Same auth-mode requirement as `LAW_MCP_ALLOWED_HOSTS` |
 | `LAW_MCP_AUTH_JWKS_URI` | unset | Override the JWKS URI discovered from `LAW_MCP_AUTH_ISSUER`'s OIDC discovery document; needed only when a provider's discovery document omits or misreports it |

--- a/README.md
+++ b/README.md
@@ -412,8 +412,9 @@ Retrieve detailed information about a specific legal act and optionally load its
 **`content_status`:** Outcome of the content-loading half of this call, one of:
 - `not_requested` - `load_content` was not set and the act was not already in the Document Store
 - `loaded` - content is in the Document Store, ready for `read_act_content` / `search_in_act`
-- `unavailable` - the act permanently has no readable text (no HTML/PDF source, a 404 on the PDF
-  fetch, or an empty extraction from either format); retrying will not change that
+- `unavailable` - the act permanently has no readable text (no HTML/PDF source, a 404 on either
+  text fetch, or an empty extraction from either format); retrying will not change that, and the
+  server remembers the absence for the metadata cache TTL rather than asking the API again
 
 A transient upstream failure during loading (an open circuit breaker, a timeout, an HTTP 5xx
 from `api.sejm.gov.pl`) is **not** a `content_status` value — it fails the call itself with

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -50,7 +50,11 @@ signalling fix, since the contract always meant "success = content loaded".
 
 - `ActService._load_content` no longer swallows exceptions. Transient failures propagate; only a
   permanent absence of readable text is handled internally, as `ContentNotAvailableError` — no
-  HTML or PDF URL at all, a 404 on the PDF fetch, or an empty extraction from either format.
+  HTML or PDF URL at all, a 404 on the PDF fetch, or an empty extraction from either format. Known
+  gap, deferred: an HTTP 404 on the `text.html` endpoint (as opposed to `text.pdf`) is not yet
+  classified as permanent absence and still surfaces as `isError=true`, naming the fetch path
+  rather than the act — the act's own metadata may have just been fetched successfully in the
+  same call.
 - An act with neither an HTML nor a PDF text URL no longer triggers a request that its metadata
   already proves pointless.
 - Hints for an act with no readable content no longer point at `read_act_content`, `search_in_act`

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -61,8 +61,10 @@ signalling fix, since the contract always meant "success = content loaded".
 - An act with neither an HTML nor a PDF text URL no longer triggers a request that its metadata
   already proves pointless.
 - Hints for an act with no readable content no longer point at `read_act_content`, `search_in_act`
-  or another `load_content=true` call; one hint names the source PDF URL instead, alongside the
-  unrelated `analyze_act_relationships` hint every `get_act_details` response already carries.
+  or another `load_content=true` call; one hint names the source PDF URL when the act has one,
+  alongside the unrelated `analyze_act_relationships` hint every `get_act_details` response
+  already carries. An act with no PDF either gets the same explanatory hint without a URL to
+  offer, rather than one pointing at a file the server itself declined to fetch.
 - A message built from an exception's own text now ends in a sentence terminator before the
   remediation sentence is appended, unless it already ends in one or ends in a URL — so the two
   sentences don't run together, and a `ContentTooLargeError` message can still end on a bare,

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [4.3.0] - 2026-09-06
 
-Failed content loading now looks like a failure. Cluster 10 closes audit findings F33 and the
-remainder of F39, and freezes the protocol guarantees v3.0.0 introduced for F16.
+Failed content loading now looks like a failure: a transient upstream problem during
+`get_act_details(load_content=True)` used to surface as a successful response with no readable
+text, and now fails the call itself. A new regression test also pins the guarantee, introduced
+when this project migrated to the official MCP SDK, that any domain exception surfaces as a
+protocol error (`isError=true`) rather than a success body with an embedded `error` field. Every
+error message built from caller-sourced or exception text is now length-bounded.
 
 ### BREAKING — content loading failures are protocol errors
 
@@ -31,9 +35,9 @@ signalling fix, since the contract always meant "success = content loaded".
 
 - `content_status` field on `get_act_details` output, with values `not_requested`, `loaded` and
   `unavailable`. The field is part of the tool's `outputSchema` and its `structuredContent`.
-  It is a pure function of the final in-memory load state, not of the `load_content` flag on
-  the current call: an act that was already loaded by an earlier call reports `loaded` even on
-  a metadata-only call that never asked to load anything.
+  `loaded` reflects the final in-memory state rather than this call's `load_content` flag, so an
+  act loaded by an earlier call reports `loaded` even on a metadata-only call that never asked to
+  load anything.
 - `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` (default `500`, range 80-10000) caps the length of error
   messages built from an exception's own text, which can quote caller input of unbounded length.
   Truncation is announced in the message rather than silent.
@@ -50,7 +54,8 @@ signalling fix, since the contract always meant "success = content loaded".
 - An act with neither an HTML nor a PDF text URL no longer triggers a request that its metadata
   already proves pointless.
 - Hints for an act with no readable content no longer point at `read_act_content`, `search_in_act`
-  or another `load_content=true` call; a single hint names the source PDF URL instead.
+  or another `load_content=true` call; one hint names the source PDF URL instead, alongside the
+  unrelated `analyze_act_relationships` hint every `get_act_details` response already carries.
 - A message built from an exception's own text now ends in a sentence terminator before the
   remediation sentence is appended, unless it already ends in one or ends in a URL — so the two
   sentences don't run together, and a `ContentTooLargeError` message can still end on a bare,
@@ -68,6 +73,9 @@ signalling fix, since the contract always meant "success = content loaded".
 
 ### Fixed
 
-- F33: a failure to load content is no longer indistinguishable from an act without text.
-- F39 (remainder): `validation`, `not_found`, `precondition` and `unavailable` messages are now
-  length-bounded.
+- A failure to load content is no longer indistinguishable from an act without text: a transient
+  upstream failure now propagates as `isError=true` instead of silently reporting
+  `is_loaded=false`.
+- `validation`, `not_found`, `precondition` and `unavailable` error messages are now
+  length-bounded, so text quoting unbounded caller input or upstream detail cannot fill the
+  caller's whole context window.

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -53,13 +53,16 @@ signalling fix, since the contract always meant "success = content loaded".
 
 - `ActService._load_content` no longer swallows exceptions. Transient failures propagate; only a
   permanent absence of readable text is handled internally, as `ContentNotAvailableError` — no
-  HTML or PDF URL at all, a 404 on the PDF fetch, or an empty extraction from either format. Known
-  gap, deferred: an HTTP 404 on the `text.html` endpoint (as opposed to `text.pdf`) is not yet
-  classified as permanent absence and still surfaces as `isError=true`, naming the fetch path
-  rather than the act — the act's own metadata may have just been fetched successfully in the
-  same call.
+  HTML or PDF URL at all, a 404 on the `text.html` or `text.pdf` fetch, or an empty extraction
+  from either format.
 - An act with neither an HTML nor a PDF text URL no longer triggers a request that its metadata
   already proves pointless.
+- A permanent absence is remembered for as long as the act's metadata stays cached
+  (`LAW_MCP_CACHE_DETAILS_TTL`, default one hour): a repeated `load_content=true` call on such an
+  act answers `content_status="unavailable"` from memory instead of re-fetching `text.html` /
+  `text.pdf`. The removed placeholder document used to play that role by accident; without a
+  replacement every retry would have cost `api.sejm.gov.pl` one or two requests for an answer that
+  cannot change before the metadata it was derived from expires.
 - Hints for an act with no readable content no longer point at `read_act_content`, `search_in_act`
   or another `load_content=true` call; one hint names the source PDF URL when the act has one,
   alongside the unrelated `analyze_act_relationships` hint every `get_act_details` response

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -1,0 +1,73 @@
+# Changelog - v4.3.0
+
+All notable changes to the `law-scrapper-mcp` project for version v4.3.0 will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [4.3.0] - 2026-09-06
+
+Failed content loading now looks like a failure. Cluster 10 closes audit findings F33 and the
+remainder of F39, and freezes the protocol guarantees v3.0.0 introduced for F16.
+
+### BREAKING — content loading failures are protocol errors
+
+`get_act_details(eli=..., load_content=True)` used to return a successful response with
+`is_loaded=false` whenever loading failed — an open circuit breaker, a timeout, an HTTP 5xx
+from `api.sejm.gov.pl`, or a conversion error. The only record of the failure was a server log
+line, and the response even hinted at retrying the call that had just failed.
+
+Such calls now fail with `isError=true`. Clients that treated `is_loaded=false` as "this act has
+no text" must distinguish two cases:
+
+- `content_status="unavailable"` in a **successful** response — the act permanently has no
+  readable text; retrying will not change that.
+- `isError=true` — the upstream is unreachable; retrying later may succeed.
+
+This mirrors the change v3.1.1 made for oversized acts, which shipped as a PATCH; it is a
+signalling fix, since the contract always meant "success = content loaded".
+
+### Added
+
+- `content_status` field on `get_act_details` output, with values `not_requested`, `loaded` and
+  `unavailable`. The field is part of the tool's `outputSchema` and its `structuredContent`.
+  It is a pure function of the final in-memory load state, not of the `load_content` flag on
+  the current call: an act that was already loaded by an earlier call reports `loaded` even on
+  a metadata-only call that never asked to load anything.
+- `LAW_MCP_ERROR_MESSAGE_MAX_CHARS` (default `500`, range 80-10000) caps the length of error
+  messages built from an exception's own text, which can quote caller input of unbounded length.
+  Truncation is announced in the message rather than silent.
+- Every tool error message now ends with a fixed one-sentence remediation hint, so a caller can
+  tell "retry shortly" from "this identifier does not exist" without parsing category names.
+  Six categories carry a hint: `not_found`, `validation`, `precondition`, `unavailable`,
+  `upstream`, `internal`.
+
+### Changed
+
+- `ActService._load_content` no longer swallows exceptions. Transient failures propagate; only a
+  permanent absence of readable text is handled internally, as `ContentNotAvailableError` — no
+  HTML or PDF URL at all, a 404 on the PDF fetch, or an empty extraction from either format.
+- An act with neither an HTML nor a PDF text URL no longer triggers a request that its metadata
+  already proves pointless.
+- Hints for an act with no readable content no longer point at `read_act_content`, `search_in_act`
+  or another `load_content=true` call; a single hint names the source PDF URL instead.
+- A message built from an exception's own text now ends in a sentence terminator before the
+  remediation sentence is appended, unless it already ends in one or ends in a URL — so the two
+  sentences don't run together, and a `ContentTooLargeError` message can still end on a bare,
+  unpunctuated PDF URL without a stray period being glued onto it.
+- The set of error categories treated as caller-sourced — and therefore subject to the length
+  cap — is now `validation`, `not_found`, `precondition` and `unavailable`. `unavailable` is
+  included because `ApiUnavailableError`'s text can embed a raw `httpx` exception, which is not
+  authored by this project even though the category itself is not new.
+
+### Removed
+
+- The placeholder documents `*No readable content available for {eli}…*` and
+  `*Content extraction failed…*`. They were stored in the document store as if they were the act,
+  made `is_loaded=true` untrue, and were matched by `search_in_act`.
+
+### Fixed
+
+- F33: a failure to load content is no longer indistinguishable from an act without text.
+- F39 (remainder): `validation`, `not_found`, `precondition` and `unavailable` messages are now
+  length-bounded.

--- a/docs/changelogs/v4.3.0.md
+++ b/docs/changelogs/v4.3.0.md
@@ -43,8 +43,11 @@ signalling fix, since the contract always meant "success = content loaded".
   Truncation is announced in the message rather than silent.
 - Every tool error message now ends with a fixed one-sentence remediation hint, so a caller can
   tell "retry shortly" from "this identifier does not exist" without parsing category names.
-  Six categories carry a hint: `not_found`, `validation`, `precondition`, `unavailable`,
-  `upstream`, `internal`.
+  Seven categories carry a hint: `not_found`, `validation`, `precondition`, `content_too_large`,
+  `unavailable`, `upstream`, `internal`. `content_too_large` (a refusal because the act is too
+  large to convert) is split out of `precondition` rather than sharing its "do a step first"
+  wording — there is no prior step for an oversized act, and the one actionable remedy (fetch the
+  source file) is already the last sentence of the body.
 
 ### Changed
 
@@ -65,9 +68,9 @@ signalling fix, since the contract always meant "success = content loaded".
   sentences don't run together, and a `ContentTooLargeError` message can still end on a bare,
   unpunctuated PDF URL without a stray period being glued onto it.
 - The set of error categories treated as caller-sourced — and therefore subject to the length
-  cap — is now `validation`, `not_found`, `precondition` and `unavailable`. `unavailable` is
-  included because `ApiUnavailableError`'s text can embed a raw `httpx` exception, which is not
-  authored by this project even though the category itself is not new.
+  cap — is now `validation`, `not_found`, `precondition`, `content_too_large` and `unavailable`.
+  `unavailable` is included because `ApiUnavailableError`'s text can embed a raw `httpx`
+  exception, which is not authored by this project even though the category itself is not new.
 
 ### Removed
 
@@ -80,6 +83,6 @@ signalling fix, since the contract always meant "success = content loaded".
 - A failure to load content is no longer indistinguishable from an act without text: a transient
   upstream failure now propagates as `isError=true` instead of silently reporting
   `is_loaded=false`.
-- `validation`, `not_found`, `precondition` and `unavailable` error messages are now
-  length-bounded, so text quoting unbounded caller input or upstream detail cannot fill the
-  caller's whole context window.
+- `validation`, `not_found`, `precondition`, `content_too_large` and `unavailable` error messages
+  are now length-bounded, so text quoting unbounded caller input or upstream detail cannot fill
+  the caller's whole context window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "law-scrapper-mcp"
-version = "4.2.0"
+version = "4.3.0"
 description = "LawScrapper MCP is an MCP server to monitoring and fetching Polish law acts published by the Polish Sejm, filters them by topic. Then with AI you can summarizes their content using an LLM."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -258,6 +258,13 @@ class Settings(BaseSettings):
     max_pattern_length: int = 512
     filter_max_records: int = 100
 
+    # Error messages. The cap is a context budget, not a security boundary: the
+    # categories it covers are built from `str(exc)`, which quotes caller input of
+    # unbounded length, and every character lands in the caller's context window.
+    # Configurable rather than a module constant because that budget differs
+    # between models and deployments (D8).
+    error_message_max_chars: int = Field(default=500, ge=80, le=10_000)
+
     @property
     def effective_max_pattern_length(self) -> int:
         """Return max pattern length clamped to the allowed range"""

--- a/src/law_scrapper_mcp/config.py
+++ b/src/law_scrapper_mcp/config.py
@@ -315,7 +315,7 @@ class Settings(BaseSettings):
 
     # Server info
     server_name: str = "law-scrapper-mcp"
-    server_version: str = "4.2.0"
+    server_version: str = "4.3.0"
 
     @property
     def user_agent(self) -> str:

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -50,6 +50,18 @@ class SetScope(StrEnum):
     PAGE = "page"
 
 
+class ContentStatus(StrEnum):
+    """Outcome of the content-loading half of `get_act_details`.
+
+    Deliberately has no member for a transient upstream failure: that path
+    ends as a protocol error, so it never reaches a response body (D2, D6).
+    """
+
+    NOT_REQUESTED = "not_requested"
+    LOADED = "loaded"
+    UNAVAILABLE = "unavailable"
+
+
 class ResultSetScope(BaseModel):
     """Zasięg zestawu wyników względem korpusu, z którego pochodzi."""
 
@@ -113,6 +125,14 @@ class ActDetailOutput(BaseModel):
     has_html: bool = False
     toc: list[dict[str, Any]] = []
     is_loaded: bool = False
+    content_status: ContentStatus = Field(
+        default=ContentStatus.NOT_REQUESTED,
+        description=(
+            "Wynik ładowania treści. 'not_requested' — wywołanie nie prosiło o treść. "
+            "'loaded' — treść jest w pamięci, można użyć read_act_content i search_in_act. "
+            "'unavailable' — akt trwale nie ma czytelnego tekstu w API; ponowne ładowanie nic nie zmieni."
+        ),
+    )
 
 
 class ContentOutput(BaseModel):

--- a/src/law_scrapper_mcp/models/tool_outputs.py
+++ b/src/law_scrapper_mcp/models/tool_outputs.py
@@ -129,7 +129,8 @@ class ActDetailOutput(BaseModel):
         default=ContentStatus.NOT_REQUESTED,
         description=(
             "Wynik ładowania treści. 'not_requested' — wywołanie nie prosiło o treść. "
-            "'loaded' — treść jest w pamięci, można użyć read_act_content i search_in_act. "
+            "'loaded' — treść jest w pamięci (mogła zostać załadowana bieżącym albo wcześniejszym "
+            "wywołaniem), można użyć read_act_content i search_in_act. "
             "'unavailable' — akt trwale nie ma czytelnego tekstu w API; ponowne ładowanie nic nie zmieni."
         ),
     )

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Any
 
+from law_scrapper_mcp.client.cache import TTLCache
 from law_scrapper_mcp.client.exceptions import (
     ActNotFoundError,
     ContentNotAvailableError,
@@ -43,6 +44,14 @@ class ActService:
         self._client = client
         self._doc_store = document_store
         self._content_processor = content_processor
+        # ELIs whose text the source has already said it cannot supply. The
+        # placeholder document D3 removed used to double as a negative cache;
+        # without one, every repeated `load_content=True` on a textless act would
+        # spend one or two upstream requests on an answer that cannot change
+        # before the metadata it was derived from expires (O1). Hence the same
+        # TTL as that metadata: `has_html`/`has_pdf` route the fetch, and both
+        # are re-checked together.
+        self._known_unavailable = TTLCache(max_entries=settings.cache_max_entries)
 
     async def get_details(self, eli: str, load_content: bool = False) -> ActDetailOutput:
         """Get act details, optionally loading content into document store."""
@@ -64,7 +73,7 @@ class ActService:
         has_pdf = bool(data.get("textPDF"))
 
         is_loaded = await self._doc_store.is_loaded(eli)
-        if load_content and not is_loaded:
+        if load_content and not is_loaded and await self._known_unavailable.get(eli) is None:
             try:
                 await self._load_content(eli, publisher, year, pos, has_html=has_html, has_pdf=has_pdf)
             except ContentNotAvailableError as exc:
@@ -72,6 +81,7 @@ class ActService:
                 # this call already fetched stays useful, and `content_status`
                 # below says plainly that there is no text to read (D6).
                 logger.info("No readable content for %s: %s", eli, exc)
+                await self._known_unavailable.set(eli, True, settings.cache_details_ttl)
             else:
                 is_loaded = await self._doc_store.is_loaded(eli)
         if is_loaded:
@@ -118,9 +128,9 @@ class ActService:
         indistinguishable from an act that simply has no text.
 
         A permanently empty extraction — whichever format supplied it — raises
-        `ContentNotAvailableError`, as does no format being available at all. A
-        404 on the PDF fetch does too; an HTML fetch 404 is not yet distinguished
-        from other transient failures and still propagates (D5, D6).
+        `ContentNotAvailableError`, as does no format being available at all and
+        a 404 on the fetch of either format: that is the source itself saying the
+        file is not there (D5, D6).
         """
         pdf_url = f"{self._client.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf"
         limit = settings.doc_store_max_size_bytes
@@ -134,7 +144,12 @@ class ActService:
             # never sits whole in memory. The post-hoc gates below stay as belt and
             # braces — they bound what the converter sees, which streaming does not.
             if has_html:
-                html = await self._client.get_act_html(publisher, year, pos, max_bytes=limit)
+                try:
+                    html = await self._client.get_act_html(publisher, year, pos, max_bytes=limit)
+                except ActNotFoundError as exc:
+                    # 404 is the source itself saying the file is not there. Every
+                    # other client error keeps its own meaning and propagates (D5).
+                    raise ContentNotAvailableError(eli, "html") from exc
                 _reject_if_too_large(eli, len(html.encode("utf-8")), limit, pdf_url)
                 # markdownify, pdfplumber and the section regex are synchronous
                 # CPU-bound work. Left in the coroutine they hold the event loop

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -8,7 +8,7 @@ from law_scrapper_mcp.client.exceptions import ContentTooLargeError, ResponseToo
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.models.tool_inputs import parse_eli
-from law_scrapper_mcp.models.tool_outputs import ActDetailOutput
+from law_scrapper_mcp.models.tool_outputs import ActDetailOutput, ContentStatus
 from law_scrapper_mcp.services.content_processor import ContentProcessor
 from law_scrapper_mcp.services.document_store import DocumentStore
 
@@ -58,11 +58,15 @@ class ActService:
         has_html = bool(data.get("textHTML"))
         has_pdf = bool(data.get("textPDF"))
 
-        # Load content if requested
+        # `content_status` is derived here and only here: two fields describing the
+        # same state drift the moment either is set by hand at the tool layer (R2).
         is_loaded = await self._doc_store.is_loaded(eli)
-        if load_content and not is_loaded:
-            await self._load_content(eli, publisher, year, pos, has_html)
-            is_loaded = await self._doc_store.is_loaded(eli)
+        content_status = ContentStatus.NOT_REQUESTED
+        if load_content:
+            if not is_loaded:
+                await self._load_content(eli, publisher, year, pos, has_html)
+                is_loaded = await self._doc_store.is_loaded(eli)
+            content_status = ContentStatus.LOADED if is_loaded else ContentStatus.UNAVAILABLE
 
         return ActDetailOutput(
             eli=data.get("ELI", eli),
@@ -85,6 +89,7 @@ class ActService:
             has_html=has_html,
             toc=self._format_toc(toc_data) if toc_data else [],
             is_loaded=is_loaded,
+            content_status=content_status,
         )
 
     async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool) -> None:

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -92,7 +92,15 @@ class ActService:
         )
 
     async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool) -> None:
-        """Load act content into document store."""
+        """Load act content into the document store.
+
+        Failure is never silent. A transient upstream problem — an open breaker, a
+        timeout, a 5xx, a converter blowing up — propagates unchanged so the tool
+        layer reports `isError=true`; the caller can then retry deliberately, which
+        is the only retry this project performs above `client/failure_policy.py` (O1).
+        The previous `except Exception: logger.error(...)` made every one of those
+        indistinguishable from an act that simply has no text.
+        """
         pdf_url = f"{self._client.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf"
         limit = settings.doc_store_max_size_bytes
         try:
@@ -110,20 +118,15 @@ class ActService:
                 # `await` in its critical sections (see its class docstring).
                 markdown = await asyncio.to_thread(self._content_processor.html_to_markdown, html)
             else:
-                # try/except/else, not a single try block: the fallback below is
-                # for an unreachable PDF, and it must not swallow a size refusal —
-                # neither one raised mid-download nor one raised after it succeeded.
-                try:
-                    pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf", max_bytes=limit)
-                except ResponseTooLargeError:
-                    raise
-                except Exception:
-                    markdown = f"*No readable content available for {eli}. PDF URL: {pdf_url}*"
-                else:
-                    _reject_if_too_large(eli, len(pdf_bytes), limit, pdf_url)
-                    markdown = await asyncio.to_thread(self._content_processor.pdf_to_text, pdf_bytes)
-                    if not markdown:
-                        markdown = f"*Content extraction failed. PDF available at: {pdf_url}*"
+                # A fetch failure here is not distinguishable from permanent absence
+                # without the D5 table (Task 3), so it takes the same default branch
+                # as every other unlisted failure: propagate, caught by the outer
+                # `except ResponseTooLargeError` if that's what it is, unchanged otherwise.
+                pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf", max_bytes=limit)
+                _reject_if_too_large(eli, len(pdf_bytes), limit, pdf_url)
+                markdown = await asyncio.to_thread(self._content_processor.pdf_to_text, pdf_bytes)
+                if not markdown:
+                    markdown = f"*Content extraction failed. PDF available at: {pdf_url}*"
 
             # Second gate, on the conversion *output*. The gates above bound the
             # input, which is enough for HTML — markdownify strips markup, so in
@@ -142,12 +145,6 @@ class ActService:
             # The client knows the URL and the budget, not the act; the refusal the
             # agent reads has to name the act and the source file it can fetch instead.
             raise ContentTooLargeError(eli, exc.size_bytes, limit, pdf_url, exact=exc.exact) from exc
-        except ContentTooLargeError:
-            # The only failure the agent can act on, so it is the only one that
-            # reaches the tool layer instead of being logged and hidden.
-            raise
-        except Exception as e:
-            logger.error(f"Failed to load content for {eli}: {e}")
 
     def _format_toc(self, toc_data: list | dict) -> list[dict[str, Any]]:
         """Format TOC data for output."""

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -58,15 +58,14 @@ class ActService:
         has_html = bool(data.get("textHTML"))
         has_pdf = bool(data.get("textPDF"))
 
-        # `content_status` is derived here and only here: two fields describing the
-        # same state drift the moment either is set by hand at the tool layer (R2).
         is_loaded = await self._doc_store.is_loaded(eli)
-        content_status = ContentStatus.NOT_REQUESTED
-        if load_content:
-            if not is_loaded:
-                await self._load_content(eli, publisher, year, pos, has_html)
-                is_loaded = await self._doc_store.is_loaded(eli)
-            content_status = ContentStatus.LOADED if is_loaded else ContentStatus.UNAVAILABLE
+        if load_content and not is_loaded:
+            await self._load_content(eli, publisher, year, pos, has_html)
+            is_loaded = await self._doc_store.is_loaded(eli)
+        # `UNAVAILABLE` is wired in Task 3, once `_load_content` can distinguish a
+        # transient failure from a permanent absence — assigning it here would mislabel
+        # a retryable failure as permanent.
+        content_status = ContentStatus.LOADED if is_loaded else ContentStatus.NOT_REQUESTED
 
         return ActDetailOutput(
             eli=data.get("ELI", eli),

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -49,8 +49,10 @@ class ActService:
         # without one, every repeated `load_content=True` on a textless act would
         # spend one or two upstream requests on an answer that cannot change
         # before the metadata it was derived from expires (O1). Hence the same
-        # TTL as that metadata: `has_html`/`has_pdf` route the fetch, and both
-        # are re-checked together.
+        # TTL value as that metadata, whose `has_html`/`has_pdf` route the fetch.
+        # Same duration, not same clock: this entry starts when the load fails,
+        # which can be later than the metadata was cached, so a verdict may
+        # outlive its snapshot by up to one more TTL window before a re-check.
         self._known_unavailable = TTLCache(max_entries=settings.cache_max_entries)
 
     async def get_details(self, eli: str, load_content: bool = False) -> ActDetailOutput:

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -66,7 +66,7 @@ class ActService:
         is_loaded = await self._doc_store.is_loaded(eli)
         if load_content and not is_loaded:
             try:
-                await self._load_content(eli, publisher, year, pos, has_html, has_pdf)
+                await self._load_content(eli, publisher, year, pos, has_html=has_html, has_pdf=has_pdf)
             except ContentNotAvailableError as exc:
                 # A permanent absence is information, not a failure: the metadata
                 # this call already fetched stays useful, and `content_status`
@@ -105,7 +105,9 @@ class ActService:
             content_status=content_status,
         )
 
-    async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool, has_pdf: bool) -> None:
+    async def _load_content(
+        self, eli: str, publisher: str, year: int, pos: int, *, has_html: bool, has_pdf: bool
+    ) -> None:
         """Load act content into the document store.
 
         Failure is never silent. A transient upstream problem — an open breaker, a
@@ -115,10 +117,10 @@ class ActService:
         The previous `except Exception: logger.error(...)` made every one of those
         indistinguishable from an act that simply has no text.
 
-        Permanent absence (no format at all, a 404 on the only available format,
-        or an extraction that yields nothing) is the one outcome that is not a
-        failure — it raises `ContentNotAvailableError` instead of propagating or
-        stashing a placeholder sentence in its place (D5, D6).
+        A permanently empty extraction — whichever format supplied it — raises
+        `ContentNotAvailableError`, as does no format being available at all. A
+        404 on the PDF fetch does too; an HTML fetch 404 is not yet distinguished
+        from other transient failures and still propagates (D5, D6).
         """
         pdf_url = f"{self._client.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf"
         limit = settings.doc_store_max_size_bytes
@@ -140,6 +142,8 @@ class ActService:
                 # `ContentProcessor`: `DocumentStore` relies on the absence of
                 # `await` in its critical sections (see its class docstring).
                 markdown = await asyncio.to_thread(self._content_processor.html_to_markdown, html)
+                if not markdown.strip():
+                    raise ContentNotAvailableError(eli, "html")
             else:
                 try:
                     pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf", max_bytes=limit)

--- a/src/law_scrapper_mcp/services/act_service.py
+++ b/src/law_scrapper_mcp/services/act_service.py
@@ -4,7 +4,12 @@ import asyncio
 import logging
 from typing import Any
 
-from law_scrapper_mcp.client.exceptions import ContentTooLargeError, ResponseTooLargeError
+from law_scrapper_mcp.client.exceptions import (
+    ActNotFoundError,
+    ContentNotAvailableError,
+    ContentTooLargeError,
+    ResponseTooLargeError,
+)
 from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.models.tool_inputs import parse_eli
@@ -60,12 +65,21 @@ class ActService:
 
         is_loaded = await self._doc_store.is_loaded(eli)
         if load_content and not is_loaded:
-            await self._load_content(eli, publisher, year, pos, has_html)
-            is_loaded = await self._doc_store.is_loaded(eli)
-        # `UNAVAILABLE` is wired in Task 3, once `_load_content` can distinguish a
-        # transient failure from a permanent absence — assigning it here would mislabel
-        # a retryable failure as permanent.
-        content_status = ContentStatus.LOADED if is_loaded else ContentStatus.NOT_REQUESTED
+            try:
+                await self._load_content(eli, publisher, year, pos, has_html, has_pdf)
+            except ContentNotAvailableError as exc:
+                # A permanent absence is information, not a failure: the metadata
+                # this call already fetched stays useful, and `content_status`
+                # below says plainly that there is no text to read (D6).
+                logger.info("No readable content for %s: %s", eli, exc)
+            else:
+                is_loaded = await self._doc_store.is_loaded(eli)
+        if is_loaded:
+            content_status = ContentStatus.LOADED
+        elif load_content:
+            content_status = ContentStatus.UNAVAILABLE
+        else:
+            content_status = ContentStatus.NOT_REQUESTED
 
         return ActDetailOutput(
             eli=data.get("ELI", eli),
@@ -91,7 +105,7 @@ class ActService:
             content_status=content_status,
         )
 
-    async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool) -> None:
+    async def _load_content(self, eli: str, publisher: str, year: int, pos: int, has_html: bool, has_pdf: bool) -> None:
         """Load act content into the document store.
 
         Failure is never silent. A transient upstream problem — an open breaker, a
@@ -100,9 +114,18 @@ class ActService:
         is the only retry this project performs above `client/failure_policy.py` (O1).
         The previous `except Exception: logger.error(...)` made every one of those
         indistinguishable from an act that simply has no text.
+
+        Permanent absence (no format at all, a 404 on the only available format,
+        or an extraction that yields nothing) is the one outcome that is not a
+        failure — it raises `ContentNotAvailableError` instead of propagating or
+        stashing a placeholder sentence in its place (D5, D6).
         """
         pdf_url = f"{self._client.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf"
         limit = settings.doc_store_max_size_bytes
+        if not has_html and not has_pdf:
+            # Metadata already says there is nothing to fetch. Asking anyway would
+            # spend a request on a guaranteed 404 against a public state API (O1).
+            raise ContentNotAvailableError(eli, "html/pdf")
         try:
             # The same limit reaches the download itself (#19): the client aborts a
             # body that runs past it while it is still streaming, so an oversized act
@@ -118,15 +141,16 @@ class ActService:
                 # `await` in its critical sections (see its class docstring).
                 markdown = await asyncio.to_thread(self._content_processor.html_to_markdown, html)
             else:
-                # A fetch failure here is not distinguishable from permanent absence
-                # without the D5 table (Task 3), so it takes the same default branch
-                # as every other unlisted failure: propagate, caught by the outer
-                # `except ResponseTooLargeError` if that's what it is, unchanged otherwise.
-                pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf", max_bytes=limit)
+                try:
+                    pdf_bytes = await self._client.get_bytes(f"acts/{publisher}/{year}/{pos}/text.pdf", max_bytes=limit)
+                except ActNotFoundError as exc:
+                    # 404 is the source itself saying the file is not there. Every
+                    # other client error keeps its own meaning and propagates (D5).
+                    raise ContentNotAvailableError(eli, "pdf") from exc
                 _reject_if_too_large(eli, len(pdf_bytes), limit, pdf_url)
                 markdown = await asyncio.to_thread(self._content_processor.pdf_to_text, pdf_bytes)
-                if not markdown:
-                    markdown = f"*Content extraction failed. PDF available at: {pdf_url}*"
+                if not markdown.strip():
+                    raise ContentNotAvailableError(eli, "pdf")
 
             # Second gate, on the conversion *output*. The gates above bound the
             # input, which is enough for HTML — markdownify strips markup, so in

--- a/src/law_scrapper_mcp/services/response_enrichment.py
+++ b/src/law_scrapper_mcp/services/response_enrichment.py
@@ -255,6 +255,8 @@ def act_details_hints(
     by a load that cannot succeed — so it steered the model straight back into
     the call that had just come up empty (F33).
     """
+    if content_status is ContentStatus.LOADED:
+        is_loaded = True
     hints = []
     if content_status is ContentStatus.UNAVAILABLE:
         # One hint, no tool: every tool this server offers for this act would

--- a/src/law_scrapper_mcp/services/response_enrichment.py
+++ b/src/law_scrapper_mcp/services/response_enrichment.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+from law_scrapper_mcp.client.sejm_client import SejmApiClient
 from law_scrapper_mcp.models.tool_outputs import (
+    ContentStatus,
     FilterOutput,
     Hint,
     LoadedDocumentInfo,
@@ -228,16 +230,40 @@ def filter_hints(output: FilterOutput, *, filter_max_records: int) -> list[Hint]
     return hints
 
 
+def act_pdf_url(publisher: str, year: int, pos: int) -> str:
+    """Public address of the act's source PDF.
+
+    Built from the client's base URL rather than a literal so the hint cannot
+    drift away from the host the server actually talks to.
+    """
+    return f"{SejmApiClient.BASE_URL}/acts/{publisher}/{year}/{pos}/text.pdf"
+
+
 def act_details_hints(
     eli: str,
     is_loaded: bool,
     has_html: bool,
     *,
     just_loaded: bool = False,
+    content_status: ContentStatus = ContentStatus.NOT_REQUESTED,
+    pdf_url: str | None = None,
 ) -> list[Hint]:
-    """Generate hints for act details."""
+    """Generate hints for act details.
+
+    `content_status` decides the shape of the list. The pre-cluster-10 version
+    keyed off `not is_loaded and has_html`, which is also the state left behind
+    by a load that cannot succeed — so it steered the model straight back into
+    the call that had just come up empty (F33).
+    """
     hints = []
-    if not is_loaded and has_html:
+    if content_status is ContentStatus.UNAVAILABLE:
+        # One hint, no tool: every tool this server offers for this act would
+        # fail, and the only remaining route to the text leaves the server (A11).
+        source = f" Pobierz plik źródłowy: {pdf_url}" if pdf_url else ""
+        hints.append(
+            Hint(message=(f"Akt {eli} nie ma czytelnej treści w API — ponowne ładowanie niczego nie zmieni.{source}"))
+        )
+    elif not is_loaded and has_html:
         hints.append(
             Hint(
                 message="Załaduj pełną treść aby czytać sekcje lub przeszukiwać akt.",

--- a/src/law_scrapper_mcp/tools/act_details.py
+++ b/src/law_scrapper_mcp/tools/act_details.py
@@ -8,8 +8,8 @@ from mcp.server.mcpserver import Context
 from pydantic import Field
 
 from law_scrapper_mcp.context import AppContext, get_app_context
-from law_scrapper_mcp.models.tool_outputs import ActDetailOutput, EnrichedResponse
-from law_scrapper_mcp.services.response_enrichment import act_details_hints
+from law_scrapper_mcp.models.tool_outputs import ActDetailOutput, ContentStatus, EnrichedResponse
+from law_scrapper_mcp.services.response_enrichment import act_details_hints, act_pdf_url
 from law_scrapper_mcp.tools.error_handling import handle_tool_errors
 
 logger = logging.getLogger(__name__)
@@ -78,6 +78,8 @@ def register(mcp: MCPServer[AppContext]) -> None:
                 eli,
                 act_details.is_loaded,
                 act_details.has_html,
-                just_loaded=load_content_bool and act_details.is_loaded,
+                just_loaded=load_content_bool and act_details.content_status is ContentStatus.LOADED,
+                content_status=act_details.content_status,
+                pdf_url=act_pdf_url(act_details.publisher, act_details.year, act_details.pos),
             ),
         )

--- a/src/law_scrapper_mcp/tools/act_details.py
+++ b/src/law_scrapper_mcp/tools/act_details.py
@@ -80,6 +80,8 @@ def register(mcp: MCPServer[AppContext]) -> None:
                 act_details.has_html,
                 just_loaded=load_content_bool and act_details.content_status is ContentStatus.LOADED,
                 content_status=act_details.content_status,
-                pdf_url=act_pdf_url(act_details.publisher, act_details.year, act_details.pos),
+                pdf_url=act_pdf_url(act_details.publisher, act_details.year, act_details.pos)
+                if act_details.has_pdf
+                else None,
             ),
         )

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -44,8 +44,24 @@ _ERROR_CATEGORIES: dict[type[Exception], str] = {
 }
 
 # `SejmApiError` embeds the upstream response body, so this category must never
-# fall through to `str(exc)`.
-_UPSTREAM_MESSAGE = "Serwis api.sejm.gov.pl nie odpowiedział poprawnie. Spróbuj ponownie za chwilę."
+# fall through to `str(exc)`. The retry advice lives in `_CATEGORY_GUIDANCE`, not
+# here, so that every category's closing sentence is written in one place.
+_UPSTREAM_MESSAGE = "Serwis api.sejm.gov.pl nie odpowiedział poprawnie."
+
+_INTERNAL_MESSAGE = "Wystąpił wewnętrzny błąd narzędzia."
+
+# One fixed sentence per category, appended to every public message (D4). Fixed,
+# because it enters the caller's context on every failure (O7); a sentence rather
+# than the category name, because the name would read as leaked internals and
+# would freeze an undocumented protocol in a free-text field.
+_CATEGORY_GUIDANCE: dict[str, str] = {
+    "not_found": "Ten zasób nie występuje w rejestrze — sprawdź identyfikator przed ponowieniem.",
+    "validation": "Popraw parametr wywołania i spróbuj ponownie.",
+    "precondition": "Wykonaj najpierw krok wymagany przez to narzędzie.",
+    "unavailable": "Ponów wywołanie za chwilę.",
+    "upstream": "Ponów wywołanie za chwilę.",
+    "internal": "Ponów wywołanie; jeśli błąd wraca, zgłoś go opiekunowi serwera.",
+}
 
 # Categories whose exception text this project did not author, and which can
 # therefore echo back what the caller submitted. `validation` messages quote
@@ -81,10 +97,12 @@ def _status_suffix(exc: Exception) -> str:
 
 def _public_message(exc: Exception, category: str) -> str:
     if category == "internal":
-        return "Wystąpił wewnętrzny błąd narzędzia. Spróbuj ponownie."
-    if category == "upstream":
-        return _UPSTREAM_MESSAGE
-    return str(exc)
+        body = _INTERNAL_MESSAGE
+    elif category == "upstream":
+        body = _UPSTREAM_MESSAGE
+    else:
+        body = str(exc)
+    return f"{body} {_CATEGORY_GUIDANCE[category]}"
 
 
 def handle_tool_errors(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:  # noqa: UP047

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -118,25 +118,32 @@ def _truncate(message: str) -> str:
     return message[: limit - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
 
 
+def _terminated(text: str) -> str:
+    """Close the body's clause so it does not run into the guidance sentence.
+
+    Skips whitespace-only text (nothing to terminate), text that already ends
+    in a sentence terminator, and text ending in a URL (a trailing period
+    would fuse onto the address and become a copy/linkify hazard).
+    """
+    if not text.strip():
+        return text
+    tokens = text.split()
+    if text[-1] in ".!?…" or tokens[-1].startswith(("http://", "https://")):
+        return text
+    return text + "."
+
+
 def _public_message(exc: Exception, category: str) -> str:
+    # Punctuated before truncation, not after: truncating first would require
+    # a separate case for "does the body already end on the truncation
+    # announcement", since that announcement is itself a complete parenthetical.
+    # A period appended past the cut point is simply discarded with the rest.
     if category in _CALLER_SOURCED_CATEGORIES:
-        body = _truncate(str(exc))
+        body = _truncate(_terminated(str(exc)))
     elif category == "upstream":
-        body = _UPSTREAM_MESSAGE
+        body = _terminated(_UPSTREAM_MESSAGE)
     else:
-        body = _INTERNAL_MESSAGE
-    # A truncated body already ends on the announcement suffix, which is itself
-    # a complete parenthetical — appending a period there would split it in two.
-    # A body ending in a bare URL (e.g. `ContentTooLargeError`'s PDF link) is
-    # left alone too: a period fused onto a URL is a copy-paste/auto-link hazard.
-    last_token = body.rsplit(maxsplit=1)[-1] if body else ""
-    if (
-        body
-        and not body.endswith(_TRUNCATION_SUFFIX)
-        and not last_token.startswith(("http://", "https://"))
-        and body[-1] not in ".!?…"
-    ):
-        body += "."
+        body = _terminated(_INTERNAL_MESSAGE)
     return f"{body} {_CATEGORY_GUIDANCE[category]}".strip()
 
 

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -19,6 +19,7 @@ from law_scrapper_mcp.client.exceptions import (
     InvalidEliError,
     SejmApiError,
 )
+from law_scrapper_mcp.config import settings
 from law_scrapper_mcp.logging_config import request_id_var
 from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
 
@@ -95,14 +96,34 @@ def _status_suffix(exc: Exception) -> str:
     return "" if status is None else f" (HTTP {status})"
 
 
+_TRUNCATION_SUFFIX = " […] (komunikat przycięty)"
+
+
+def _truncate(message: str) -> str:
+    """Bound a message this project did not author.
+
+    The cut is announced rather than silent: a model reading a sentence that
+    simply stops has no way to tell truncation from the real end of the text,
+    and would draw conclusions from a fragment (D8).
+    """
+    limit = settings.error_message_max_chars
+    if len(message) <= limit:
+        return message
+    return message[: limit - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
+
+
 def _public_message(exc: Exception, category: str) -> str:
     if category == "internal":
         body = _INTERNAL_MESSAGE
     elif category == "upstream":
         body = _UPSTREAM_MESSAGE
     else:
-        body = str(exc)
-    return f"{body} {_CATEGORY_GUIDANCE[category]}"
+        body = _truncate(str(exc))
+    # A truncated body already ends on the announcement suffix, which is itself
+    # a complete parenthetical — appending a period there would split it in two.
+    if body and not body.endswith(_TRUNCATION_SUFFIX) and body[-1] not in ".!?…":
+        body += "."
+    return f"{body} {_CATEGORY_GUIDANCE[category]}".strip()
 
 
 def handle_tool_errors(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:  # noqa: UP047

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -74,6 +74,12 @@ _CATEGORY_GUIDANCE: dict[str, str] = {
 # out of scope here, and redacting it costs only log detail.
 _REDACTED_DETAIL_CATEGORIES = frozenset({"validation", "upstream"})
 
+# Categories whose message body is `str(exc)` and therefore unbounded in
+# length. `unavailable` is included even though its text is project-authored:
+# the branch below is source-shaped, not provenance-shaped, and excluding it
+# would mean two different boundaries doing almost the same job (D8).
+_CALLER_SOURCED_CATEGORIES = frozenset({"validation", "not_found", "precondition", "unavailable"})
+
 
 class ToolExecutionError(Exception):
     """Public, sanitized tool execution failure."""
@@ -113,15 +119,23 @@ def _truncate(message: str) -> str:
 
 
 def _public_message(exc: Exception, category: str) -> str:
-    if category == "internal":
-        body = _INTERNAL_MESSAGE
+    if category in _CALLER_SOURCED_CATEGORIES:
+        body = _truncate(str(exc))
     elif category == "upstream":
         body = _UPSTREAM_MESSAGE
     else:
-        body = _truncate(str(exc))
+        body = _INTERNAL_MESSAGE
     # A truncated body already ends on the announcement suffix, which is itself
     # a complete parenthetical — appending a period there would split it in two.
-    if body and not body.endswith(_TRUNCATION_SUFFIX) and body[-1] not in ".!?…":
+    # A body ending in a bare URL (e.g. `ContentTooLargeError`'s PDF link) is
+    # left alone too: a period fused onto a URL is a copy-paste/auto-link hazard.
+    last_token = body.rsplit(maxsplit=1)[-1] if body else ""
+    if (
+        body
+        and not body.endswith(_TRUNCATION_SUFFIX)
+        and not last_token.startswith(("http://", "https://"))
+        and body[-1] not in ".!?…"
+    ):
         body += "."
     return f"{body} {_CATEGORY_GUIDANCE[category]}".strip()
 

--- a/src/law_scrapper_mcp/tools/error_handling.py
+++ b/src/law_scrapper_mcp/tools/error_handling.py
@@ -36,7 +36,7 @@ _ERROR_CATEGORIES: dict[type[Exception], str] = {
     ResultSetNotFoundError: "precondition",
     ResultSetTooLargeError: "precondition",
     ContentNotAvailableError: "not_found",
-    ContentTooLargeError: "precondition",
+    ContentTooLargeError: "content_too_large",
     ApiUnavailableError: "unavailable",
     SejmApiError: "upstream",
     httpx.TimeoutException: "upstream",
@@ -55,10 +55,17 @@ _INTERNAL_MESSAGE = "Wystąpił wewnętrzny błąd narzędzia."
 # because it enters the caller's context on every failure (O7); a sentence rather
 # than the category name, because the name would read as leaked internals and
 # would freeze an undocumented protocol in a free-text field.
+#
+# `content_too_large` is split out of `precondition` rather than sharing its
+# "do a step first" wording (D9): `ContentTooLargeError` has no prior step —
+# the act is simply too large, and the one actionable remedy (fetch the source
+# file) is already the last sentence of the body. Reusing `precondition`'s
+# guidance there would misdirect the model toward a step that does not exist.
 _CATEGORY_GUIDANCE: dict[str, str] = {
     "not_found": "Ten zasób nie występuje w rejestrze — sprawdź identyfikator przed ponowieniem.",
     "validation": "Popraw parametr wywołania i spróbuj ponownie.",
     "precondition": "Wykonaj najpierw krok wymagany przez to narzędzie.",
+    "content_too_large": "Ponowne wywołanie niczego nie zmieni — pobierz treść z podanego adresu.",
     "unavailable": "Ponów wywołanie za chwilę.",
     "upstream": "Ponów wywołanie za chwilę.",
     "internal": "Ponów wywołanie; jeśli błąd wraca, zgłoś go opiekunowi serwera.",
@@ -78,7 +85,9 @@ _REDACTED_DETAIL_CATEGORIES = frozenset({"validation", "upstream"})
 # length. `unavailable` is included even though its text is project-authored:
 # the branch below is source-shaped, not provenance-shaped, and excluding it
 # would mean two different boundaries doing almost the same job (D8).
-_CALLER_SOURCED_CATEGORIES = frozenset({"validation", "not_found", "precondition", "unavailable"})
+# `content_too_large` inherits `precondition`'s truncation behaviour unchanged
+# (D9 only splits the guidance sentence, not this boundary).
+_CALLER_SOURCED_CATEGORIES = frozenset({"validation", "not_found", "precondition", "content_too_large", "unavailable"})
 
 
 class ToolExecutionError(Exception):

--- a/tests/TEST_SUITE_SUMMARY.md
+++ b/tests/TEST_SUITE_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Test suite for Law Scrapper MCP v4.2.0, covering models, services, stores, the Sejm API
+Test suite for Law Scrapper MCP v4.3.0, covering models, services, stores, the Sejm API
 client and its egress controls, authentication, the HTTP surface, the 13 tools, pagination
 contracts, and the real MCP transports.
 
@@ -90,6 +90,7 @@ tests/
 │   │   ├── test_browse_paging.py       # `browse()` fetches one page, reports the year's count, does not re-slice, reads `effective_date` from entryIntoForce
 │   │   ├── test_changes_service.py     # ChangesService: date/keyword/publisher params, paged upstream window
 │   │   ├── test_comparison_service.py  # ComparisonService: concurrent fetches, sibling cancellation, comparison mapping
+│   │   ├── test_content_load_failures.py # Transient loading failures propagate; permanent absence (no format, 404, empty extraction) is a documented `unavailable`, not a placeholder
 │   │   ├── test_content_service.py     # TOC/section/search pagination, naive-implementation equivalence, atomic against reload
 │   │   ├── test_date_service.py        # DateService: accepted formats, offsets, Polish error messages, clock seam
 │   │   ├── test_metadata_concurrency.py# Metadata categories fetched concurrently, bounded by the client semaphore, ordered, cached
@@ -102,10 +103,12 @@ tests/
 │   │   ├── test_search_pagination.py   # PageInfo for search and browse windows
 │   │   └── test_search_service.py      # SearchService: keyword/date/title/in-force params, detail levels, browse by publisher/year, query summary, default limit
 │   └── test_tools/
+│       ├── test_act_details_tool.py    # `get_act_details` never hints a PDF URL the server's own metadata proves absent
 │       ├── test_dates_tool.py          # `calculate_legal_date` rejects boolean offsets at the tool boundary
 │       └── test_search_tool.py         # `search_legal_acts` validates `limit`/`offset` instead of ignoring bad values (#18)
 └── integration/
     ├── test_tools_e2e.py               # In-memory Client, all 13 tools, success and `is_error` paths
+    ├── test_content_failure_contract.py # Transient content-loading failures are protocol errors (`isError=true`), never a success body
     ├── test_content_pagination.py      # Section/TOC/search-in-act pagination over the wire
     ├── test_result_pagination.py       # Search/browse/filter/changes pagination over the wire
     ├── test_listing_pagination.py      # `list_loaded_documents` / `list_result_sets` pages

--- a/tests/integration/test_content_failure_contract.py
+++ b/tests/integration/test_content_failure_contract.py
@@ -56,11 +56,10 @@ async def test_transient_content_failure_is_a_protocol_error(failing_content_cli
 
     Message note: A4's own text asks for "a message of the `unavailable` category" —
     not the `upstream` category's `_UPSTREAM_MESSAGE`, which belongs to a different
-    exception family. Today (Tasks 1-4, before Task 6's per-category remediation
-    suffix exists) that message is `ApiUnavailableError`'s own text, e.g.
-    "API Sejmu chwilowo niedostępne (HTTP 503)". Task 6 appends a suffix to this
-    body rather than replacing it (spec D4/A12), so asserting on the existing
-    prefix should keep holding once Task 6 lands.
+    exception family. That message is `ApiUnavailableError`'s own text, e.g.
+    "API Sejmu chwilowo niedostępne (HTTP 503)", with Task 6's per-category
+    remediation sentence appended after it (spec D4/A12) rather than replacing it,
+    so asserting on the existing prefix still holds.
     """
     result = await failing_content_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
 

--- a/tests/integration/test_content_failure_contract.py
+++ b/tests/integration/test_content_failure_contract.py
@@ -65,11 +65,11 @@ async def test_transient_content_failure_is_a_protocol_error(failing_content_cli
     result = await failing_content_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
 
     assert result.is_error is True
+    assert result.structured_content is None
     payload = str(result.content)
     assert "content_status" not in payload
     assert "Ustawa testowa" not in payload
-    assert "niedostępne" in payload
-    assert "503" in payload
+    assert "niedostępne (HTTP 503)" in payload
 
 
 async def test_tool_failures_are_protocol_errors_not_success_bodies(mcp_client: Any) -> None:
@@ -82,7 +82,7 @@ async def test_tool_failures_are_protocol_errors_not_success_bodies(mcp_client: 
     result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1"})
 
     assert result.is_error is True
-    assert result.structured_content is None or "error" not in (result.structured_content or {})
+    assert result.structured_content is None
 
 
 async def test_a_successful_call_still_carries_no_error_key(mcp_client: Any) -> None:

--- a/tests/integration/test_content_failure_contract.py
+++ b/tests/integration/test_content_failure_contract.py
@@ -1,0 +1,95 @@
+"""Protocol-level contract for content loading failures (cluster 10, A4/A15).
+
+The in-memory `mcp.Client` is the only place these properties are observable:
+`is_error` and `structured_content` are protocol fields, not service returns.
+This module builds its own respx routes rather than reusing `mock_api_responses`,
+because it needs an act whose text endpoint fails.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import respx
+from httpx import Response
+
+from mcp_helpers import parse_tool_result
+
+pytestmark = [pytest.mark.integration, pytest.mark.anyio]
+
+ACT_URL = "https://api.sejm.gov.pl/eli/acts/DU/2024/1"
+
+FAILING_ACT = {
+    "ELI": "DU/2024/1",
+    "publisher": "DU",
+    "year": 2024,
+    "pos": 1,
+    "title": "Ustawa testowa z niedostępną treścią",
+    "status": "akt obowiązujący",
+    "type": "Ustawa",
+    "textHTML": "/eli/acts/DU/2024/1/text.html",
+    "textPDF": "/eli/acts/DU/2024/1/text.pdf",
+}
+
+
+@pytest.fixture
+async def failing_content_client() -> Any:
+    """In-memory MCP client whose act text endpoint always answers 503."""
+    from mcp import Client
+
+    from law_scrapper_mcp.server import app
+
+    with respx.mock:
+        respx.get(ACT_URL).mock(return_value=Response(200, json=FAILING_ACT))
+        respx.get(f"{ACT_URL}/struct").mock(return_value=Response(404))
+        respx.get(f"{ACT_URL}/text.html").mock(return_value=Response(503, text="maintenance"))
+        async with Client(app) as client:
+            yield client
+
+
+async def test_transient_content_failure_is_a_protocol_error(failing_content_client: Any) -> None:
+    """An unreachable upstream ends the call, it does not shrink the payload (A4).
+
+    Runtime note: the client's retry loop runs its full budget before giving up,
+    so this test takes a few seconds. That is the production path, not a defect.
+
+    Message note: A4's own text asks for "a message of the `unavailable` category" —
+    not the `upstream` category's `_UPSTREAM_MESSAGE`, which belongs to a different
+    exception family. Today (Tasks 1-4, before Task 6's per-category remediation
+    suffix exists) that message is `ApiUnavailableError`'s own text, e.g.
+    "API Sejmu chwilowo niedostępne (HTTP 503)". Task 6 appends a suffix to this
+    body rather than replacing it (spec D4/A12), so asserting on the existing
+    prefix should keep holding once Task 6 lands.
+    """
+    result = await failing_content_client.call_tool("get_act_details", {"eli": "DU/2024/1", "load_content": True})
+
+    assert result.is_error is True
+    payload = str(result.content)
+    assert "content_status" not in payload
+    assert "Ustawa testowa" not in payload
+    assert "niedostępne" in payload
+    assert "503" in payload
+
+
+async def test_tool_failures_are_protocol_errors_not_success_bodies(mcp_client: Any) -> None:
+    """A domain failure must never be an `error` key inside a success body (A15, F16).
+
+    `read_act_content` on a document that was never loaded raises
+    `DocumentNotLoadedError` — a plain domain exception, exactly the shape v3.0.0
+    changed from a `{data, hints, error}` envelope into a protocol error.
+    """
+    result = await mcp_client.call_tool("read_act_content", {"eli": "DU/2024/1"})
+
+    assert result.is_error is True
+    assert result.structured_content is None or "error" not in (result.structured_content or {})
+
+
+async def test_a_successful_call_still_carries_no_error_key(mcp_client: Any) -> None:
+    """The success envelope stays `{data, hints}` — the F16 fix, frozen (A15)."""
+    result = await mcp_client.call_tool("get_act_details", {"eli": "DU/2024/1"})
+
+    payload = parse_tool_result(result)
+    assert set(payload) >= {"data", "hints"}
+    assert "error" not in payload
+    assert payload["data"]["content_status"] == "not_requested"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -213,7 +213,7 @@ class TestSettingsDefaults:
         """Test default server info."""
         settings = Settings()
         assert settings.server_name == "law-scrapper-mcp"
-        assert settings.server_version == "4.2.0"
+        assert settings.server_version == "4.3.0"
 
 
 class TestSettingsFromEnvironment:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -425,6 +425,22 @@ class TestShutdownGrace:
             Settings()
 
 
+class TestErrorMessageMaxChars:
+    def test_error_message_max_chars_default(self) -> None:
+        """The cap exists and is a context budget, not a security boundary (D8)."""
+        assert Settings().error_message_max_chars == 500
+
+    @pytest.mark.parametrize("value", ["79", "10001"])
+    def test_error_message_max_chars_outside_the_band_is_rejected(self, monkeypatch, value: str) -> None:
+        monkeypatch.setenv("LAW_MCP_ERROR_MESSAGE_MAX_CHARS", value)
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_error_message_max_chars_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("LAW_MCP_ERROR_MESSAGE_MAX_CHARS", "1000")
+        assert Settings().error_message_max_chars == 1000
+
+
 class TestLogLevel:
     """`LAW_MCP_LOG_LEVEL` is a closed set, not free text (#31)."""
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -11,6 +11,9 @@ from law_scrapper_mcp.client.exceptions import ActNotFoundError, ApiUnavailableE
 from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
 from law_scrapper_mcp.tools.error_handling import ToolExecutionError, _classify_error, handle_tool_errors
 
+# Bound to the value under test so the assertion does not restate the wording.
+_CATEGORY_GUIDANCE_SENTENCE_FOR_VALIDATION = "Popraw parametr wywołania i spróbuj ponownie."
+
 
 class TestCategoryGuidance:
     """Each category tells the caller what to do next (A12, D4).
@@ -205,3 +208,76 @@ def test_content_too_large_is_classified_as_precondition() -> None:
     )
 
     assert _classify_error(error) == "precondition"
+
+
+class TestMessageTruncation:
+    """`str(exc)` messages are bounded; project-authored ones are not (A13, A16, D8)."""
+
+    def test_long_validation_message_is_truncated(self) -> None:
+        from law_scrapper_mcp.config import settings
+        from law_scrapper_mcp.tools.error_handling import _TRUNCATION_SUFFIX, _public_message
+
+        limit = settings.error_message_max_chars
+        exc = ValueError("A" * (limit * 3))
+
+        message = _public_message(exc, "validation")
+        body = message.removesuffix(_CATEGORY_GUIDANCE_SENTENCE_FOR_VALIDATION).rstrip()
+
+        assert len(body) <= limit
+        assert body.endswith(_TRUNCATION_SUFFIX)
+
+    def test_a_short_message_is_left_alone(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _TRUNCATION_SUFFIX, _public_message
+
+        message = _public_message(ValueError("krótki komunikat"), "validation")
+
+        assert "krótki komunikat" in message
+        assert _TRUNCATION_SUFFIX not in message
+
+    def test_upstream_body_never_reaches_the_message(self) -> None:
+        """A 40 kB upstream body is excluded by category, not by length (A16, F39)."""
+        from law_scrapper_mcp.tools.error_handling import _public_message
+
+        body = "<html>" + ("x" * 40_000) + "</html>"
+        exc = SejmApiError(f"HTTP 500: {body}", status_code=500, url="https://api.sejm.gov.pl/eli/acts")
+
+        message = _public_message(exc, "upstream")
+
+        assert "x" * 100 not in message
+        assert len(message) < 300
+
+    def test_the_limit_is_configurable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from law_scrapper_mcp import config
+        from law_scrapper_mcp.tools.error_handling import _public_message
+
+        monkeypatch.setattr(config.settings, "error_message_max_chars", 80)
+        message = _public_message(ValueError("B" * 500), "validation")
+
+        assert len(message) < 500
+
+
+class TestMessagePunctuation:
+    """The body's clause is terminated before the guidance sentence starts (D4)."""
+
+    def test_a_body_without_terminal_punctuation_gets_one(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _public_message
+
+        message = _public_message(ValueError("brak kropki"), "validation")
+
+        assert "brak kropki. Popraw parametr" in message
+
+    def test_a_body_that_already_ends_in_a_terminator_is_not_doubled(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _UPSTREAM_MESSAGE, _public_message
+
+        exc = SejmApiError("HTTP 500: body", status_code=500, url="https://api.sejm.gov.pl/eli/acts")
+        message = _public_message(exc, "upstream")
+
+        assert ".." not in message
+        assert message.startswith(_UPSTREAM_MESSAGE)
+
+    def test_an_empty_body_leaves_no_leading_space(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, _public_message
+
+        message = _public_message(ValueError(""), "validation")
+
+        assert message == _CATEGORY_GUIDANCE["validation"]

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -281,3 +281,31 @@ class TestMessagePunctuation:
         message = _public_message(ValueError(""), "validation")
 
         assert message == _CATEGORY_GUIDANCE["validation"]
+
+    def test_a_body_ending_in_a_url_is_not_glued_to_a_period(self) -> None:
+        """A period fused onto a URL is a copy-paste/auto-link hazard."""
+        from law_scrapper_mcp.client.exceptions import ContentTooLargeError
+        from law_scrapper_mcp.tools.error_handling import _public_message
+
+        pdf_url = "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf"
+        exc = ContentTooLargeError(
+            eli="DU/2024/1",
+            size_bytes=9_000_000,
+            limit_bytes=5_242_880,
+            pdf_url=pdf_url,
+        )
+
+        message = _public_message(exc, "precondition")
+
+        assert f"{pdf_url} " in message
+        assert f"{pdf_url}." not in message
+
+
+class TestCallerSourcedCategories:
+    """D8's truncation boundary is source-shaped, not an implicit `else`."""
+
+    def test_caller_sourced_categories_cover_every_category_except_internal_and_upstream(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _CALLER_SOURCED_CATEGORIES, _ERROR_CATEGORIES
+
+        all_categories = set(_ERROR_CATEGORIES.values()) | {"internal"}
+        assert _CALLER_SOURCED_CATEGORIES | {"internal", "upstream"} == all_categories

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -33,7 +33,7 @@ class TestCategoryGuidance:
     def test_every_category_ends_with_its_guidance(self, exc: Exception, category: str) -> None:
         from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, _public_message
 
-        message = _public_message(exc, category)
+        message = _public_message(exc, _classify_error(exc))
 
         assert message.endswith(_CATEGORY_GUIDANCE[category])
         assert category not in message
@@ -167,7 +167,7 @@ async def test_content_too_large_message_survives_sanitization() -> None:
     wording and the source URL.
     """
     from law_scrapper_mcp.client.exceptions import ContentTooLargeError
-    from law_scrapper_mcp.tools.error_handling import ToolExecutionError, handle_tool_errors
+    from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, ToolExecutionError, handle_tool_errors
 
     @handle_tool_errors
     async def failing_tool() -> None:
@@ -190,6 +190,7 @@ async def test_content_too_large_message_survives_sanitization() -> None:
     assert "przekracza limit" in message
     assert "wewnętrzny błąd" not in message
     assert "…" not in message
+    assert message.endswith(_CATEGORY_GUIDANCE["precondition"])
 
 
 def test_content_too_large_is_classified_as_precondition() -> None:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -275,10 +275,13 @@ class TestMessagePunctuation:
         assert ".." not in message
         assert message.startswith(_UPSTREAM_MESSAGE)
 
-    def test_an_empty_body_leaves_no_leading_space(self) -> None:
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_a_blank_body_leaves_no_leading_space_and_does_not_crash(self, blank: str) -> None:
+        """`"   ".rsplit(maxsplit=1)` used to return `[]`, crashing `[-1]` with
+        an `IndexError` that escaped `handle_tool_errors` unsanitized."""
         from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, _public_message
 
-        message = _public_message(ValueError(""), "validation")
+        message = _public_message(ValueError(blank), "validation")
 
         assert message == _CATEGORY_GUIDANCE["validation"]
 
@@ -299,6 +302,34 @@ class TestMessagePunctuation:
 
         assert f"{pdf_url} " in message
         assert f"{pdf_url}." not in message
+
+
+class TestTerminated:
+    """`_terminated` in isolation, independent of category routing."""
+
+    def test_adds_a_period_when_missing(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _terminated
+
+        assert _terminated("brak kropki") == "brak kropki."
+
+    @pytest.mark.parametrize("terminator", [".", "!", "?", "…"])
+    def test_does_not_double_an_existing_terminator(self, terminator: str) -> None:
+        from law_scrapper_mcp.tools.error_handling import _terminated
+
+        text = f"już zakończone{terminator}"
+        assert _terminated(text) == text
+
+    def test_does_not_glue_a_period_onto_a_url(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _terminated
+
+        text = "Pobierz plik źródłowy: https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf"
+        assert _terminated(text) == text
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_whitespace_only_text_passes_through_unchanged(self, blank: str) -> None:
+        from law_scrapper_mcp.tools.error_handling import _terminated
+
+        assert _terminated(blank) == blank
 
 
 class TestCallerSourcedCategories:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -12,6 +12,44 @@ from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, Resul
 from law_scrapper_mcp.tools.error_handling import ToolExecutionError, _classify_error, handle_tool_errors
 
 
+class TestCategoryGuidance:
+    """Each category tells the caller what to do next (A12, D4).
+
+    The category name itself stays out of the message: naming it would freeze
+    an undocumented protocol in a text field and leak implementation detail.
+    """
+
+    @pytest.mark.parametrize(
+        ("exc", "category"),
+        [
+            (ActNotFoundError("DU/2024/1"), "not_found"),
+            (ValueError("zły parametr"), "validation"),
+            (ResultSetNotFoundError("rs_1"), "precondition"),
+            (ApiUnavailableError("down", status_code=503), "unavailable"),
+            (SejmApiError("HTTP 500: body", status_code=500), "upstream"),
+            (KeyError("boom"), "internal"),
+        ],
+    )
+    def test_every_category_ends_with_its_guidance(self, exc: Exception, category: str) -> None:
+        from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, _public_message
+
+        message = _public_message(exc, category)
+
+        assert message.endswith(_CATEGORY_GUIDANCE[category])
+        assert category not in message
+
+    def test_guidance_covers_every_category_the_classifier_can_return(self) -> None:
+        from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE, _ERROR_CATEGORIES
+
+        assert set(_ERROR_CATEGORIES.values()) | {"internal"} == set(_CATEGORY_GUIDANCE)
+
+    def test_transient_and_permanent_guidance_differ(self) -> None:
+        """The whole point of D4: 'retry' must not read like 'does not exist'."""
+        from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE
+
+        assert _CATEGORY_GUIDANCE["unavailable"] != _CATEGORY_GUIDANCE["not_found"]
+
+
 class TestClassifyError:
     """ResultSetTooLargeError must classify as precondition"""
 
@@ -144,10 +182,14 @@ async def test_content_too_large_message_survives_sanitization() -> None:
         await failing_tool()
 
     message = str(excinfo.value)
+    # A14, as amended by D4: the URL survives in full and nothing is truncated.
+    # It is no longer the last text in the message, because `precondition` — like
+    # every other category — now carries a remediation sentence (A12).
     assert "DU/2024/1" in message
     assert "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf" in message
     assert "przekracza limit" in message
     assert "wewnętrzny błąd" not in message
+    assert "…" not in message
 
 
 def test_content_too_large_is_classified_as_precondition() -> None:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -7,7 +7,12 @@ import logging
 import httpx
 import pytest
 
-from law_scrapper_mcp.client.exceptions import ActNotFoundError, ApiUnavailableError, SejmApiError
+from law_scrapper_mcp.client.exceptions import (
+    ActNotFoundError,
+    ApiUnavailableError,
+    ContentTooLargeError,
+    SejmApiError,
+)
 from law_scrapper_mcp.services.result_store import ResultSetNotFoundError, ResultSetTooLargeError
 from law_scrapper_mcp.tools.error_handling import ToolExecutionError, _classify_error, handle_tool_errors
 
@@ -28,6 +33,12 @@ class TestCategoryGuidance:
             (ActNotFoundError("DU/2024/1"), "not_found"),
             (ValueError("zły parametr"), "validation"),
             (ResultSetNotFoundError("rs_1"), "precondition"),
+            (
+                ContentTooLargeError(
+                    eli="DU/2024/1", size_bytes=9_000_000, limit_bytes=5_242_880, pdf_url="https://example/text.pdf"
+                ),
+                "content_too_large",
+            ),
             (ApiUnavailableError("down", status_code=503), "unavailable"),
             (SejmApiError("HTTP 500: body", status_code=500), "upstream"),
             (KeyError("boom"), "internal"),
@@ -51,6 +62,16 @@ class TestCategoryGuidance:
         from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE
 
         assert _CATEGORY_GUIDANCE["unavailable"] != _CATEGORY_GUIDANCE["not_found"]
+
+    def test_content_too_large_has_its_own_guidance_distinct_from_precondition(self) -> None:
+        """`ContentTooLargeError` has no prior step to perform — reusing
+        `precondition`'s "do a step first" wording would misdirect the model,
+        since the actionable remedy (fetch the source file) is already the
+        last sentence of the body, not something a retry could satisfy."""
+        from law_scrapper_mcp.tools.error_handling import _CATEGORY_GUIDANCE
+
+        assert _CATEGORY_GUIDANCE["content_too_large"] != _CATEGORY_GUIDANCE["precondition"]
+        assert "krok" not in _CATEGORY_GUIDANCE["content_too_large"]
 
 
 class TestClassifyError:
@@ -185,18 +206,21 @@ async def test_content_too_large_message_survives_sanitization() -> None:
         await failing_tool()
 
     message = str(excinfo.value)
-    # A14, as amended by D4: the URL survives in full and nothing is truncated.
-    # It is no longer the last text in the message, because `precondition` — like
-    # every other category — now carries a remediation sentence (A12).
+    # A14, as amended by D4/D9: the URL survives in full and nothing is truncated.
+    # It is no longer the last text in the message, because every category now
+    # carries a remediation sentence (A12) — but `ContentTooLargeError` gets its
+    # own `content_too_large` category rather than sharing `precondition`'s
+    # "do a prior step" wording, which does not describe this situation (there
+    # is no prior step; the file is simply too large).
     assert "DU/2024/1" in message
     assert "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf" in message
     assert "przekracza limit" in message
     assert "wewnętrzny błąd" not in message
     assert "…" not in message
-    assert message.endswith(_CATEGORY_GUIDANCE["precondition"])
+    assert message.endswith(_CATEGORY_GUIDANCE["content_too_large"])
 
 
-def test_content_too_large_is_classified_as_precondition() -> None:
+def test_content_too_large_is_classified_as_content_too_large() -> None:
     from law_scrapper_mcp.client.exceptions import ContentTooLargeError
     from law_scrapper_mcp.tools.error_handling import _classify_error
 
@@ -207,7 +231,7 @@ def test_content_too_large_is_classified_as_precondition() -> None:
         pdf_url="https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf",
     )
 
-    assert _classify_error(error) == "precondition"
+    assert _classify_error(error) == "content_too_large"
 
 
 class TestMessageTruncation:
@@ -298,7 +322,7 @@ class TestMessagePunctuation:
             pdf_url=pdf_url,
         )
 
-        message = _public_message(exc, "precondition")
+        message = _public_message(exc, "content_too_large")
 
         assert f"{pdf_url} " in message
         assert f"{pdf_url}." not in message

--- a/tests/unit/test_response_enrichment.py
+++ b/tests/unit/test_response_enrichment.py
@@ -383,6 +383,24 @@ def test_unavailable_content_hints_lead_nowhere_dead() -> None:
     assert not any(hint.tool == "get_act_details" and (hint.parameters or {}).get("load_content") for hint in hints)
 
 
+def test_unavailable_content_keeps_the_relationship_hint() -> None:
+    """Relationship analysis reads metadata, not text, so it survives UNAVAILABLE.
+
+    Per the brief's own design note: this is the one suggestion that still works
+    when the act has no readable content.
+    """
+    hints = act_details_hints(
+        "DU/2024/1",
+        is_loaded=False,
+        has_html=True,
+        content_status=ContentStatus.UNAVAILABLE,
+        pdf_url="https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf",
+    )
+
+    tools = [hint.tool for hint in hints]
+    assert "analyze_act_relationships" in tools
+
+
 def test_unavailable_content_hint_points_at_the_source_pdf() -> None:
     """Exactly one hint explains the absence and hands over the source URL (A11)."""
     pdf_url = "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf"

--- a/tests/unit/test_response_enrichment.py
+++ b/tests/unit/test_response_enrichment.py
@@ -1,8 +1,21 @@
 """Tests for search/browse response hint generation."""
 
-from law_scrapper_mcp.models.tool_outputs import ActSummaryOutput, FilterOutput, Hint, ResultSetScope, SetScope
+from law_scrapper_mcp.models.tool_outputs import (
+    ActSummaryOutput,
+    ContentStatus,
+    FilterOutput,
+    Hint,
+    ResultSetScope,
+    SetScope,
+)
 from law_scrapper_mcp.services.pagination import paginate_items
-from law_scrapper_mcp.services.response_enrichment import filter_hints, metadata_hints, search_hints
+from law_scrapper_mcp.services.response_enrichment import (
+    act_details_hints,
+    act_pdf_url,
+    filter_hints,
+    metadata_hints,
+    search_hints,
+)
 
 
 def _page_scope(stored: int = 20, corpus: int = 1_984, offset: int = 0) -> ResultSetScope:
@@ -347,3 +360,66 @@ def test_the_inconclusive_hint_names_no_tool() -> None:
     )
 
     assert filter_hints(output, filter_max_records=100)[0].tool is None
+
+
+def test_unavailable_content_hints_lead_nowhere_dead() -> None:
+    """No hint may send the model back through a door that is shut (A10).
+
+    The old hint fired on `not is_loaded and has_html` — precisely the state a
+    failed or impossible load leaves behind — so the model was invited to repeat
+    the call that had just produced nothing.
+    """
+    hints = act_details_hints(
+        "DU/2024/1",
+        is_loaded=False,
+        has_html=True,
+        content_status=ContentStatus.UNAVAILABLE,
+        pdf_url="https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf",
+    )
+
+    tools = [hint.tool for hint in hints]
+    assert "read_act_content" not in tools
+    assert "search_in_act" not in tools
+    assert not any(hint.tool == "get_act_details" and (hint.parameters or {}).get("load_content") for hint in hints)
+
+
+def test_unavailable_content_hint_points_at_the_source_pdf() -> None:
+    """Exactly one hint explains the absence and hands over the source URL (A11)."""
+    pdf_url = "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf"
+
+    hints = act_details_hints(
+        "DU/2024/1",
+        is_loaded=False,
+        has_html=False,
+        content_status=ContentStatus.UNAVAILABLE,
+        pdf_url=pdf_url,
+    )
+
+    explaining = [hint for hint in hints if pdf_url in hint.message]
+    assert len(explaining) == 1
+    assert explaining[0].tool is None
+
+
+def test_loaded_content_still_offers_the_reading_tools() -> None:
+    """The `loaded` path keeps every hint it had before this cluster."""
+    hints = act_details_hints(
+        "DU/2024/1",
+        is_loaded=True,
+        has_html=True,
+        content_status=ContentStatus.LOADED,
+    )
+
+    tools = [hint.tool for hint in hints]
+    assert "read_act_content" in tools
+    assert "search_in_act" in tools
+
+
+def test_not_requested_still_offers_to_load() -> None:
+    """A metadata-only call keeps the invitation to load content (O3)."""
+    hints = act_details_hints("DU/2024/1", is_loaded=False, has_html=True)
+
+    assert any(hint.tool == "get_act_details" and (hint.parameters or {}).get("load_content") for hint in hints)
+
+
+def test_act_pdf_url_is_the_public_source_address() -> None:
+    assert act_pdf_url("DU", 2024, 1) == "https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.pdf"

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -133,8 +133,15 @@ class TestActService:
         assert result_no_load.content_status == "loaded"
 
     @respx.mock
-    async def test_get_details_load_content_pdf_fallback(self, service: ActService, act_detail: dict):
-        """Test loading PDF content when HTML is not available."""
+    async def test_unparseable_pdf_is_not_loaded(self, service: ActService, act_detail: dict):
+        """An unparseable PDF is a parse failure, treated the same as an absence.
+
+        `%PDF-1.4 fake pdf` isn't valid PDF structure, so `pdf_to_text` fails to
+        extract anything and returns `""` — a different scenario from a genuinely
+        empty document (see `test_empty_extraction_is_a_documented_absence` in
+        test_content_load_failures.py), but one that lands on the same
+        `ContentNotAvailableError` path today.
+        """
         # Modify act_detail to not have HTML
         act_detail_no_html = act_detail.copy()
         act_detail_no_html["textHTML"] = None

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -122,7 +122,15 @@ class TestActService:
         result = await service.get_details("DU/2024/1", load_content=True)
 
         assert result.is_loaded is True
+        assert result.content_status == "loaded"
         # Should not make additional HTTP requests for content
+
+        # Regression test for R2 drift: content_status reflects store state
+        # regardless of what the current call requested (load_content=False)
+        result_no_load = await service.get_details("DU/2024/1", load_content=False)
+
+        assert result_no_load.is_loaded is True
+        assert result_no_load.content_status == "loaded"
 
     @respx.mock
     async def test_get_details_load_content_pdf_fallback(self, service: ActService, act_detail: dict):

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -149,8 +149,11 @@ class TestActService:
 
         result = await service.get_details("DU/2024/1", load_content=True)
 
-        # Content should be loaded (even if PDF extraction fails)
+        # `%PDF-1.4 fake pdf` extracts to nothing, which is now a stated absence
+        # rather than a placeholder document (D3).
         assert result.has_pdf is True
+        assert result.content_status == "unavailable"
+        assert result.is_loaded is False
 
     @respx.mock
     async def test_get_details_handles_missing_content(self, service: ActService, act_detail: dict):
@@ -168,6 +171,7 @@ class TestActService:
 
         assert result.has_html is False
         assert result.has_pdf is False
+        assert result.content_status == "unavailable"
 
     @respx.mock
     async def test_get_details_from_url_eli(self, service: ActService, act_detail: dict):

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -216,3 +216,35 @@ class TestActService:
 
         with pytest.raises(Exception):  # noqa: B017
             await service.get_details("DU/2024/999")
+
+    @respx.mock
+    async def test_content_status_not_requested(self, service: ActService, act_detail: dict):
+        """A metadata-only call must not claim anything about content (A8, O3)."""
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
+
+        result = await service.get_details("DU/2024/1", load_content=False)
+
+        assert result.content_status == "not_requested"
+        assert result.is_loaded is False
+
+    @respx.mock
+    async def test_content_status_loaded(
+        self,
+        service: ActService,
+        act_detail: dict,
+        sample_act_html: str,
+        document_store: DocumentStore,
+    ):
+        """A successful load reports `loaded`, consistent with `is_loaded` (A9, R2)."""
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.html").mock(
+            return_value=Response(200, text=sample_act_html)
+        )
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "loaded"
+        assert result.is_loaded is True
+        assert await document_store.is_loaded("DU/2024/1")

--- a/tests/unit/test_services/test_act_service.py
+++ b/tests/unit/test_services/test_act_service.py
@@ -50,6 +50,7 @@ class TestActService:
         assert result.has_html is True
         assert result.has_pdf is True
         assert result.is_loaded is False
+        assert result.content_status == "not_requested"
 
     @respx.mock
     async def test_get_details_with_structure(self, service: ActService, act_detail: dict, act_structure: list):
@@ -95,6 +96,7 @@ class TestActService:
         result = await service.get_details("DU/2024/1", load_content=True)
 
         assert result.is_loaded is True
+        assert result.content_status == "loaded"
         assert await document_store.is_loaded("DU/2024/1")
 
     @respx.mock
@@ -216,35 +218,3 @@ class TestActService:
 
         with pytest.raises(Exception):  # noqa: B017
             await service.get_details("DU/2024/999")
-
-    @respx.mock
-    async def test_content_status_not_requested(self, service: ActService, act_detail: dict):
-        """A metadata-only call must not claim anything about content (A8, O3)."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
-
-        result = await service.get_details("DU/2024/1", load_content=False)
-
-        assert result.content_status == "not_requested"
-        assert result.is_loaded is False
-
-    @respx.mock
-    async def test_content_status_loaded(
-        self,
-        service: ActService,
-        act_detail: dict,
-        sample_act_html: str,
-        document_store: DocumentStore,
-    ):
-        """A successful load reports `loaded`, consistent with `is_loaded` (A9, R2)."""
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1").mock(return_value=Response(200, json=act_detail))
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/struct").mock(return_value=Response(404))
-        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/1/text.html").mock(
-            return_value=Response(200, text=sample_act_html)
-        )
-
-        result = await service.get_details("DU/2024/1", load_content=True)
-
-        assert result.content_status == "loaded"
-        assert result.is_loaded is True
-        assert await document_store.is_loaded("DU/2024/1")

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -13,8 +13,6 @@ from law_scrapper_mcp.services.act_service import ActService
 from law_scrapper_mcp.services.content_processor import ContentProcessor
 from law_scrapper_mcp.services.document_store import DocumentStore
 
-pytestmark = pytest.mark.asyncio
-
 ACT_URL = "https://api.sejm.gov.pl/eli/acts/DU/2024/1"
 
 
@@ -42,6 +40,8 @@ def _mock_metadata(act_detail: dict, *, html: bool, pdf: bool) -> None:
 
 class TestTransientFailuresPropagate:
     """A failing upstream must not be reported as an act without text (A1-A3)."""
+
+    pytestmark = pytest.mark.asyncio
 
     @respx.mock
     async def test_open_breaker_propagates(
@@ -115,6 +115,8 @@ class TestTransientFailuresPropagate:
 
 class TestPermanentAbsenceIsASuccess:
     """An act that has no readable text is a fact, not a failure (A5-A7)."""
+
+    pytestmark = pytest.mark.asyncio
 
     @respx.mock
     async def test_missing_pdf_is_a_documented_absence(

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -155,6 +155,29 @@ class TestPermanentAbsenceIsASuccess:
         assert not await document_store.is_loaded("DU/2024/1")
 
     @respx.mock
+    async def test_empty_html_extraction_is_a_documented_absence(
+        self, mock_client: SejmApiClient, document_store: DocumentStore, act_detail: dict
+    ) -> None:
+        """The symmetric HTML case: an empty extraction is an absence, not a load (I1)."""
+
+        class EmptyProcessor(ContentProcessor):
+            def html_to_markdown(self, html: str) -> str:
+                return "   \n  "
+
+        service = ActService(
+            client=mock_client,
+            document_store=document_store,
+            content_processor=EmptyProcessor(),
+        )
+        _mock_metadata(act_detail, html=True, pdf=False)
+        respx.get(f"{ACT_URL}/text.html").mock(return_value=Response(200, text="<html><body></body></html>"))
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "unavailable"
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
     async def test_neither_format_present_sends_no_request(
         self, service: ActService, act_detail: dict, document_store: DocumentStore
     ) -> None:

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -111,3 +111,81 @@ class TestTransientFailuresPropagate:
             await service.get_details("DU/2024/1", load_content=True)
 
         assert not await document_store.is_loaded("DU/2024/1")
+
+
+class TestPermanentAbsenceIsASuccess:
+    """An act that has no readable text is a fact, not a failure (A5-A7)."""
+
+    @respx.mock
+    async def test_missing_pdf_is_a_documented_absence(
+        self, service: ActService, act_detail: dict, document_store: DocumentStore
+    ) -> None:
+        """404 on the only available format: success, stated plainly (A5)."""
+        _mock_metadata(act_detail, html=False, pdf=True)
+        respx.get(f"{ACT_URL}/text.pdf").mock(return_value=Response(404))
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "unavailable"
+        assert result.is_loaded is False
+        assert result.title  # metadata still came through
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
+    async def test_empty_extraction_is_a_documented_absence(
+        self, mock_client: SejmApiClient, document_store: DocumentStore, act_detail: dict
+    ) -> None:
+        """An empty extraction stores nothing at all — no stand-in sentence (A6)."""
+
+        class EmptyProcessor(ContentProcessor):
+            def pdf_to_text(self, pdf_bytes: bytes) -> str:
+                return "   \n  "
+
+        service = ActService(
+            client=mock_client,
+            document_store=document_store,
+            content_processor=EmptyProcessor(),
+        )
+        _mock_metadata(act_detail, html=False, pdf=True)
+        respx.get(f"{ACT_URL}/text.pdf").mock(return_value=Response(200, content=b"%PDF-1.4 fake"))
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "unavailable"
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
+    async def test_neither_format_present_sends_no_request(
+        self, service: ActService, act_detail: dict, document_store: DocumentStore
+    ) -> None:
+        """Metadata already proves the fetch is pointless, so it is not sent (O1).
+
+        No route is registered for text.pdf: if the code still requested it,
+        respx would fail the test with an unmocked-request error.
+        """
+        _mock_metadata(act_detail, html=False, pdf=False)
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "unavailable"
+        assert not await document_store.is_loaded("DU/2024/1")
+
+
+def test_no_placeholder_literals_remain_in_src() -> None:
+    """The stand-in sentences are gone for good (A7).
+
+    They were English text in an agent-facing field, they made `is_loaded=True`
+    a lie, and `search_in_act` matched against them as if they were the act.
+    """
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[3] / "src"
+    banned = ("*No readable content available", "*Content extraction failed")
+    offenders = [
+        f"{path}: {needle}"
+        for path in src.rglob("*.py")
+        for needle in banned
+        if needle in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -47,7 +47,7 @@ class TestTransientFailuresPropagate:
     async def test_open_breaker_propagates(
         self, service: ActService, act_detail: dict, document_store: DocumentStore
     ) -> None:
-        """An open circuit breaker rejects before any request leaves (A1)."""
+        """A non-httpx exception (what an open breaker raises) survives the retry loop and propagates (A1)."""
         _mock_metadata(act_detail, html=True, pdf=True)
         respx.get(f"{ACT_URL}/text.html").mock(
             side_effect=ApiUnavailableError("Circuit breaker otwarty", status_code=503)
@@ -64,10 +64,8 @@ class TestTransientFailuresPropagate:
         _mock_metadata(act_detail, html=True, pdf=True)
         respx.get(f"{ACT_URL}/text.html").mock(side_effect=httpx.TimeoutException("read timed out"))
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ApiUnavailableError):
             await service.get_details("DU/2024/1", load_content=True)
-
-        assert not isinstance(excinfo.value, ValueError)
 
     @respx.mock
     async def test_html_5xx_propagates(self, service: ActService, act_detail: dict) -> None:

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -1,0 +1,115 @@
+"""The three disjoint outcomes of loading act content (cluster 10, D2/D5)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from law_scrapper_mcp.client.exceptions import ApiUnavailableError
+from law_scrapper_mcp.client.sejm_client import SejmApiClient
+from law_scrapper_mcp.services.act_service import ActService
+from law_scrapper_mcp.services.content_processor import ContentProcessor
+from law_scrapper_mcp.services.document_store import DocumentStore
+
+pytestmark = pytest.mark.asyncio
+
+ACT_URL = "https://api.sejm.gov.pl/eli/acts/DU/2024/1"
+
+
+@pytest.fixture
+def service(
+    mock_client: SejmApiClient,
+    document_store: DocumentStore,
+    content_processor: ContentProcessor,
+) -> ActService:
+    return ActService(
+        client=mock_client,
+        document_store=document_store,
+        content_processor=content_processor,
+    )
+
+
+def _mock_metadata(act_detail: dict, *, html: bool, pdf: bool) -> None:
+    """Route the two metadata calls every `get_details` makes."""
+    detail = act_detail.copy()
+    detail["textHTML"] = "/eli/acts/DU/2024/1/text.html" if html else None
+    detail["textPDF"] = "/eli/acts/DU/2024/1/text.pdf" if pdf else None
+    respx.get(ACT_URL).mock(return_value=Response(200, json=detail))
+    respx.get(f"{ACT_URL}/struct").mock(return_value=Response(404))
+
+
+class TestTransientFailuresPropagate:
+    """A failing upstream must not be reported as an act without text (A1-A3)."""
+
+    @respx.mock
+    async def test_open_breaker_propagates(
+        self, service: ActService, act_detail: dict, document_store: DocumentStore
+    ) -> None:
+        """An open circuit breaker rejects before any request leaves (A1)."""
+        _mock_metadata(act_detail, html=True, pdf=True)
+        respx.get(f"{ACT_URL}/text.html").mock(
+            side_effect=ApiUnavailableError("Circuit breaker otwarty", status_code=503)
+        )
+
+        with pytest.raises(ApiUnavailableError):
+            await service.get_details("DU/2024/1", load_content=True)
+
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
+    async def test_timeout_propagates(self, service: ActService, act_detail: dict) -> None:
+        """A read timeout is transient, never an absence of content (A2)."""
+        _mock_metadata(act_detail, html=True, pdf=True)
+        respx.get(f"{ACT_URL}/text.html").mock(side_effect=httpx.TimeoutException("read timed out"))
+
+        with pytest.raises(Exception) as excinfo:
+            await service.get_details("DU/2024/1", load_content=True)
+
+        assert not isinstance(excinfo.value, ValueError)
+
+    @respx.mock
+    async def test_html_5xx_propagates(self, service: ActService, act_detail: dict) -> None:
+        """HTTP 500 on text.html surfaces as unavailability (A2)."""
+        _mock_metadata(act_detail, html=True, pdf=True)
+        respx.get(f"{ACT_URL}/text.html").mock(return_value=Response(500, text="boom"))
+
+        with pytest.raises(ApiUnavailableError):
+            await service.get_details("DU/2024/1", load_content=True)
+
+    @respx.mock
+    async def test_pdf_5xx_propagates(self, service: ActService, act_detail: dict) -> None:
+        """HTTP 503 on text.pdf is transient, unlike a 404 (A2, D5)."""
+        _mock_metadata(act_detail, html=False, pdf=True)
+        respx.get(f"{ACT_URL}/text.pdf").mock(return_value=Response(503, text="maintenance"))
+
+        with pytest.raises(ApiUnavailableError):
+            await service.get_details("DU/2024/1", load_content=True)
+
+    @respx.mock
+    async def test_converter_failure_propagates(
+        self, mock_client: SejmApiClient, document_store: DocumentStore, act_detail: dict
+    ) -> None:
+        """An exception outside the D5 table takes the default branch: propagate (A3).
+
+        An unknown failure must never be allowed to look like missing content —
+        that is the whole point of replacing the blacklist with a whitelist.
+        """
+
+        class ExplodingProcessor(ContentProcessor):
+            def html_to_markdown(self, html: str) -> str:
+                raise RuntimeError("markdownify blew up")
+
+        service = ActService(
+            client=mock_client,
+            document_store=document_store,
+            content_processor=ExplodingProcessor(),
+        )
+        _mock_metadata(act_detail, html=True, pdf=True)
+        respx.get(f"{ACT_URL}/text.html").mock(return_value=Response(200, text="<html><body>x</body></html>"))
+
+        with pytest.raises(RuntimeError, match="markdownify blew up"):
+            await service.get_details("DU/2024/1", load_content=True)
+
+        assert not await document_store.is_loaded("DU/2024/1")

--- a/tests/unit/test_services/test_content_load_failures.py
+++ b/tests/unit/test_services/test_content_load_failures.py
@@ -134,6 +134,41 @@ class TestPermanentAbsenceIsASuccess:
         assert not await document_store.is_loaded("DU/2024/1")
 
     @respx.mock
+    async def test_missing_html_is_a_documented_absence(
+        self, service: ActService, act_detail: dict, document_store: DocumentStore
+    ) -> None:
+        """The HTML twin of A5: a 404 on text.html is the source saying "no file" (D5)."""
+        _mock_metadata(act_detail, html=True, pdf=False)
+        respx.get(f"{ACT_URL}/text.html").mock(return_value=Response(404))
+
+        result = await service.get_details("DU/2024/1", load_content=True)
+
+        assert result.content_status == "unavailable"
+        assert result.is_loaded is False
+        assert result.title
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
+    async def test_permanent_absence_is_remembered(
+        self, service: ActService, act_detail: dict, document_store: DocumentStore
+    ) -> None:
+        """A repeated load of a textless act must not spend another upstream request (O1).
+
+        The placeholder document D3 removed used to double as a negative cache;
+        without a replacement every retry would re-fetch an answer that cannot
+        change before the metadata it was derived from expires.
+        """
+        _mock_metadata(act_detail, html=False, pdf=True)
+        route = respx.get(f"{ACT_URL}/text.pdf").mock(return_value=Response(404))
+
+        first = await service.get_details("DU/2024/1", load_content=True)
+        second = await service.get_details("DU/2024/1", load_content=True)
+
+        assert first.content_status == second.content_status == "unavailable"
+        assert route.call_count == 1
+        assert not await document_store.is_loaded("DU/2024/1")
+
+    @respx.mock
     async def test_empty_extraction_is_a_documented_absence(
         self, mock_client: SejmApiClient, document_store: DocumentStore, act_detail: dict
     ) -> None:

--- a/tests/unit/test_tools/test_act_details_tool.py
+++ b/tests/unit/test_tools/test_act_details_tool.py
@@ -1,0 +1,68 @@
+"""Tool-boundary tests for `get_act_details`' hint wiring (final-review I1).
+
+`act_details_hints` already refuses to name a PDF URL when none is given, but
+`tools/act_details.py` used to compute that URL unconditionally, regardless of
+`has_pdf`. No existing test caught this: every direct `act_details_hints` test
+in `test_response_enrichment.py` passes `pdf_url=` explicitly, so the
+production wiring in `act_details.py` was never exercised for `has_pdf=False`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import respx
+from httpx import Response
+
+pytestmark = pytest.mark.anyio
+
+NEITHER_FORMAT_ACT = {
+    "ELI": "DU/2024/9",
+    "publisher": "DU",
+    "year": 2024,
+    "pos": 9,
+    "title": "Ustawa testowa bez formatu treści",
+    "status": "akt obowiązujący",
+    "type": "Ustawa",
+    "textHTML": None,
+    "textPDF": None,
+}
+
+
+@pytest.fixture
+async def neither_format_client() -> Any:
+    """In-memory MCP client for an act whose own metadata advertises no text at all."""
+    from mcp import Client
+
+    from law_scrapper_mcp.server import app
+
+    with respx.mock:
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/9").mock(
+            return_value=Response(200, json=NEITHER_FORMAT_ACT)
+        )
+        respx.get("https://api.sejm.gov.pl/eli/acts/DU/2024/9/struct").mock(return_value=Response(404))
+        async with Client(app) as client:
+            yield client
+
+
+async def test_unavailable_hint_never_names_a_pdf_the_server_knows_is_absent(
+    neither_format_client: Any,
+) -> None:
+    """`has_pdf=False` must not produce a hint pointing at `text.pdf`.
+
+    `act_service._load_content` refuses to request `text.pdf` for this act on
+    politeness grounds (its own metadata already proves the request pointless);
+    the hint builder must not then instruct the caller to make that exact
+    request itself.
+    """
+    result = await neither_format_client.call_tool("get_act_details", {"eli": "DU/2024/9", "load_content": True})
+
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["data"]["content_status"] == "unavailable"
+    assert result.structured_content["data"]["has_pdf"] is False
+
+    hint_messages = [hint["message"] for hint in result.structured_content["hints"]]
+    assert not any("text.pdf" in message for message in hint_messages)
+    assert not any("http://" in message or "https://" in message for message in hint_messages)

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "law-scrapper-mcp"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary

Signal content loading failures properly and cap error message length.

- Transient upstream failures (open circuit breaker, timeouts, 5xx) during `get_act_details(load_content=True)` now surface as `isError=true` instead of silently returning `is_loaded=false` with misleading hints.
- Permanent content absence (no HTML or PDF at all) returns success with new field `content_status="unavailable"` to distinguish from transient failures — the act exists, but has no readable text.
- Error messages from caller input or upstream responses are now length-bounded (configurable `LAW_MCP_ERROR_MESSAGE_MAX_CHARS`, default 500).
- All error messages end with a fixed one-sentence remediation hint ("Retry shortly", "Act not in registry", etc.).
- Regression tests freeze the v3.0.0 protocol fix: any domain exception surfaces as `isError=true`, never in a success envelope.

New `content_status` field on `get_act_details` output with three values: `not_requested`, `loaded`, `unavailable`. Hints for unavailable content now point to the PDF URL instead of to futile re-loading.

Changelog: v4.3.0 with BREAKING note — calls that previously returned success now fail with `isError=true`.

## Test plan

✓ Unit tests: 1412 passed
✓ Integration tests: 112 passed  
✓ ruff check: No issues
✓ ruff format: 124 files already formatted
✓ mypy: No issues

All acceptance criteria covered:
- Transient failures propagate as `isError=true`
- Permanent absence handled as success with `content_status="unavailable"`
- No placeholder documents in DocumentStore
- Hints avoid re-loading futile calls
- Error messages carry remediation guidance and respect length bounds
- Protocol-level regression frozen